### PR TITLE
chore: add fastlane changelog for v1.0.10

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/10.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10.txt
@@ -1,0 +1,5 @@
+Fix Android file sharing
+- Fixed Telegram and other apps disabling send button for shared files (added MIME types)
+- Added share intent queries for Android 11+ compatibility
+- Version and build number now displayed on home screen and About dialog
+- Version is read dynamically from app — no more hardcoded strings


### PR DESCRIPTION
## Summary
- Add fastlane changelog `10.txt` for build 10 (v1.0.10)
- Documents: MIME type fix for file sharing, Android 11+ intent queries, dynamic version display

## Test plan
- [x] Verify `fastlane/metadata/android/en-US/changelogs/10.txt` exists and is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)