### PR TITLE
feat(webapp): Log tab + decouple restore from the scan loop

### DIFF
--- a/docs/superpowers/plans/2026-07-28-webapp-log-tab.md
+++ b/docs/superpowers/plans/2026-07-28-webapp-log-tab.md
@@ -1,0 +1,848 @@
+# Web App Log Tab + Restore Decoupling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the recurring "Restore button stops working" bug by decoupling restore from the scan loop (behind a testable `RestoreOrchestrator` seam), and add a Log tab backed by a dependency-free in-memory ring-buffer logger.
+
+**Architecture:** A dependency-free `Logger` (`src/log/logger.ts`) with an in-memory ring buffer + pub/sub. The restore/scan orchestration moves into `app/ui/restore-orchestrator.ts` behind an injected `RestoreIO` seam so it can be driven by a DOM stub + `MockTransport` in tests; `restore-panel.ts` becomes a thin adapter that builds the real IO. A `log-panel.ts` renders the Log tab. UI/glue-layer instrumentation calls `log.*`; the core codecs stay untouched.
+
+**Tech Stack:** TypeScript (ESM, NodeNext — imports use `.js`), esbuild, `node --test`, web-platform globals (`Date.now`, `crypto.subtle`, `Blob`, `navigator.clipboard`).
+
+## Global Constraints
+
+- Core (`src/`) stays dependency-free and uses only web-platform globals; the logger adds no runtime dependency. `package.json` `dependencies` stays exactly `{ "chameleon-ultra.js" }`.
+- ESM NodeNext: every intra-project import uses the compiled `.js` path, even from `.ts` sources.
+- Tab order in `shell.ts` `TABS` and in `index.html`: `archive, restore, files, log, about` (Log before About).
+- Console mirroring defaults **off** so `npm test` output stays pristine.
+- Log `data` payloads never contain file contents or passwords — only ids, counts, sizes, error strings.
+- Reuse the in-place reconcile renderer `renderArchiveList` (`app/ui/restore-view.ts`) and typed errors (`PasswordRequiredError` from `app/controller.ts`, `DecryptionError` from `src/crypto.ts`). Do not reintroduce `innerHTML=''` rebuilds in the restore flow (the Log list is non-interactive text, so `replaceChildren()` there is fine).
+- Node ≥ 22 for tests/build: `source ~/.nvm/nvm.sh && nvm use --lts` first (shell default is Node 14). `rm -rf dist` before running tests: `rm -rf dist && npx tsc && node --test 'dist/test/**/*.test.js'`.
+
+---
+
+## File Structure
+
+- `src/log/logger.ts` (create) — `LogLevel`, `LogEntry`, `LEVELS`, `formatLogLine`, `Logger`, `log` singleton.
+- `app/ui/restore-orchestrator.ts` (create) — `RestoreIO` interface + `RestoreOrchestrator` (scan/restore orchestration).
+- `app/ui/restore-panel.ts` (rewrite) — thin adapter building the real IO + scan-step loop.
+- `app/ui/log-panel.ts` (create) — Log tab glue.
+- `app/ui/shell.ts` (modify) — add `'log'` to `TABS`.
+- `app/index.html` (modify) — Log tab button + `#panel-log` section.
+- `app/main.ts` (modify) — `initLogPanel()`.
+- `app/ui/device.ts`, `app/ui/archive-panel.ts`, `app/ui/files-panel.ts` (modify) — light instrumentation.
+- Tests: `test/logger.test.ts`, `test/restore-orchestrator.test.ts`.
+
+---
+
+## Task 1: Logger core
+
+**Files:**
+- Create: `webapp/src/log/logger.ts`
+- Test: `webapp/test/logger.test.ts`
+
+**Interfaces:**
+- Consumes: nothing (leaf; web-platform globals only).
+- Produces:
+  - `type LogLevel = 'debug' | 'info' | 'warn' | 'error'`
+  - `interface LogEntry { seq: number; t: number; level: LogLevel; cat: string; msg: string; data?: unknown; }`
+  - `const LEVELS: Record<LogLevel, number>` (`debug:0, info:1, warn:2, error:3`)
+  - `function formatLogLine(e: LogEntry): string`
+  - `class Logger` with `debug/info/warn/error(cat, msg, data?)`, `subscribe(cb): () => void`, `snapshot(): LogEntry[]`, `clear(): void`, `setMirrorToConsole(on): void`
+  - `const log: Logger` (singleton; capacity 1000, mirror off)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `webapp/test/logger.test.ts`:
+
+```ts
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Logger, formatLogLine, type LogEntry } from '../src/log/logger.js';
+
+test('formatLogLine is deterministic (UTC time, padded level)', () => {
+  const e: LogEntry = { seq: 0, t: 0, level: 'info', cat: 'scan', msg: 'hi' };
+  assert.equal(formatLogLine(e), '00:00:00.000 INFO  [scan] hi');
+  assert.equal(formatLogLine({ ...e, level: 'error', data: { id: 'x' } }), '00:00:00.000 ERROR [scan] hi {"id":"x"}');
+});
+
+test('info appends an entry retrievable via snapshot with monotonic seq', () => {
+  const log = new Logger();
+  log.info('cat', 'first');
+  log.warn('cat', 'second', { n: 2 });
+  const s = log.snapshot();
+  assert.equal(s.length, 2);
+  assert.equal(s[0]!.msg, 'first');
+  assert.equal(s[0]!.level, 'info');
+  assert.equal(s[1]!.data && (s[1]!.data as { n: number }).n, 2);
+  assert.equal(s[1]!.seq, s[0]!.seq + 1);
+});
+
+test('ring buffer evicts oldest at capacity', () => {
+  const log = new Logger({ capacity: 3 });
+  for (let i = 0; i < 5; i++) log.info('c', `m${i}`);
+  const msgs = log.snapshot().map((e) => e.msg);
+  assert.deepEqual(msgs, ['m2', 'm3', 'm4']);
+});
+
+test('subscribe fires on each append; unsubscribe stops it', () => {
+  const log = new Logger();
+  const seen: string[] = [];
+  const off = log.subscribe((e) => seen.push(e.msg));
+  log.info('c', 'a');
+  off();
+  log.info('c', 'b');
+  assert.deepEqual(seen, ['a']);
+});
+
+test('clear empties the buffer', () => {
+  const log = new Logger();
+  log.info('c', 'a');
+  log.clear();
+  assert.equal(log.snapshot().length, 0);
+});
+
+test('a throwing subscriber does not break logging or other subscribers', () => {
+  const log = new Logger();
+  const seen: string[] = [];
+  log.subscribe(() => { throw new Error('boom'); });
+  log.subscribe((e) => seen.push(e.msg));
+  assert.doesNotThrow(() => log.info('c', 'a'));
+  assert.deepEqual(seen, ['a']);
+});
+
+test('console mirror is off by default and forwards when enabled', () => {
+  const calls: string[] = [];
+  const orig = console.info;
+  console.info = (msg?: unknown) => { calls.push(String(msg)); };
+  try {
+    const log = new Logger();
+    log.info('c', 'silent');
+    assert.equal(calls.length, 0);
+    log.setMirrorToConsole(true);
+    log.info('c', 'loud');
+    assert.equal(calls.length, 1);
+  } finally {
+    console.info = orig;
+  }
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+source ~/.nvm/nvm.sh && nvm use --lts
+cd webapp && rm -rf dist && npx tsc
+```
+Expected: FAIL — `Cannot find module '../src/log/logger.js'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `webapp/src/log/logger.ts`:
+
+```ts
+/**
+ * Dependency-free in-memory event log: a capped ring buffer plus pub/sub, used
+ * by the Log tab. Web-platform globals only, so it runs under node --test.
+ */
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface LogEntry {
+  seq: number;      // monotonic counter (stable ordering)
+  t: number;        // Date.now() epoch ms
+  level: LogLevel;
+  cat: string;      // category, e.g. 'restore', 'scan', 'device'
+  msg: string;
+  data?: unknown;   // small structured context (never file contents or passwords)
+}
+
+export interface LoggerOptions { capacity?: number; mirrorToConsole?: boolean; }
+
+export const LEVELS: Record<LogLevel, number> = { debug: 0, info: 1, warn: 2, error: 3 };
+
+/** Stable one-line rendering: `hh:mm:ss.mmm LEVEL [cat] msg {data}` (UTC time). */
+export function formatLogLine(e: LogEntry): string {
+  const time = new Date(e.t).toISOString().slice(11, 23);
+  const data = e.data === undefined ? '' : ` ${JSON.stringify(e.data)}`;
+  return `${time} ${e.level.toUpperCase().padEnd(5)} [${e.cat}] ${e.msg}${data}`;
+}
+
+export class Logger {
+  private readonly capacity: number;
+  private mirror: boolean;
+  private readonly buf: LogEntry[] = [];
+  private readonly subs = new Set<(e: LogEntry) => void>();
+  private seq = 0;
+
+  constructor(opts?: LoggerOptions) {
+    this.capacity = opts?.capacity ?? 1000;
+    this.mirror = opts?.mirrorToConsole ?? false;
+  }
+
+  private emit(level: LogLevel, cat: string, msg: string, data?: unknown): void {
+    const e: LogEntry = { seq: this.seq++, t: Date.now(), level, cat, msg, ...(data !== undefined ? { data } : {}) };
+    this.buf.push(e);
+    if (this.buf.length > this.capacity) this.buf.shift();
+    if (this.mirror) { try { console[level](formatLogLine(e)); } catch { /* ignore console failures */ } }
+    for (const cb of this.subs) { try { cb(e); } catch { /* a broken subscriber must not break logging */ } }
+  }
+
+  debug(cat: string, msg: string, data?: unknown): void { this.emit('debug', cat, msg, data); }
+  info(cat: string, msg: string, data?: unknown): void { this.emit('info', cat, msg, data); }
+  warn(cat: string, msg: string, data?: unknown): void { this.emit('warn', cat, msg, data); }
+  error(cat: string, msg: string, data?: unknown): void { this.emit('error', cat, msg, data); }
+
+  subscribe(cb: (e: LogEntry) => void): () => void {
+    this.subs.add(cb);
+    return () => { this.subs.delete(cb); };
+  }
+  snapshot(): LogEntry[] { return [...this.buf]; }
+  clear(): void { this.buf.length = 0; }
+  setMirrorToConsole(on: boolean): void { this.mirror = on; }
+}
+
+export const log = new Logger();
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd webapp && rm -rf dist && npx tsc && node --test dist/test/logger.test.js
+```
+Expected: PASS — 7 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add webapp/src/log/logger.ts webapp/test/logger.test.ts
+git commit -m "feat(webapp): dependency-free ring-buffer Logger for the Log tab"
+```
+
+---
+
+## Task 2: RestoreOrchestrator + DOM-stub regression test
+
+**Files:**
+- Create: `webapp/app/ui/restore-orchestrator.ts`
+- Test: `webapp/test/restore-orchestrator.test.ts`
+
+**Interfaces:**
+- Consumes: `RestoreController`, `PasswordRequiredError` (`app/controller.js`); `DecryptionError` (`src/crypto.js`); `renderArchiveList` (`app/ui/restore-view.js`); `humanError` (`app/ui/errors.js`); `Transport` type (`src/transport/transport.js`); `StoredFile` type (`src/storage/file-store.js`); `Logger` type (`src/log/logger.js`). Test also uses `MockTransport` (`src/transport/mock-transport.js`) and `ArchiveController` (`app/controller.js`).
+- Produces:
+  - `interface RestoreIO { container: HTMLElement; files: { saveRestored(e: Omit<StoredFile,'createdAt'>): Promise<void> }; promptPassword(message: string): string | null; download(data: Uint8Array, name: string): void; fallbackName(): string; setFileName(name: string): void; setStatus(msg: string): void; log: Logger; }`
+  - `class RestoreOrchestrator` with `constructor(io: RestoreIO)`, `startSession(transport: Transport): void`, `scanStep(signal: AbortSignal): Promise<void>`, `restoreArchive(id: string): Promise<void>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `webapp/test/restore-orchestrator.test.ts`:
+
+```ts
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { MockTransport } from '../src/transport/mock-transport.js';
+import { ArchiveController } from '../app/controller.js';
+import { RestoreOrchestrator, type RestoreIO } from '../app/ui/restore-orchestrator.js';
+import { Logger } from '../src/log/logger.js';
+
+/** Minimal DOM stub (as in restore-view.test.ts) — but click() is async and
+ *  awaits handler return values, so a button click that triggers an async
+ *  restore can be awaited deterministically in the test. */
+interface StubEl {
+  tagName: string; className: string; textContent: string; disabled: boolean;
+  children: StubEl[]; parent: StubEl | null; ownerDocument: StubDoc;
+  attrs: Record<string, string>; listeners: Record<string, Array<() => unknown>>;
+  append(...k: StubEl[]): void; appendChild(k: StubEl): StubEl; remove(): void;
+  setAttribute(n: string, v: string): void; getAttribute(n: string): string | null;
+  addEventListener(t: string, fn: () => unknown): void; click(): Promise<void>;
+}
+interface StubDoc { createElement(tag: string): StubEl; }
+function makeDoc(): StubDoc {
+  const doc: StubDoc = {
+    createElement(tag) {
+      const el: StubEl = {
+        tagName: tag.toUpperCase(), className: '', textContent: '', disabled: false,
+        children: [], parent: null, ownerDocument: doc, attrs: {}, listeners: {},
+        append(...k) { for (const c of k) { c.parent = el; el.children.push(c); } },
+        appendChild(k) { k.parent = el; el.children.push(k); return k; },
+        remove() { if (el.parent) { el.parent.children.splice(el.parent.children.indexOf(el), 1); el.parent = null; } },
+        setAttribute(n, v) { el.attrs[n] = v; },
+        getAttribute(n) { return el.attrs[n] ?? null; },
+        addEventListener(t, fn) { (el.listeners[t] ??= []).push(fn); },
+        async click() { for (const fn of el.listeners['click'] ?? []) await fn(); },
+      };
+      return el;
+    },
+  };
+  return doc;
+}
+
+const uidFor = (a: number) => (i: number) => new Uint8Array([a, 0, 0, i]);
+
+/** Archive `data` to mock cards and return the stored bytes per card. */
+async function archiveToCards(data: Uint8Array, opts: { compress: boolean; password?: string; fileName: string }): Promise<Uint8Array[]> {
+  const src = new MockTransport();
+  const ctrl = new ArchiveController(src);
+  const uid = uidFor(0xa0);
+  const total = await ctrl.prepare({ data, fileName: opts.fileName, compress: opts.compress, password: opts.password, payloadSize: 720 });
+  const stored: Uint8Array[] = [];
+  for (let i = 0; i < total; i++) {
+    src.enqueueTag(uid(i)); await ctrl.writeNextCard();
+    src.enqueueTag(uid(i)); await src.awaitTag(); stored.push(await src.readChunk());
+  }
+  return stored;
+}
+
+function makeIO(container: StubEl, over?: Partial<RestoreIO>) {
+  const downloads: Array<{ data: Uint8Array; name: string }> = [];
+  const saved: Array<{ id: string; isEncrypted: boolean }> = [];
+  const io: RestoreIO = {
+    container: container as unknown as HTMLElement,
+    files: { async saveRestored(e) { saved.push({ id: e.id, isEncrypted: e.isEncrypted }); } },
+    promptPassword: () => null,
+    download: (data, name) => downloads.push({ data, name }),
+    fallbackName: () => 'restored.bin',
+    setFileName: () => {},
+    setStatus: () => {},
+    log: new Logger(),
+    ...over,
+  };
+  return { io, downloads, saved };
+}
+
+const signal = () => new AbortController().signal;
+
+test('restore works for multiple archives, repeatedly, independent of the scan loop', async () => {
+  const plain = crypto.getRandomValues(new Uint8Array(1500));   // multi-card, incompressible
+  const secret = crypto.getRandomValues(new Uint8Array(1500));
+  const cardsA = await archiveToCards(plain, { compress: false, fileName: 'a.bin' });
+  const cardsB = await archiveToCards(secret, { compress: false, password: 'pw', fileName: 'b.bin' });
+
+  const doc = makeDoc();
+  const container = doc.createElement('div');
+  const { io, downloads, saved } = makeIO(container, { promptPassword: () => 'pw' });
+  const orch = new RestoreOrchestrator(io);
+
+  const rt = new MockTransport();
+  orch.startSession(rt);
+  cardsA.forEach((b, i) => rt.enqueueTag(new Uint8Array([1, 0, 0, i]), b));
+  cardsB.forEach((b, i) => rt.enqueueTag(new Uint8Array([2, 0, 0, i]), b));
+  // Drive detection deterministically (MockTransport.awaitTag throws when idle,
+  // so we never run the panel's unbounded loop).
+  for (let i = 0; i < cardsA.length + cardsB.length; i++) await orch.scanStep(signal());
+
+  const rows = (container as unknown as StubEl).children;
+  assert.equal(rows.length, 2, 'both archives detected as rows');
+  const btn = (rowIdx: number) => rows[rowIdx]!.children[1]!; // [span, Restore button]
+
+  // Click archive A's Restore button -> restores the plain archive.
+  await btn(0).click();
+  assert.equal(downloads.length, 1);
+  assert.deepEqual(downloads[0]!.data, plain);
+  assert.equal(downloads[0]!.name, 'a.bin');
+
+  // Click archive B's button -> encrypted, promptPassword supplies 'pw'.
+  await btn(1).click();
+  assert.equal(downloads.length, 2);
+  assert.deepEqual(downloads[1]!.data, secret);
+
+  // Regression: click archive A AGAIN -> restores a second time (the pre-fix
+  // one-shot handler restored only once; a dead re-click would leave length 2).
+  await btn(0).click();
+  assert.equal(downloads.length, 3);
+  assert.deepEqual(downloads[2]!.data, plain);
+
+  // Restore-after-"stop": no scanStep in between, direct call still works.
+  await orch.restoreArchive(rows[1]!.getAttribute('data-archive-id')!);
+  assert.equal(downloads.length, 4);
+  assert.deepEqual(downloads[3]!.data, secret);
+
+  assert.ok(saved.some((s) => !s.isEncrypted) && saved.some((s) => s.isEncrypted), 'both saved to history');
+});
+
+test('restoreArchive ignores a wrong-then-cancelled password without downloading', async () => {
+  const secret = crypto.getRandomValues(new Uint8Array(800));
+  const cards = await archiveToCards(secret, { compress: false, password: 'pw', fileName: 's.bin' });
+  const doc = makeDoc();
+  const container = doc.createElement('div');
+  // First prompt returns a wrong password, second returns null (cancel).
+  const answers = ['nope', null] as Array<string | null>;
+  const { io, downloads } = makeIO(container, { promptPassword: () => answers.shift() ?? null });
+  const orch = new RestoreOrchestrator(io);
+  const rt = new MockTransport();
+  orch.startSession(rt);
+  cards.forEach((b, i) => rt.enqueueTag(new Uint8Array([3, 0, 0, i]), b));
+  for (let i = 0; i < cards.length; i++) await orch.scanStep(signal());
+  await (container as unknown as StubEl).children[0]!.children[1]!.click();
+  assert.equal(downloads.length, 0, 'cancelled restore downloads nothing');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd webapp && rm -rf dist && npx tsc
+```
+Expected: FAIL — `Cannot find module '../app/ui/restore-orchestrator.js'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `webapp/app/ui/restore-orchestrator.ts`:
+
+```ts
+/**
+ * DOM-light restore/scan orchestration behind an injected IO seam. Restoring is
+ * decoupled from the scan loop: each rendered Restore button calls
+ * restoreArchive(id) directly, so it works during a scan, after Stop, and
+ * repeatedly for different archives. The panel supplies the real DOM/browser IO;
+ * tests supply a DOM stub + MockTransport.
+ */
+import { RestoreController, PasswordRequiredError } from '../controller.js';
+import { DecryptionError } from '../../src/crypto.js';
+import { renderArchiveList } from './restore-view.js';
+import { humanError } from './errors.js';
+import type { Transport } from '../../src/transport/transport.js';
+import type { StoredFile } from '../../src/storage/file-store.js';
+import type { Logger } from '../../src/log/logger.js';
+
+export interface RestoreIO {
+  container: HTMLElement;
+  files: { saveRestored(e: Omit<StoredFile, 'createdAt'>): Promise<void> };
+  promptPassword(message: string): string | null;
+  download(data: Uint8Array, name: string): void;
+  fallbackName(): string;
+  setFileName(name: string): void;
+  setStatus(msg: string): void;
+  log: Logger;
+}
+
+export class RestoreOrchestrator {
+  private ctrl: RestoreController | null = null;
+  private restoring = false;
+
+  constructor(private readonly io: RestoreIO) {}
+
+  private render(list: Parameters<typeof renderArchiveList>[1]): void {
+    renderArchiveList(this.io.container, list, (id) => this.restoreArchive(id));
+  }
+
+  startSession(transport: Transport): void {
+    this.ctrl = new RestoreController(transport);
+    this.render([]); // clear any rows from a previous session
+    this.io.log.info('scan', 'Session started');
+  }
+
+  async scanStep(signal: AbortSignal): Promise<void> {
+    if (this.ctrl === null) throw new Error('scanStep before startSession');
+    const list = await this.ctrl.scanNextCard(signal);
+    this.render(list);
+    this.io.log.debug('scan', 'Detection', { archives: list.length, complete: list.filter((d) => d.complete).length });
+  }
+
+  async restoreArchive(id: string): Promise<void> {
+    if (this.ctrl === null) { this.io.log.warn('restore', 'Ignored: no session', { id }); return; }
+    if (this.restoring) { this.io.log.warn('restore', 'Ignored: already restoring', { id }); return; }
+    const ctrl = this.ctrl;
+    this.restoring = true;
+    this.io.log.info('restore', 'Restore clicked', { id });
+    try {
+      let pw: string | undefined;
+      let result: { data: Uint8Array; fileName: string | null } | undefined;
+      for (let attempt = 0; attempt < 5; attempt++) {
+        try { result = await ctrl.restore(id, pw); break; }
+        catch (e) {
+          if (e instanceof PasswordRequiredError || e instanceof DecryptionError) {
+            const entered = this.io.promptPassword(e instanceof DecryptionError ? 'Wrong password. Enter password:' : 'This archive is encrypted. Enter password:');
+            if (entered === null) { this.io.setStatus('Cancelled.'); this.io.log.info('restore', 'Cancelled', { id }); return; }
+            pw = entered; continue;
+          }
+          throw e;
+        }
+      }
+      if (!result) { this.io.setStatus('Too many failed password attempts.'); this.io.log.warn('restore', 'Too many password attempts', { id }); return; }
+      const name = result.fileName ?? this.io.fallbackName();
+      if (result.fileName) this.io.setFileName(result.fileName);
+      this.io.download(result.data, name);
+      this.io.setStatus(`Restored ${result.data.length} bytes → ${name}.`);
+      this.io.log.info('restore', 'Restored', { id, bytes: result.data.length, name });
+      try {
+        const meta = ctrl.detectedArchives().find((d) => d.archiveId === id);
+        if (meta) {
+          await this.io.files.saveRestored({
+            id, name: result.fileName ?? name, size: result.data.length,
+            isEncrypted: meta.isEncrypted, isCompressed: meta.isCompressed,
+            totalChunks: meta.totalChunks, payload: ctrl.assembledPayload(id),
+          });
+          this.io.log.info('files', 'Saved to history', { id });
+        }
+      } catch (e) {
+        this.io.log.warn('files', 'History save failed (non-fatal)', { id, error: String(e) });
+      }
+    } catch (e) {
+      this.io.setStatus(humanError(e));
+      this.io.log.error('restore', 'Restore failed', { id, error: String(e) });
+    } finally {
+      this.restoring = false;
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd webapp && rm -rf dist && npx tsc && node --test dist/test/restore-orchestrator.test.js
+```
+Expected: PASS — 2 tests (multi-restore + cancelled-password).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add webapp/app/ui/restore-orchestrator.ts webapp/test/restore-orchestrator.test.ts
+git commit -m "feat(webapp): RestoreOrchestrator decouples restore from the scan loop (+ DOM-stub regression test)"
+```
+
+---
+
+## Task 3: restore-panel.ts thin adapter
+
+**Files:**
+- Rewrite: `webapp/app/ui/restore-panel.ts`
+
+**Interfaces:**
+- Consumes: `RestoreOrchestrator`, `RestoreIO` (`app/ui/restore-orchestrator.js`); `TagTimeoutError`, `UnsupportedTagError` (`src/transport/transport.js`); `currentTransport`, `onConnectionChange` (`app/ui/device.js`); `filesController` (`app/ui/files-panel.js`); `humanError` (`app/ui/errors.js`); `log` (`src/log/logger.js`).
+- Produces: `initRestorePanel(): void` (unchanged signature; `main.ts` already calls it).
+
+- [ ] **Step 1: Replace the file**
+
+Overwrite `webapp/app/ui/restore-panel.ts` with:
+
+```ts
+/** Restore tab: thin adapter — builds the DOM/browser IO for RestoreOrchestrator and runs the scan-step loop. */
+import { RestoreOrchestrator, type RestoreIO } from './restore-orchestrator.js';
+import { TagTimeoutError, UnsupportedTagError } from '../../src/transport/transport.js';
+import { currentTransport, onConnectionChange } from './device.js';
+import { filesController } from './files-panel.js';
+import { humanError } from './errors.js';
+import { log } from '../../src/log/logger.js';
+
+const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
+
+export function initRestorePanel(): void {
+  const setStatus = (msg: string) => { $('restore-status').textContent = msg; };
+  let scanAbort: AbortController | null = null;
+
+  const io: RestoreIO = {
+    container: $('archives'),
+    files: filesController,
+    promptPassword: (message) => window.prompt(message),
+    download: (data, name) => {
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(new Blob([data as BlobPart]));
+      a.download = name;
+      a.click();
+      URL.revokeObjectURL(a.href);
+    },
+    fallbackName: () => ($('fname') as HTMLInputElement).value || 'restored.bin',
+    setFileName: (name) => { ($('fname') as HTMLInputElement).value = name; },
+    setStatus,
+    log,
+  };
+  const orch = new RestoreOrchestrator(io);
+
+  onConnectionChange((connected) => {
+    ($('scan') as HTMLButtonElement).disabled = !connected;
+    if (connected) setStatus('Scan a pile of cards to detect archives.');
+  });
+
+  $('scan').addEventListener('click', async () => {
+    const transport = currentTransport();
+    if (!transport) return;
+    orch.startSession(transport);
+    scanAbort = new AbortController();
+    ($('scan') as HTMLButtonElement).disabled = true;
+    ($('stop-scan') as HTMLButtonElement).disabled = false;
+    setStatus('Scanning — tap cards on the reader…');
+    log.info('scan', 'Scan started');
+    try {
+      for (;;) {
+        try {
+          await orch.scanStep(scanAbort.signal);
+          setStatus('Tap more cards, or Restore a complete one.');
+        } catch (e) {
+          if (e instanceof DOMException && e.name === 'AbortError') break;
+          if (e instanceof TagTimeoutError) continue;
+          if (e instanceof UnsupportedTagError) { setStatus('Unsupported tag — tap a Mifare Classic 1K or NTAG.'); log.warn('scan', 'Unsupported tag'); continue; }
+          setStatus(`Skipped a card: ${humanError(e)}`);
+          log.warn('scan', 'Skipped a card', { error: String(e) });
+          continue;
+        }
+      }
+    } finally {
+      ($('stop-scan') as HTMLButtonElement).disabled = true;
+      ($('scan') as HTMLButtonElement).disabled = false;
+      log.info('scan', 'Scan stopped');
+    }
+  });
+
+  $('stop-scan').addEventListener('click', () => { scanAbort?.abort(); });
+}
+```
+
+- [ ] **Step 2: Type-check, run the full suite, and build the bundle**
+
+```bash
+cd webapp && rm -rf dist && npx tsc && node --test 'dist/test/**/*.test.js'
+npx esbuild app/main.ts --bundle --format=esm --outfile=/tmp/log-bundle-check.js
+```
+Expected: `tsc` clean; all tests pass (logger + orchestrator + all pre-existing); esbuild prints a size with no errors. (This task is UI glue; its restore logic is covered by Task 2's orchestrator test and the button-click reliability by `restore-view.test.ts`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add webapp/app/ui/restore-panel.ts
+git commit -m "refactor(webapp): restore-panel is a thin adapter over RestoreOrchestrator"
+```
+
+---
+
+## Task 4: Log tab UI + wiring
+
+**Files:**
+- Create: `webapp/app/ui/log-panel.ts`
+- Modify: `webapp/app/ui/shell.ts` (add `'log'` to `TABS`)
+- Modify: `webapp/app/index.html` (Log tab button + `#panel-log` section)
+- Modify: `webapp/app/main.ts` (`initLogPanel()`)
+
+**Interfaces:**
+- Consumes: `log`, `formatLogLine`, `LEVELS`, `LogEntry`, `LogLevel` (`src/log/logger.js`).
+- Produces: `initLogPanel(): void`.
+
+- [ ] **Step 1: Add `'log'` to the tab list**
+
+In `webapp/app/ui/shell.ts`, change:
+```ts
+const TABS = ['archive', 'restore', 'files', 'about'] as const;
+```
+to:
+```ts
+const TABS = ['archive', 'restore', 'files', 'log', 'about'] as const;
+```
+
+- [ ] **Step 2: Add the Log tab button + panel markup**
+
+In `webapp/app/index.html`, add the tab button after the `files` button (line ~80):
+```html
+        <button role="tab" data-tab="log" aria-selected="false">Log</button>
+```
+(so the order is Archive, Restore, Files, Log, About).
+
+And add this section immediately after the `#panel-files` `</section>` (before `#panel-about`):
+```html
+      <section id="panel-log" role="tabpanel" hidden>
+        <div class="card">
+          <div style="display:flex;gap:0.6rem;flex-wrap:wrap;align-items:center">
+            <label>level
+              <select id="log-level">
+                <option value="debug">debug</option>
+                <option value="info" selected>info</option>
+                <option value="warn">warn</option>
+                <option value="error">error</option>
+              </select>
+            </label>
+            <label><input type="checkbox" id="log-autoscroll" checked /> auto-scroll</label>
+            <label><input type="checkbox" id="log-console" /> mirror to console</label>
+            <button id="log-clear">Clear</button>
+            <button id="log-copy">Copy</button>
+            <button id="log-download">Download</button>
+          </div>
+          <div id="log" style="font-family:monospace;font-size:0.8rem;max-height:60vh;overflow:auto;white-space:pre-wrap;margin-top:0.6rem"></div>
+        </div>
+      </section>
+```
+
+- [ ] **Step 3: Create the panel**
+
+Create `webapp/app/ui/log-panel.ts`:
+
+```ts
+/** Log tab: live view of the in-app event log with min-level filter + export. */
+import { log, formatLogLine, LEVELS, type LogEntry, type LogLevel } from '../../src/log/logger.js';
+
+const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
+
+export function initLogPanel(): void {
+  const box = $('log');
+  const levelSel = $('log-level') as HTMLSelectElement;
+  const autoscroll = $('log-autoscroll') as HTMLInputElement;
+  const consoleChk = $('log-console') as HTMLInputElement;
+  const minLevel = (): number => LEVELS[levelSel.value as LogLevel] ?? 0;
+
+  const addRow = (e: LogEntry): void => {
+    const row = document.createElement('div');
+    row.dataset['level'] = e.level;
+    row.textContent = formatLogLine(e);
+    row.hidden = LEVELS[e.level] < minLevel();
+    box.appendChild(row);
+    if (autoscroll.checked) box.scrollTop = box.scrollHeight;
+  };
+
+  const rerender = (): void => {
+    box.replaceChildren(); // log rows are non-interactive text — safe to rebuild
+    for (const e of log.snapshot()) addRow(e);
+  };
+
+  rerender();
+  log.subscribe(addRow);
+
+  levelSel.addEventListener('change', () => {
+    const min = minLevel();
+    for (const row of Array.from(box.children) as HTMLElement[]) {
+      const lvl = row.dataset['level'] as LogLevel | undefined;
+      row.hidden = lvl === undefined ? false : LEVELS[lvl] < min;
+    }
+  });
+  consoleChk.addEventListener('change', () => log.setMirrorToConsole(consoleChk.checked));
+  $('log-clear').addEventListener('click', () => { log.clear(); rerender(); });
+  $('log-copy').addEventListener('click', () => {
+    void navigator.clipboard?.writeText(log.snapshot().map(formatLogLine).join('\n'));
+  });
+  $('log-download').addEventListener('click', () => {
+    const text = log.snapshot().map(formatLogLine).join('\n');
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(new Blob([text], { type: 'text/plain' }));
+    a.download = `nfc-archiver-log-${new Date().toISOString().replace(/[:.]/g, '-')}.txt`;
+    a.click();
+    URL.revokeObjectURL(a.href);
+  });
+}
+```
+
+- [ ] **Step 4: Wire it in `main.ts`**
+
+In `webapp/app/main.ts`, add the import:
+```ts
+import { initLogPanel } from './ui/log-panel.js';
+```
+and call it after `initFilesPanel();`:
+```ts
+initLogPanel();
+```
+
+- [ ] **Step 5: Type-check, run the suite, build the bundle**
+
+```bash
+cd webapp && rm -rf dist && npx tsc && node --test 'dist/test/**/*.test.js'
+npx esbuild app/main.ts --bundle --format=esm --outfile=/tmp/log-bundle-check.js
+```
+Expected: `tsc` clean; all tests pass; bundle builds. (Panel is glue; `formatLogLine` is unit-tested in Task 1.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add webapp/app/ui/log-panel.ts webapp/app/ui/shell.ts webapp/app/index.html webapp/app/main.ts
+git commit -m "feat(webapp): Log tab (live event view, level filter, copy/download)"
+```
+
+---
+
+## Task 5: Instrumentation (device, archive, files)
+
+**Files:**
+- Modify: `webapp/app/ui/device.ts`, `webapp/app/ui/archive-panel.ts`, `webapp/app/ui/files-panel.ts`
+
+**Interfaces:**
+- Consumes: `log` (`src/log/logger.js`). No new produced interface.
+
+- [ ] **Step 1: Instrument `device.ts` connect**
+
+Add the import near the top of `webapp/app/ui/device.ts` (with the other `./` imports):
+```ts
+import { log } from '../../src/log/logger.js';
+```
+In the `$('connect')` click handler, add logging around the existing body:
+```ts
+  $('connect').addEventListener('click', async () => {
+    log.info('device', 'Connecting');
+    try {
+      ultra = new ChameleonUltra();
+      await ultra.use(new WebbleAdapter());
+      transport = new AutoTransport(new SdkChameleonDevice(ultra));
+      await transport.connect();
+      $('conn').textContent = 'connected';
+      ($('diagnose') as HTMLButtonElement).disabled = false;
+      for (const cb of listeners) cb(true);
+      deviceStatus.textContent = 'Connected.';
+      log.info('device', 'Connected');
+    } catch (e) {
+      deviceStatus.textContent = humanError(e);
+      log.error('device', 'Connect failed', { error: String(e) });
+    }
+  });
+```
+
+- [ ] **Step 2: Instrument `archive-panel.ts`**
+
+Add the import near the top of `webapp/app/ui/archive-panel.ts`:
+```ts
+import { log } from '../../src/log/logger.js';
+```
+The write handler is `$('archive').click`: it calls `const total = await ctrl.prepare({ ... })` (line 80), then a `while (!done) { … }` loop (lines 83-99), then a `} catch (e) { … }` (line 100). Add two log lines, at exact anchors:
+
+1. Immediately **after** the `const total = await ctrl.prepare({ ... });` line and its following `render(0, total, false);`:
+```ts
+      log.info('archive', 'Prepared', { cards: total });
+```
+2. Immediately **after** the closing brace of the `while (!done) { … }` loop (i.e. between the loop's `}` and the `} catch (e) {`), where the archive is fully written:
+```ts
+      log.info('archive', 'Write complete', { cards: total });
+```
+Do not change any control flow.
+
+- [ ] **Step 3: Instrument `files-panel.ts`**
+
+Add the import near the top of `webapp/app/ui/files-panel.ts`:
+```ts
+import { log } from '../../src/log/logger.js';
+```
+In the module-level `download(id, setStatus)` function, after the successful `setStatus(\`Downloaded ...\`)` line, add:
+```ts
+      log.info('files', 'Downloaded', { id, name });
+```
+In `initFilesPanel`, in the `onDelete` handler, after `await filesController.delete(id);` add:
+```ts
+        log.info('files', 'Deleted', { id });
+```
+In the `$('files-clear')` handler, after `const n = await filesController.clear();` add:
+```ts
+    log.info('files', 'Cleared', { count: n });
+```
+
+- [ ] **Step 4: Type-check, run the suite, build the bundle**
+
+```bash
+cd webapp && rm -rf dist && npx tsc && node --test 'dist/test/**/*.test.js'
+npx esbuild app/main.ts --bundle --format=esm --outfile=/tmp/log-bundle-check.js
+```
+Expected: `tsc` clean; all tests pass; bundle builds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add webapp/app/ui/device.ts webapp/app/ui/archive-panel.ts webapp/app/ui/files-panel.ts
+git commit -m "feat(webapp): instrument device/archive/files panels with log events"
+```
+
+---
+
+## Final verification (after all tasks)
+
+```bash
+cd webapp && rm -rf dist && npx tsc && node --test 'dist/test/**/*.test.js'   # all pass
+npx esbuild app/main.ts --bundle --format=esm --outfile=/tmp/log-bundle-check.js  # builds
+node -e "console.log(Object.keys(require('./package.json').dependencies))"        # ['chameleon-ultra.js']
+grep -rn "innerHTML" app/ui/restore-panel.ts app/ui/restore-orchestrator.ts       # expect no output
+```
+
+**Manual browser smoke (Windows-host Chromium + Chameleon):** connect; scan a pile of 5–6 archives; open the **Log** tab and confirm events stream (scan started, detections, restore clicked/restored); restore archive A then B then A again from one scan **without rescanning** — all succeed; hit **Stop**, then restore another — succeeds; use **Copy**/**Download** to export the trace. This is the acceptance test for the decoupling fix.
+
+Then use **superpowers:finishing-a-development-branch** to open the PR (base `master`).

--- a/docs/superpowers/specs/2026-07-28-webapp-log-tab-design.md
+++ b/docs/superpowers/specs/2026-07-28-webapp-log-tab-design.md
@@ -1,0 +1,146 @@
+# Web App Log Tab + Restore Decoupling — Design
+
+**Status:** approved (brainstorm) — 2026-07-28
+
+**Goal:** (1) Fix the recurring "Restore button stops working" bug by decoupling the restore action from the scan loop, and (2) add a **Log** tab that records the app's internal UI/glue events in an in-memory ring buffer so behavior is observable and shareable.
+
+## Motivation
+
+The Restore tab's buttons stop responding intermittently — reported after restoring one archive and after finishing a scan of several archives. Root cause (confirmed by reading `webapp/app/ui/restore-panel.ts`): the entire restore lifecycle lives inside a single `$('scan')` click handler. The Restore buttons' `onPick(id)` only sets a local `pickedId` and aborts the scan loop; the actual restore runs once *after* the loop breaks, then the handler returns. Consequences:
+
+- Only **one** archive can be restored per Scan click.
+- After that restore completes — or after **Stop** — the handler has returned. The archive rows remain (the in-place reconcile keeps their buttons alive), but their `onPick` now points at a finished handler: it sets `pickedId` on a dead closure and aborts an already-aborted controller. Clicking Restore does nothing.
+
+This is an architectural coupling, not a flaky timing issue. The `RestoreController` already restores from in-memory chunks (no transport needed), so restore does not need the scan loop at all. Two fixes were already tried on this button (skip blank cards; in-place reconcile so buttons aren't torn down); this third change addresses the actual root cause, and the Log tab makes the fix self-verifying and helps with the genuinely hardware-flaky cases (RF/tag detection) that can't be reproduced without the device.
+
+## Decisions (locked during brainstorming)
+
+1. **Bundle** the restore decoupling fix and the Log tab in one iteration; the refactored restore flow is instrumented from birth.
+2. **In-memory ring buffer** (~1000 entries, cleared on reload) + **export** (Copy to clipboard, Download `.txt`). No cross-reload persistence (this bug is within-session; matches the app's client-only, no-storage ethos).
+3. Instrument at the **UI/glue layer** (panels + `device.ts`). The dependency-free core codecs stay untouched.
+
+## Architecture
+
+Four pieces, following existing patterns (dependency-free `src/` core + thin DOM glue in `app/`).
+
+```
+webapp/
+  src/log/
+    logger.ts           # dependency-free Logger (ring buffer + pub/sub) + `log` singleton; unit-tested under node
+  app/ui/
+    log-panel.ts        # subscribes to `log`, renders the Log tab, Clear/Copy/Download/level-filter/auto-scroll
+    restore-panel.ts    # MODIFIED: decouple restore from the scan loop + emit log events
+    device.ts           # MODIFIED: log connect/disconnect
+    archive-panel.ts    # MODIFIED (light): log archive prepare/write-complete
+    files-panel.ts      # MODIFIED (light): log download/delete/clear
+    shell.ts            # MODIFIED: add 'log' to the TABS tuple
+  app/
+    index.html          # MODIFIED: add the Log tab button + panel section
+    main.ts             # MODIFIED: initLogPanel()
+```
+
+### Logger core (`src/log/logger.ts`)
+
+Dependency-free, web-platform globals only (`Date.now`), so it runs under `node --test` like the rest of `src/`.
+
+```ts
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface LogEntry {
+  seq: number;      // monotonic counter (stable ordering + de-dupe in the panel)
+  t: number;        // Date.now() epoch ms
+  level: LogLevel;
+  cat: string;      // category, e.g. 'restore', 'scan', 'device'
+  msg: string;
+  data?: unknown;   // small structured context, e.g. { id, count }
+}
+
+export interface LoggerOptions { capacity?: number; mirrorToConsole?: boolean; }
+
+export class Logger {
+  constructor(opts?: LoggerOptions);            // default capacity 1000, mirrorToConsole false
+  debug(cat: string, msg: string, data?: unknown): void;
+  info(cat: string, msg: string, data?: unknown): void;
+  warn(cat: string, msg: string, data?: unknown): void;
+  error(cat: string, msg: string, data?: unknown): void;
+  subscribe(cb: (e: LogEntry) => void): () => void;  // fires on each new append; returns an unsubscribe fn
+  snapshot(): LogEntry[];                             // current buffer, oldest-first
+  clear(): void;                                      // empties the buffer (no subscriber notification)
+  setMirrorToConsole(on: boolean): void;
+}
+
+export const log: Logger;   // the app-wide singleton (capacity 1000, console mirror off)
+```
+
+Behavior:
+- Each `debug/info/warn/error` builds a `LogEntry` (stamping `seq` from an internal counter and `t = Date.now()`), pushes it into a ring buffer capped at `capacity` (oldest evicted when full), and synchronously notifies every subscriber with the new entry.
+- `mirrorToConsole` (default **off**) additionally forwards to `console[level]` — kept off by default so the test suite's output stays pristine; the Log tab exposes a toggle.
+- `subscribe` fires only on new appends and returns an unsubscribe function; a subscriber added after entries exist calls `snapshot()` once to backfill (the panel does this on mount).
+- `clear()` empties the buffer and does **not** notify subscribers. The Log panel owns the Clear button: it calls `log.clear()` then re-renders empty from `snapshot()`. This keeps the subscriber contract to a single append event — no separate clear/reset channel is needed.
+
+### Restore decoupling (`app/ui/restore-panel.ts`)
+
+Restructure `initRestorePanel` so `RestoreController` and the detected archives outlive the scan loop, and restoring is a standalone action:
+
+- Panel-scoped state: `let ctrl: RestoreController | null`, `let scanAbort: AbortController | null`, `let restoring = false`.
+- **`restoreArchive(id: string)`** — standalone async function, the `onPick` handler passed to `renderArchiveList`. It:
+  1. returns early (with a log line) if `ctrl` is null or `restoring` is already true (prevents overlapping restores / double password prompts);
+  2. sets `restoring = true`, logs `restore` "clicked" `{id}`;
+  3. runs the existing password-retry loop (`ctrl.restore(id, pw)` with `PasswordRequiredError`/`DecryptionError` → `prompt` → retry, max 5), triggers the Blob download, then the non-fatal Files-capture (`filesController.saveRestored` with `ctrl.assembledPayload(id)`), logging start/success/error/download/capture;
+  4. `finally` sets `restoring = false`.
+- **Scan** click: build `ctrl = new RestoreController(transport)`; clear the archives container (`renderArchiveList($('archives'), [], restoreArchive)`); create `scanAbort`; run the accumulate-and-render loop that ends **only** on `AbortError` (Stop) — it never breaks on a pick; per-tap `TagTimeoutError`/`UnsupportedTagError`/other errors continue as today. Each `scanNextCard` return calls `renderArchiveList($('archives'), list, restoreArchive)` and logs the detection summary.
+- **Stop** click: `scanAbort?.abort()` — stops accumulating; `ctrl` and the rendered archives (and their working Restore buttons) persist.
+
+Result: restore archive A, then B, then C from one scan, and restore after Stop, all work — because each button calls `restoreArchive` directly against the still-live `ctrl`, independent of scan-loop state. `restoreArchive` reads the outer `ctrl` variable, so it always targets the current scan session; clearing the container at scan start removes stale rows from a prior session.
+
+Concurrency note: while scanning continues, a restore may run concurrently; this is safe because `RestoreController.restore`/`assembledPayload` snapshot the group's chunks (`[...group.chunks.values()]`) at call time, and the transport is used only by the scan loop (restore is in-memory compute). The `restoring` guard serializes user-triggered restores.
+
+### Log tab UI (`app/ui/log-panel.ts` + `index.html` + `shell.ts`)
+
+- `shell.ts`: add `'log'` to the `TABS` tuple (`['archive','restore','files','log','about']` — order per the Global Constraints below). The existing tab machinery (per-tab button click → `activateTab`) then covers it.
+- `index.html`: add a `<button role="tab" data-tab="log">Log</button>` in `#tabs` and a `<section id="panel-log">` containing a controls row (`#log-clear`, `#log-copy`, `#log-download`, a `#log-level` `<select>` with debug/info/warn/error, a `#log-console` mirror-to-console checkbox, a `#log-autoscroll` checkbox) and a scrolling monospace container `#log`.
+- `log-panel.ts` `initLogPanel()`:
+  - Backfills from `log.snapshot()`, then `log.subscribe` to append each new entry as a row. Rows are non-interactive text (`hh:mm:ss.mmm  LEVEL  [cat]  msg  {data-json}`), so simple append is safe (no reconcile needed); a row below the current `#log-level` threshold is created hidden and toggled when the filter changes.
+  - **Clear** → `log.clear()` then re-render empty. **Copy** → join visible entries to text → `navigator.clipboard.writeText`. **Download** → Blob `.txt` (`nfc-archiver-log-<timestamp>.txt`). **Level filter** → show/hide rows at/above the selected minimum level. **Mirror to console** → `log.setMirrorToConsole`. **Auto-scroll** (default on) → scroll to bottom on new entries.
+- `main.ts`: call `initLogPanel()` alongside the other panel inits.
+
+### Instrumentation points (UI/glue layer)
+
+- `device.ts`: `device` "connecting" / "connected" `{name?}` / "connect failed" `{error}` / "disconnected".
+- `restore-panel.ts`: `scan` started / stopped; `scan` detection `{count, complete}` per render; per-tap `warn` skip/timeout/unsupported; `restore` clicked `{id}` / password-prompt / success `{bytes, name}` / error `{error}` / download `{name}` / files-capture ok|fail.
+- `archive-panel.ts` (light): `archive` prepared `{cards}` / write progress `{written, total}` / complete.
+- `files-panel.ts` (light): `files` download `{id}` / delete `{id}` / clear `{count}`.
+
+Log `data` payloads carry only small, non-sensitive context (ids, counts, sizes, error messages) — never file contents or passwords.
+
+## Data flow
+
+Module calls `log.info(cat, msg, data)` → `Logger` appends to the ring buffer + notifies subscribers → the Log panel (if mounted) appends a row. Export copies/downloads the current buffer as text. Reload clears everything.
+
+## Error handling
+
+- The logger never throws into callers: `subscribe` callbacks are invoked in a try/catch so a broken subscriber can't break logging; a failed `console` mirror is ignored.
+- Instrumentation calls are fire-and-forget (`log.*` returns void) and must never change control flow — a logging call is never in a position where its absence would alter behavior.
+- The restore refactor preserves all existing error handling (password retry, non-fatal Files capture, per-tap skips); it only relocates where restore is invoked from.
+
+## Testing
+
+- `src/log/logger.ts` unit tests (under `node --test`): append then `snapshot()` returns entries oldest-first with monotonic `seq`; ring-buffer eviction at capacity (e.g. capacity 3, push 5 → last 3 kept); `subscribe` fires on each append and the returned unsubscribe stops further calls; `clear()` empties the buffer; `setMirrorToConsole(true)` forwards to console (spy) and default is silent; a throwing subscriber does not break `log.*` or other subscribers.
+- `log-panel.ts` and the `restore-panel.ts` refactor are DOM glue. The Restore buttons' click reliability (fire `onPick` per click, across re-renders, per row id) is already covered by `test/restore-view.test.ts`; the multi-restore / restore-after-stop behavior is verified live via the new Log tab trace (the event sequence is the acceptance evidence) and by code review. No new DOM harness is added for the panels (YAGNI — the reusable renderer is already tested, and the fix is a wiring change).
+
+## Out of scope (YAGNI)
+
+- Cross-reload / persistent log storage; remote log shipping.
+- Instrumenting the dependency-free core codecs or the transport/SDK layer (can be added later since the logger lives in `src/`).
+- Log search, structured filtering beyond a min-level threshold, or per-category toggles.
+- Changing restore UX beyond the decoupling (e.g. auto-stopping the scan on pick) — scanning keeps running until Stop.
+
+## Global constraints
+
+- Core (`src/`) stays dependency-free and uses only web-platform globals; the logger adds no runtime dependency (`dependencies` stays exactly `['chameleon-ultra.js']`).
+- ESM NodeNext: intra-project imports use `.js` paths.
+- Tab order in `shell.ts` `TABS` and in `index.html`: `archive, restore, files, log, about` (Log before About).
+- Console mirroring defaults **off** so `npm test` output stays pristine.
+- Log `data` never contains file contents or passwords.
+- Reuse the existing in-place reconcile renderer (`renderArchiveList`) and typed errors (`PasswordRequiredError`, `DecryptionError`); do not reintroduce `innerHTML=''` list rebuilds in the restore flow.
+- Node ≥ 22 for tests/build; `rm -rf dist` before `npm test`.

--- a/docs/superpowers/specs/2026-07-28-webapp-log-tab-design.md
+++ b/docs/superpowers/specs/2026-07-28-webapp-log-tab-design.md
@@ -28,9 +28,10 @@ webapp/
   src/log/
     logger.ts           # dependency-free Logger (ring buffer + pub/sub) + `log` singleton; unit-tested under node
   app/ui/
-    log-panel.ts        # subscribes to `log`, renders the Log tab, Clear/Copy/Download/level-filter/auto-scroll
-    restore-panel.ts    # MODIFIED: decouple restore from the scan loop + emit log events
-    device.ts           # MODIFIED: log connect/disconnect
+    log-panel.ts             # subscribes to `log`, renders the Log tab, Clear/Copy/Download/level-filter/auto-scroll
+    restore-orchestrator.ts  # NEW: DOM-light restore/scan orchestration behind an injected IO seam (unit-tested with a DOM stub)
+    restore-panel.ts         # MODIFIED: thin IO adapter — builds the real DOM/browser IO, wires Scan/Stop, runs the scan-step loop
+    device.ts                # MODIFIED: log connect/disconnect
     archive-panel.ts    # MODIFIED (light): log archive prepare/write-complete
     files-panel.ts      # MODIFIED (light): log download/delete/clear
     shell.ts            # MODIFIED: add 'log' to the TABS tuple
@@ -78,22 +79,44 @@ Behavior:
 - `subscribe` fires only on new appends and returns an unsubscribe function; a subscriber added after entries exist calls `snapshot()` once to backfill (the panel does this on mount).
 - `clear()` empties the buffer and does **not** notify subscribers. The Log panel owns the Clear button: it calls `log.clear()` then re-renders empty from `snapshot()`. This keeps the subscriber contract to a single append event — no separate clear/reset channel is needed.
 
-### Restore decoupling (`app/ui/restore-panel.ts`)
+### Restore decoupling — orchestrator seam (`app/ui/restore-orchestrator.ts` + `restore-panel.ts`)
 
-Restructure `initRestorePanel` so `RestoreController` and the detected archives outlive the scan loop, and restoring is a standalone action:
+The bug lives in DOM glue, so to make the fix regression-testable it is extracted into a DOM-light **`RestoreOrchestrator`** that depends only on an injected IO seam (real DOM in the browser, stubs in tests). `restore-panel.ts` becomes the thin adapter that builds the real IO and runs the scan-step loop.
 
-- Panel-scoped state: `let ctrl: RestoreController | null`, `let scanAbort: AbortController | null`, `let restoring = false`.
-- **`restoreArchive(id: string)`** — standalone async function, the `onPick` handler passed to `renderArchiveList`. It:
-  1. returns early (with a log line) if `ctrl` is null or `restoring` is already true (prevents overlapping restores / double password prompts);
-  2. sets `restoring = true`, logs `restore` "clicked" `{id}`;
-  3. runs the existing password-retry loop (`ctrl.restore(id, pw)` with `PasswordRequiredError`/`DecryptionError` → `prompt` → retry, max 5), triggers the Blob download, then the non-fatal Files-capture (`filesController.saveRestored` with `ctrl.assembledPayload(id)`), logging start/success/error/download/capture;
-  4. `finally` sets `restoring = false`.
-- **Scan** click: build `ctrl = new RestoreController(transport)`; clear the archives container (`renderArchiveList($('archives'), [], restoreArchive)`); create `scanAbort`; run the accumulate-and-render loop that ends **only** on `AbortError` (Stop) — it never breaks on a pick; per-tap `TagTimeoutError`/`UnsupportedTagError`/other errors continue as today. Each `scanNextCard` return calls `renderArchiveList($('archives'), list, restoreArchive)` and logs the detection summary.
-- **Stop** click: `scanAbort?.abort()` — stops accumulating; `ctrl` and the rendered archives (and their working Restore buttons) persist.
+**`RestoreOrchestrator` (`app/ui/restore-orchestrator.ts`)**
 
-Result: restore archive A, then B, then C from one scan, and restore after Stop, all work — because each button calls `restoreArchive` directly against the still-live `ctrl`, independent of scan-loop state. `restoreArchive` reads the outer `ctrl` variable, so it always targets the current scan session; clearing the container at scan start removes stale rows from a prior session.
+```ts
+export interface RestoreIO {
+  container: HTMLElement;                          // the #archives list element (real or a DOM stub)
+  files: { saveRestored(e: Omit<StoredFile, 'createdAt'>): Promise<void> };
+  promptPassword(message: string): string | null;  // wraps window.prompt (null = cancelled)
+  download(data: Uint8Array, name: string): void;   // wraps the Blob/anchor download
+  fallbackName(): string;                           // e.g. the #fname value or 'restored.bin'
+  setFileName(name: string): void;                  // reflect a recovered filename back into the UI
+  setStatus(msg: string): void;
+  log: Logger;
+}
 
-Concurrency note: while scanning continues, a restore may run concurrently; this is safe because `RestoreController.restore`/`assembledPayload` snapshot the group's chunks (`[...group.chunks.values()]`) at call time, and the transport is used only by the scan loop (restore is in-memory compute). The `restoring` guard serializes user-triggered restores.
+export class RestoreOrchestrator {
+  constructor(io: RestoreIO);
+  startSession(transport: Transport): void;   // new RestoreController(transport); clear container via renderArchiveList(container, [], onPick)
+  scanStep(signal: AbortSignal): Promise<void>;// ONE scanNextCard(signal) + renderArchiveList(container, list, onPick=restoreArchive) + detection log; throws AbortError/TagTimeoutError/… to the caller
+  restoreArchive(id: string): Promise<void>;   // standalone restore, the onPick handler; callable anytime
+}
+```
+
+- `restoreArchive(id)`: returns early (with a log line) if there is no active controller or `restoring` is already true (a private guard that prevents overlapping restores / double password prompts); otherwise sets `restoring = true`, logs `restore` "clicked" `{id}`, runs the password-retry loop (`ctrl.restore(id, pw)`; on `PasswordRequiredError`/`DecryptionError` → `io.promptPassword(message)` → retry, max 5; a `null` prompt cancels), calls `io.download(data, name)` and `io.setFileName` on a recovered name, then the non-fatal Files capture (`io.files.saveRestored({ … payload: ctrl.assembledPayload(id) })`), logging start/success/error/download/capture, and clears `restoring` in `finally`.
+- `scanStep(signal)`: one `ctrl.scanNextCard(signal)` then `renderArchiveList(io.container, list, (id) => this.restoreArchive(id))` and a detection log. It does not swallow errors — the panel's loop routes them.
+
+**`restore-panel.ts` (thin adapter)**
+
+- Builds a `RestoreIO` from the real DOM (`#archives` container, `#restore-status`, `#fname`), `filesController`, a `promptPassword` over `window.prompt` with the encrypted/wrong-password messages, a `download` over Blob+anchor, and the `log` singleton; constructs one `RestoreOrchestrator`.
+- **Scan** click: `orch.startSession(currentTransport())`; create `scanAbort`; loop `for(;;){ try { await orch.scanStep(scanAbort.signal) } catch (e) { AbortError → break; TagTimeoutError → continue; UnsupportedTagError → status+continue; else → status+continue } }`; `finally` re-enables Scan / disables Stop and logs scan stopped.
+- **Stop** click: `scanAbort?.abort()` — stops accumulating; the orchestrator, its controller, and the rendered archives (with working Restore buttons) persist.
+
+Result: restore archive A, then B, then C from one scan, and restore after Stop, all work — each button calls `orch.restoreArchive` directly against the still-live controller, independent of scan-loop state. `startSession` clears the container so a new scan drops stale rows.
+
+Concurrency: a restore may overlap a running scan safely — `RestoreController.restore`/`assembledPayload` snapshot the group's chunks (`[...group.chunks.values()]`) at call time, and the transport is used only by the scan loop (restore is in-memory compute). The `restoring` guard serializes user-triggered restores.
 
 ### Log tab UI (`app/ui/log-panel.ts` + `index.html` + `shell.ts`)
 
@@ -125,8 +148,15 @@ Module calls `log.info(cat, msg, data)` → `Logger` appends to the ring buffer 
 
 ## Testing
 
-- `src/log/logger.ts` unit tests (under `node --test`): append then `snapshot()` returns entries oldest-first with monotonic `seq`; ring-buffer eviction at capacity (e.g. capacity 3, push 5 → last 3 kept); `subscribe` fires on each append and the returned unsubscribe stops further calls; `clear()` empties the buffer; `setMirrorToConsole(true)` forwards to console (spy) and default is silent; a throwing subscriber does not break `log.*` or other subscribers.
-- `log-panel.ts` and the `restore-panel.ts` refactor are DOM glue. The Restore buttons' click reliability (fire `onPick` per click, across re-renders, per row id) is already covered by `test/restore-view.test.ts`; the multi-restore / restore-after-stop behavior is verified live via the new Log tab trace (the event sequence is the acceptance evidence) and by code review. No new DOM harness is added for the panels (YAGNI — the reusable renderer is already tested, and the fix is a wiring change).
+- **`src/log/logger.ts`** unit tests (under `node --test`): append then `snapshot()` returns entries oldest-first with monotonic `seq`; ring-buffer eviction at capacity (e.g. capacity 3, push 5 → last 3 kept); `subscribe` fires on each append and the returned unsubscribe stops further calls; `clear()` empties the buffer; `setMirrorToConsole(true)` forwards to `console` (spy) and the default is silent; a throwing subscriber does not break `log.*` or other subscribers.
+
+- **`app/ui/restore-orchestrator.ts`** — a DOM-stub regression test (`test/restore-orchestrator.test.ts`) that reproduces the exact bug and proves the fix. It reuses the minimal `makeDoc()` DOM stub from `test/restore-view.test.ts` (same shape: `createElement`, `children`, `append/appendChild/remove`, `get/setAttribute`, `addEventListener`, `click`) for the `container`, and a `MockTransport` for detection:
+  - Build the orchestrator with a stub `RestoreIO`: the stub `container`; a `download` capturing `{data, name}` calls; a `promptPassword` returning a scripted password; a `files` whose `saveRestored` records entries; capturing `setStatus`/`setFileName`/`fallbackName`; a fresh `Logger`.
+  - `startSession(mock)`, enqueue a **plain** archive A and an **encrypted** archive B (built with an `archiveToCards`-style helper), then call `scanStep(new AbortController().signal)` repeatedly until both are complete — driving detection deterministically without touching the infinite panel loop (`MockTransport.awaitTag` throws `TagTimeoutError` when idle, so the test never runs an unbounded loop).
+  - Find A's Restore button in the stub container (`[data-archive-id]` row → button child), `.click()` it, await, and assert `download` fired with A's original bytes + filename and a Files entry was saved. Then click **B**'s button (encrypted → `promptPassword` supplies the password) and assert the decrypted original bytes. Then click **A's button again** and assert it restores a **second** time — this is the regression assertion: the pre-fix one-shot handler restored only once, so a re-click doing nothing (no new `download` call) would fail this test.
+  - A `scanStep`-free assertion: after detection, call `restoreArchive(id)` directly (simulating "restore after Stop") and confirm it still downloads — proving restore does not depend on an active scan loop.
+
+- **`log-panel.ts`** and the thin `restore-panel.ts` adapter remain DOM glue; the reusable renderer's click reliability is covered by `test/restore-view.test.ts`, the orchestration by the test above, and the live Log-tab trace is the manual acceptance evidence. No further DOM harness is added for the thin adapter (YAGNI).
 
 ## Out of scope (YAGNI)
 

--- a/webapp/app/index.html
+++ b/webapp/app/index.html
@@ -78,6 +78,7 @@
         <button role="tab" data-tab="archive" aria-selected="true">Archive</button>
         <button role="tab" data-tab="restore" aria-selected="false">Restore</button>
         <button role="tab" data-tab="files" aria-selected="false">Files</button>
+        <button role="tab" data-tab="log" aria-selected="false">Log</button>
         <button role="tab" data-tab="about" aria-selected="false">About</button>
       </div>
 
@@ -118,6 +119,27 @@
           <div style="margin-top:0.6rem"><span id="files-info" class="muted"></span>
             &nbsp;&nbsp;<button id="files-clear">Clear all</button></div>
           <p id="files-status" class="muted"></p>
+        </div>
+      </section>
+
+      <section id="panel-log" role="tabpanel" hidden>
+        <div class="card">
+          <div style="display:flex;gap:0.6rem;flex-wrap:wrap;align-items:center">
+            <label>level
+              <select id="log-level">
+                <option value="debug">debug</option>
+                <option value="info" selected>info</option>
+                <option value="warn">warn</option>
+                <option value="error">error</option>
+              </select>
+            </label>
+            <label><input type="checkbox" id="log-autoscroll" checked /> auto-scroll</label>
+            <label><input type="checkbox" id="log-console" /> mirror to console</label>
+            <button id="log-clear">Clear</button>
+            <button id="log-copy">Copy</button>
+            <button id="log-download">Download</button>
+          </div>
+          <div id="log" style="font-family:monospace;font-size:0.8rem;max-height:60vh;overflow:auto;white-space:pre-wrap;margin-top:0.6rem"></div>
         </div>
       </section>
 

--- a/webapp/app/main.ts
+++ b/webapp/app/main.ts
@@ -4,6 +4,7 @@ import { initDeviceBar } from './ui/device.js';
 import { initArchivePanel } from './ui/archive-panel.js';
 import { initRestorePanel } from './ui/restore-panel.js';
 import { initFilesPanel } from './ui/files-panel.js';
+import { initLogPanel } from './ui/log-panel.js';
 import { initAboutPanel } from './ui/about-panel.js';
 
 initShell();
@@ -11,4 +12,5 @@ initDeviceBar();
 initArchivePanel();
 initRestorePanel();
 initFilesPanel();
+initLogPanel();
 initAboutPanel();

--- a/webapp/app/ui/archive-panel.ts
+++ b/webapp/app/ui/archive-panel.ts
@@ -5,6 +5,7 @@ import { estimateCardCount } from '../estimate.js';
 import { NtagType, ntagChunkPayloadSize } from '../../src/nfc/type2.js';
 import { currentTransport, onConnectionChange } from './device.js';
 import { humanError } from './errors.js';
+import { log } from '../../src/log/logger.js';
 
 const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
 
@@ -79,6 +80,7 @@ export function initArchivePanel(): void {
     try {
       const total = await ctrl.prepare({ data: src.data, fileName: src.fileName, compress, password: pass || undefined, payloadSize: selectedPayloadSize() });
       render(0, total, false);
+      log.info('archive', 'Prepared', { cards: total });
       let done = false;
       while (!done) {
         try {
@@ -97,6 +99,7 @@ export function initArchivePanel(): void {
           } else { throw e; }
         }
       }
+      log.info('archive', 'Write complete', { cards: total });
     } catch (e) {
       hideProgress();
       setStatus(humanError(e));

--- a/webapp/app/ui/device.ts
+++ b/webapp/app/ui/device.ts
@@ -10,6 +10,7 @@ import { SdkChameleonDevice } from '../../src/transport/sdk-chameleon-device.js'
 import { AutoTransport } from '../../src/transport/auto-transport.js';
 import { diagnoseCard, type RawAntiColl } from '../diagnostics.js';
 import { humanError } from './errors.js';
+import { log } from '../../src/log/logger.js';
 
 const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
 const hex = (b: Uint8Array): string =>
@@ -31,6 +32,7 @@ export function initDeviceBar(): void {
   const deviceStatus = $('device-status');
 
   $('connect').addEventListener('click', async () => {
+    log.info('device', 'Connecting');
     try {
       ultra = new ChameleonUltra();
       // use() is async (the adapter's install() runs availability checks etc.);
@@ -42,8 +44,10 @@ export function initDeviceBar(): void {
       ($('diagnose') as HTMLButtonElement).disabled = false;
       for (const cb of listeners) cb(true);
       deviceStatus.textContent = 'Connected.';
+      log.info('device', 'Connected');
     } catch (e) {
       deviceStatus.textContent = humanError(e);
+      log.error('device', 'Connect failed', { error: String(e) });
     }
   });
 

--- a/webapp/app/ui/files-panel.ts
+++ b/webapp/app/ui/files-panel.ts
@@ -14,7 +14,7 @@ export const filesController = new FilesController(new IdbFileStore());
 
 async function download(id: string, setStatus: (m: string) => void): Promise<void> {
   let pw: string | undefined;
-  for (let attempt = 0; attempt < 5; attempt++) {
+  for (let attempt = 0; attempt <= 5; attempt++) {
     try {
       const { data, name } = await filesController.prepareDownload(id, pw);
       const a = document.createElement('a');
@@ -27,6 +27,7 @@ async function download(id: string, setStatus: (m: string) => void): Promise<voi
       return;
     } catch (e) {
       if (e instanceof PasswordRequiredError || e instanceof DecryptionError) {
+        if (attempt === 5) break;
         const entered = prompt(e instanceof DecryptionError ? 'Wrong password. Enter password:' : 'This file is encrypted. Enter password:') ?? undefined;
         if (entered === undefined) { setStatus('Cancelled.'); return; }
         pw = entered; continue;

--- a/webapp/app/ui/files-panel.ts
+++ b/webapp/app/ui/files-panel.ts
@@ -5,6 +5,7 @@ import { renderFileList, humanSize } from './files-view.js';
 import { PasswordRequiredError } from '../controller.js';
 import { DecryptionError } from '../../src/crypto.js';
 import { humanError } from './errors.js';
+import { log } from '../../src/log/logger.js';
 
 const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
 
@@ -22,6 +23,7 @@ async function download(id: string, setStatus: (m: string) => void): Promise<voi
       a.click();
       URL.revokeObjectURL(a.href);
       setStatus(`Downloaded ${humanSize(data.length)} → ${name}.`);
+      log.info('files', 'Downloaded', { id, name });
       return;
     } catch (e) {
       if (e instanceof PasswordRequiredError || e instanceof DecryptionError) {
@@ -44,7 +46,7 @@ export function initFilesPanel(): void {
       const files = await filesController.list();
       renderFileList($('files'), files, {
         onDownload: (id) => { void download(id, setStatus); },
-        onDelete: async (id) => { await filesController.delete(id); await refresh(); },
+        onDelete: async (id) => { await filesController.delete(id); log.info('files', 'Deleted', { id }); await refresh(); },
       });
       const info = await filesController.info();
       $('files-empty').hidden = info.count > 0;
@@ -57,6 +59,7 @@ export function initFilesPanel(): void {
   $('files-clear').addEventListener('click', async () => {
     if (!confirm('Delete all stored files? This cannot be undone.')) return;
     const n = await filesController.clear();
+    log.info('files', 'Cleared', { count: n });
     await refresh();
     setStatus(`Cleared ${n} file(s).`);
   });

--- a/webapp/app/ui/log-panel.ts
+++ b/webapp/app/ui/log-panel.ts
@@ -1,0 +1,50 @@
+/** Log tab: live view of the in-app event log with min-level filter + export. */
+import { log, formatLogLine, LEVELS, type LogEntry, type LogLevel } from '../../src/log/logger.js';
+
+const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
+
+export function initLogPanel(): void {
+  const box = $('log');
+  const levelSel = $('log-level') as HTMLSelectElement;
+  const autoscroll = $('log-autoscroll') as HTMLInputElement;
+  const consoleChk = $('log-console') as HTMLInputElement;
+  const minLevel = (): number => LEVELS[levelSel.value as LogLevel] ?? 0;
+
+  const addRow = (e: LogEntry): void => {
+    const row = document.createElement('div');
+    row.dataset['level'] = e.level;
+    row.textContent = formatLogLine(e);
+    row.hidden = LEVELS[e.level] < minLevel();
+    box.appendChild(row);
+    if (autoscroll.checked) box.scrollTop = box.scrollHeight;
+  };
+
+  const rerender = (): void => {
+    box.replaceChildren(); // log rows are non-interactive text — safe to rebuild
+    for (const e of log.snapshot()) addRow(e);
+  };
+
+  rerender();
+  log.subscribe(addRow);
+
+  levelSel.addEventListener('change', () => {
+    const min = minLevel();
+    for (const row of Array.from(box.children) as HTMLElement[]) {
+      const lvl = row.dataset['level'] as LogLevel | undefined;
+      row.hidden = lvl === undefined ? false : LEVELS[lvl] < min;
+    }
+  });
+  consoleChk.addEventListener('change', () => log.setMirrorToConsole(consoleChk.checked));
+  $('log-clear').addEventListener('click', () => { log.clear(); rerender(); });
+  $('log-copy').addEventListener('click', () => {
+    void navigator.clipboard?.writeText(log.snapshot().map(formatLogLine).join('\n'));
+  });
+  $('log-download').addEventListener('click', () => {
+    const text = log.snapshot().map(formatLogLine).join('\n');
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(new Blob([text], { type: 'text/plain' }));
+    a.download = `nfc-archiver-log-${new Date().toISOString().replace(/[:.]/g, '-')}.txt`;
+    a.click();
+    URL.revokeObjectURL(a.href);
+  });
+}

--- a/webapp/app/ui/log-panel.ts
+++ b/webapp/app/ui/log-panel.ts
@@ -16,6 +16,7 @@ export function initLogPanel(): void {
     row.textContent = formatLogLine(e);
     row.hidden = LEVELS[e.level] < minLevel();
     box.appendChild(row);
+    while (box.children.length > 1000) box.firstChild?.remove();
     if (autoscroll.checked) box.scrollTop = box.scrollHeight;
   };
 

--- a/webapp/app/ui/restore-orchestrator.ts
+++ b/webapp/app/ui/restore-orchestrator.ts
@@ -56,15 +56,16 @@ export class RestoreOrchestrator {
     try {
       let pw: string | undefined;
       let result: { data: Uint8Array; fileName: string | null } | undefined;
-      for (let attempt = 0; attempt < 5; attempt++) {
+      // attempt 0 tries with no password (unencrypted archives succeed here);
+      // then up to 5 user-entered passwords are each actually tried.
+      for (let attempt = 0; attempt <= 5; attempt++) {
         try { result = await ctrl.restore(id, pw); break; }
         catch (e) {
-          if (e instanceof PasswordRequiredError || e instanceof DecryptionError) {
-            const entered = this.io.promptPassword(e instanceof DecryptionError ? 'Wrong password. Enter password:' : 'This archive is encrypted. Enter password:');
-            if (entered === null) { this.io.setStatus('Cancelled.'); this.io.log.info('restore', 'Cancelled', { id }); return; }
-            pw = entered; continue;
-          }
-          throw e;
+          if (!(e instanceof PasswordRequiredError || e instanceof DecryptionError)) throw e;
+          if (attempt === 5) break; // 5 passwords already tried
+          const entered = this.io.promptPassword(e instanceof DecryptionError ? 'Wrong password. Enter password:' : 'This archive is encrypted. Enter password:');
+          if (entered === null) { this.io.setStatus('Cancelled.'); this.io.log.info('restore', 'Cancelled', { id }); return; }
+          pw = entered;
         }
       }
       if (!result) { this.io.setStatus('Too many failed password attempts.'); this.io.log.warn('restore', 'Too many password attempts', { id }); return; }

--- a/webapp/app/ui/restore-orchestrator.ts
+++ b/webapp/app/ui/restore-orchestrator.ts
@@ -1,0 +1,96 @@
+/**
+ * DOM-light restore/scan orchestration behind an injected IO seam. Restoring is
+ * decoupled from the scan loop: each rendered Restore button calls
+ * restoreArchive(id) directly, so it works during a scan, after Stop, and
+ * repeatedly for different archives. The panel supplies the real DOM/browser IO;
+ * tests supply a DOM stub + MockTransport.
+ */
+import { RestoreController, PasswordRequiredError } from '../controller.js';
+import { DecryptionError } from '../../src/crypto.js';
+import { renderArchiveList } from './restore-view.js';
+import { humanError } from './errors.js';
+import type { Transport } from '../../src/transport/transport.js';
+import type { StoredFile } from '../../src/storage/file-store.js';
+import type { Logger } from '../../src/log/logger.js';
+
+export interface RestoreIO {
+  container: HTMLElement;
+  files: { saveRestored(e: Omit<StoredFile, 'createdAt'>): Promise<void> };
+  promptPassword(message: string): string | null;
+  download(data: Uint8Array, name: string): void;
+  fallbackName(): string;
+  setFileName(name: string): void;
+  setStatus(msg: string): void;
+  log: Logger;
+}
+
+export class RestoreOrchestrator {
+  private ctrl: RestoreController | null = null;
+  private restoring = false;
+
+  constructor(private readonly io: RestoreIO) {}
+
+  private render(list: Parameters<typeof renderArchiveList>[1]): void {
+    renderArchiveList(this.io.container, list, (id) => this.restoreArchive(id));
+  }
+
+  startSession(transport: Transport): void {
+    this.ctrl = new RestoreController(transport);
+    this.render([]); // clear any rows from a previous session
+    this.io.log.info('scan', 'Session started');
+  }
+
+  async scanStep(signal: AbortSignal): Promise<void> {
+    if (this.ctrl === null) throw new Error('scanStep before startSession');
+    const list = await this.ctrl.scanNextCard(signal);
+    this.render(list);
+    this.io.log.debug('scan', 'Detection', { archives: list.length, complete: list.filter((d) => d.complete).length });
+  }
+
+  async restoreArchive(id: string): Promise<void> {
+    if (this.ctrl === null) { this.io.log.warn('restore', 'Ignored: no session', { id }); return; }
+    if (this.restoring) { this.io.log.warn('restore', 'Ignored: already restoring', { id }); return; }
+    const ctrl = this.ctrl;
+    this.restoring = true;
+    this.io.log.info('restore', 'Restore clicked', { id });
+    try {
+      let pw: string | undefined;
+      let result: { data: Uint8Array; fileName: string | null } | undefined;
+      for (let attempt = 0; attempt < 5; attempt++) {
+        try { result = await ctrl.restore(id, pw); break; }
+        catch (e) {
+          if (e instanceof PasswordRequiredError || e instanceof DecryptionError) {
+            const entered = this.io.promptPassword(e instanceof DecryptionError ? 'Wrong password. Enter password:' : 'This archive is encrypted. Enter password:');
+            if (entered === null) { this.io.setStatus('Cancelled.'); this.io.log.info('restore', 'Cancelled', { id }); return; }
+            pw = entered; continue;
+          }
+          throw e;
+        }
+      }
+      if (!result) { this.io.setStatus('Too many failed password attempts.'); this.io.log.warn('restore', 'Too many password attempts', { id }); return; }
+      const name = result.fileName ?? this.io.fallbackName();
+      if (result.fileName) this.io.setFileName(result.fileName);
+      this.io.download(result.data, name);
+      this.io.setStatus(`Restored ${result.data.length} bytes → ${name}.`);
+      this.io.log.info('restore', 'Restored', { id, bytes: result.data.length, name });
+      try {
+        const meta = ctrl.detectedArchives().find((d) => d.archiveId === id);
+        if (meta) {
+          await this.io.files.saveRestored({
+            id, name: result.fileName ?? name, size: result.data.length,
+            isEncrypted: meta.isEncrypted, isCompressed: meta.isCompressed,
+            totalChunks: meta.totalChunks, payload: ctrl.assembledPayload(id),
+          });
+          this.io.log.info('files', 'Saved to history', { id });
+        }
+      } catch (e) {
+        this.io.log.warn('files', 'History save failed (non-fatal)', { id, error: String(e) });
+      }
+    } catch (e) {
+      this.io.setStatus(humanError(e));
+      this.io.log.error('restore', 'Restore failed', { id, error: String(e) });
+    } finally {
+      this.restoring = false;
+    }
+  }
+}

--- a/webapp/app/ui/restore-panel.ts
+++ b/webapp/app/ui/restore-panel.ts
@@ -1,17 +1,34 @@
-/** Restore tab: scan a pile of cards, detect archives, pick a complete one to restore. */
-import { RestoreController, PasswordRequiredError } from '../controller.js';
+/** Restore tab: thin adapter — builds the DOM/browser IO for RestoreOrchestrator and runs the scan-step loop. */
+import { RestoreOrchestrator, type RestoreIO } from './restore-orchestrator.js';
 import { TagTimeoutError, UnsupportedTagError } from '../../src/transport/transport.js';
-import { DecryptionError } from '../../src/crypto.js';
 import { currentTransport, onConnectionChange } from './device.js';
-import { renderArchiveList } from './restore-view.js';
-import { humanError } from './errors.js';
 import { filesController } from './files-panel.js';
+import { humanError } from './errors.js';
+import { log } from '../../src/log/logger.js';
 
 const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
 
 export function initRestorePanel(): void {
   const setStatus = (msg: string) => { $('restore-status').textContent = msg; };
   let scanAbort: AbortController | null = null;
+
+  const io: RestoreIO = {
+    container: $('archives'),
+    files: filesController,
+    promptPassword: (message) => window.prompt(message),
+    download: (data, name) => {
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(new Blob([data as BlobPart]));
+      a.download = name;
+      a.click();
+      URL.revokeObjectURL(a.href);
+    },
+    fallbackName: () => ($('fname') as HTMLInputElement).value || 'restored.bin',
+    setFileName: (name) => { ($('fname') as HTMLInputElement).value = name; },
+    setStatus,
+    log,
+  };
+  const orch = new RestoreOrchestrator(io);
 
   onConnectionChange((connected) => {
     ($('scan') as HTMLButtonElement).disabled = !connected;
@@ -21,91 +38,32 @@ export function initRestorePanel(): void {
   $('scan').addEventListener('click', async () => {
     const transport = currentTransport();
     if (!transport) return;
-    const ctrl = new RestoreController(transport);
+    orch.startSession(transport);
     scanAbort = new AbortController();
-    let pickedId: string | null = null;
     ($('scan') as HTMLButtonElement).disabled = true;
     ($('stop-scan') as HTMLButtonElement).disabled = false;
     setStatus('Scanning — tap cards on the reader…');
-    const onPick = (id: string) => {
-      pickedId = id;
-      $('archives').querySelectorAll('button').forEach((b) => { (b as HTMLButtonElement).disabled = true; });
-      scanAbort?.abort();
-    };
-
+    log.info('scan', 'Scan started');
     try {
-      try {
-        for (;;) {
-          try {
-            const list = await ctrl.scanNextCard(scanAbort.signal);
-            renderArchiveList($('archives'), list, onPick);
-            setStatus(`Detected ${list.length} archive(s). Tap more cards, or Restore a complete one.`);
-          } catch (e) {
-            // Only an abort (Stop / Restore pick) ends the scan; every per-tap
-            // failure just skips that card so the session — and its Restore
-            // buttons — stay alive.
-            if (e instanceof DOMException && e.name === 'AbortError') break;
-            if (e instanceof TagTimeoutError) continue;
-            if (e instanceof UnsupportedTagError) { setStatus('Unsupported tag — tap a Mifare Classic 1K or NTAG.'); continue; }
-            setStatus(`Skipped a card: ${humanError(e)}`);
-            continue;
-          }
-        }
-      } catch (e) {
-        setStatus(humanError(e));
-        return;
-      }
-
-      if (!pickedId) { setStatus('Stopped scanning.'); return; }
-      const chosenId = pickedId;
-
-      try {
-        let pw: string | undefined;
-        let result: { data: Uint8Array; fileName: string | null } | undefined;
-        for (let attempt = 0; attempt < 5; attempt++) {
-          try { result = await ctrl.restore(chosenId, pw); break; }
-          catch (e) {
-            if (e instanceof PasswordRequiredError || e instanceof DecryptionError) {
-              const entered = prompt(e instanceof DecryptionError ? 'Wrong password. Enter password:' : 'This archive is encrypted. Enter password:') ?? undefined;
-              if (entered === undefined) { setStatus('Cancelled.'); return; }
-              pw = entered; continue;
-            }
-            throw e;
-          }
-        }
-        if (!result) { setStatus('Too many failed password attempts.'); return; }
-        const name = result.fileName ?? (($('fname') as HTMLInputElement).value || 'restored.bin');
-        if (result.fileName) ($('fname') as HTMLInputElement).value = result.fileName;
-        const a = document.createElement('a');
-        a.href = URL.createObjectURL(new Blob([result.data as BlobPart]));
-        a.download = name;
-        a.click();
-        URL.revokeObjectURL(a.href);
-        setStatus(`Restored ${result.data.length} bytes → ${name}.`);
-        // Persist a re-downloadable Files entry (non-fatal on failure — the
-        // download already succeeded). Encrypted archives store ciphertext.
+      for (;;) {
         try {
-          const meta = ctrl.detectedArchives().find((d) => d.archiveId === chosenId);
-          if (meta) {
-            await filesController.saveRestored({
-              id: chosenId,
-              name: result.fileName ?? name,
-              size: result.data.length,
-              isEncrypted: meta.isEncrypted,
-              isCompressed: meta.isCompressed,
-              totalChunks: meta.totalChunks,
-              payload: ctrl.assembledPayload(chosenId),
-            });
-          }
-        } catch { /* history save failed; the restore/download still succeeded */ }
-      } catch (e) {
-        setStatus(humanError(e));
+          await orch.scanStep(scanAbort.signal);
+          setStatus('Tap more cards, or Restore a complete one.');
+        } catch (e) {
+          if (e instanceof DOMException && e.name === 'AbortError') break;
+          if (e instanceof TagTimeoutError) continue;
+          if (e instanceof UnsupportedTagError) { setStatus('Unsupported tag — tap a Mifare Classic 1K or NTAG.'); log.warn('scan', 'Unsupported tag'); continue; }
+          setStatus(`Skipped a card: ${humanError(e)}`);
+          log.warn('scan', 'Skipped a card', { error: String(e) });
+          continue;
+        }
       }
     } finally {
       ($('stop-scan') as HTMLButtonElement).disabled = true;
       ($('scan') as HTMLButtonElement).disabled = false;
+      log.info('scan', 'Scan stopped');
     }
   });
 
-  $('stop-scan').addEventListener('click', () => scanAbort?.abort());
+  $('stop-scan').addEventListener('click', () => { scanAbort?.abort(); });
 }

--- a/webapp/app/ui/shell.ts
+++ b/webapp/app/ui/shell.ts
@@ -1,7 +1,7 @@
 /** App shell: tab switching and the light/dark theme toggle. DOM glue only. */
 
 const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
-const TABS = ['archive', 'restore', 'files', 'about'] as const;
+const TABS = ['archive', 'restore', 'files', 'log', 'about'] as const;
 
 function activateTab(name: string): void {
   for (const t of TABS) {

--- a/webapp/src/log/logger.ts
+++ b/webapp/src/log/logger.ts
@@ -1,0 +1,62 @@
+/**
+ * Dependency-free in-memory event log: a capped ring buffer plus pub/sub, used
+ * by the Log tab. Web-platform globals only, so it runs under node --test.
+ */
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface LogEntry {
+  seq: number;      // monotonic counter (stable ordering)
+  t: number;        // Date.now() epoch ms
+  level: LogLevel;
+  cat: string;      // category, e.g. 'restore', 'scan', 'device'
+  msg: string;
+  data?: unknown;   // small structured context (never file contents or passwords)
+}
+
+export interface LoggerOptions { capacity?: number; mirrorToConsole?: boolean; }
+
+export const LEVELS: Record<LogLevel, number> = { debug: 0, info: 1, warn: 2, error: 3 };
+
+/** Stable one-line rendering: `hh:mm:ss.mmm LEVEL [cat] msg {data}` (UTC time). */
+export function formatLogLine(e: LogEntry): string {
+  const time = new Date(e.t).toISOString().slice(11, 23);
+  const data = e.data === undefined ? '' : ` ${JSON.stringify(e.data)}`;
+  return `${time} ${e.level.toUpperCase().padEnd(5)} [${e.cat}] ${e.msg}${data}`;
+}
+
+export class Logger {
+  private readonly capacity: number;
+  private mirror: boolean;
+  private readonly buf: LogEntry[] = [];
+  private readonly subs = new Set<(e: LogEntry) => void>();
+  private seq = 0;
+
+  constructor(opts?: LoggerOptions) {
+    this.capacity = opts?.capacity ?? 1000;
+    this.mirror = opts?.mirrorToConsole ?? false;
+  }
+
+  private emit(level: LogLevel, cat: string, msg: string, data?: unknown): void {
+    const e: LogEntry = { seq: this.seq++, t: Date.now(), level, cat, msg, ...(data !== undefined ? { data } : {}) };
+    this.buf.push(e);
+    if (this.buf.length > this.capacity) this.buf.shift();
+    if (this.mirror) { try { console[level](formatLogLine(e)); } catch { /* ignore console failures */ } }
+    for (const cb of this.subs) { try { cb(e); } catch { /* a broken subscriber must not break logging */ } }
+  }
+
+  debug(cat: string, msg: string, data?: unknown): void { this.emit('debug', cat, msg, data); }
+  info(cat: string, msg: string, data?: unknown): void { this.emit('info', cat, msg, data); }
+  warn(cat: string, msg: string, data?: unknown): void { this.emit('warn', cat, msg, data); }
+  error(cat: string, msg: string, data?: unknown): void { this.emit('error', cat, msg, data); }
+
+  subscribe(cb: (e: LogEntry) => void): () => void {
+    this.subs.add(cb);
+    return () => { this.subs.delete(cb); };
+  }
+  snapshot(): LogEntry[] { return [...this.buf]; }
+  clear(): void { this.buf.length = 0; }
+  setMirrorToConsole(on: boolean): void { this.mirror = on; }
+}
+
+export const log = new Logger();

--- a/webapp/test/logger.test.ts
+++ b/webapp/test/logger.test.ts
@@ -1,0 +1,70 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Logger, formatLogLine, type LogEntry } from '../src/log/logger.js';
+
+test('formatLogLine is deterministic (UTC time, padded level)', () => {
+  const e: LogEntry = { seq: 0, t: 0, level: 'info', cat: 'scan', msg: 'hi' };
+  assert.equal(formatLogLine(e), '00:00:00.000 INFO  [scan] hi');
+  assert.equal(formatLogLine({ ...e, level: 'error', data: { id: 'x' } }), '00:00:00.000 ERROR [scan] hi {"id":"x"}');
+});
+
+test('info appends an entry retrievable via snapshot with monotonic seq', () => {
+  const log = new Logger();
+  log.info('cat', 'first');
+  log.warn('cat', 'second', { n: 2 });
+  const s = log.snapshot();
+  assert.equal(s.length, 2);
+  assert.equal(s[0]!.msg, 'first');
+  assert.equal(s[0]!.level, 'info');
+  assert.equal(s[1]!.data && (s[1]!.data as { n: number }).n, 2);
+  assert.equal(s[1]!.seq, s[0]!.seq + 1);
+});
+
+test('ring buffer evicts oldest at capacity', () => {
+  const log = new Logger({ capacity: 3 });
+  for (let i = 0; i < 5; i++) log.info('c', `m${i}`);
+  const msgs = log.snapshot().map((e) => e.msg);
+  assert.deepEqual(msgs, ['m2', 'm3', 'm4']);
+});
+
+test('subscribe fires on each append; unsubscribe stops it', () => {
+  const log = new Logger();
+  const seen: string[] = [];
+  const off = log.subscribe((e) => seen.push(e.msg));
+  log.info('c', 'a');
+  off();
+  log.info('c', 'b');
+  assert.deepEqual(seen, ['a']);
+});
+
+test('clear empties the buffer', () => {
+  const log = new Logger();
+  log.info('c', 'a');
+  log.clear();
+  assert.equal(log.snapshot().length, 0);
+});
+
+test('a throwing subscriber does not break logging or other subscribers', () => {
+  const log = new Logger();
+  const seen: string[] = [];
+  log.subscribe(() => { throw new Error('boom'); });
+  log.subscribe((e) => seen.push(e.msg));
+  assert.doesNotThrow(() => log.info('c', 'a'));
+  assert.deepEqual(seen, ['a']);
+});
+
+test('console mirror is off by default and forwards when enabled', () => {
+  const calls: string[] = [];
+  const orig = console.info;
+  console.info = (msg?: unknown) => { calls.push(String(msg)); };
+  try {
+    const log = new Logger();
+    log.info('c', 'silent');
+    assert.equal(calls.length, 0);
+    log.setMirrorToConsole(true);
+    log.info('c', 'loud');
+    assert.equal(calls.length, 1);
+  } finally {
+    console.info = orig;
+  }
+});

--- a/webapp/test/restore-orchestrator.test.ts
+++ b/webapp/test/restore-orchestrator.test.ts
@@ -1,0 +1,138 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { MockTransport } from '../src/transport/mock-transport.js';
+import { ArchiveController } from '../app/controller.js';
+import { RestoreOrchestrator, type RestoreIO } from '../app/ui/restore-orchestrator.js';
+import { Logger } from '../src/log/logger.js';
+
+/** Minimal DOM stub (as in restore-view.test.ts) — but click() is async and
+ *  awaits handler return values, so a button click that triggers an async
+ *  restore can be awaited deterministically in the test. */
+interface StubEl {
+  tagName: string; className: string; textContent: string; disabled: boolean;
+  children: StubEl[]; parent: StubEl | null; ownerDocument: StubDoc;
+  attrs: Record<string, string>; listeners: Record<string, Array<() => unknown>>;
+  append(...k: StubEl[]): void; appendChild(k: StubEl): StubEl; remove(): void;
+  setAttribute(n: string, v: string): void; getAttribute(n: string): string | null;
+  addEventListener(t: string, fn: () => unknown): void; click(): Promise<void>;
+}
+interface StubDoc { createElement(tag: string): StubEl; }
+function makeDoc(): StubDoc {
+  const doc: StubDoc = {
+    createElement(tag) {
+      const el: StubEl = {
+        tagName: tag.toUpperCase(), className: '', textContent: '', disabled: false,
+        children: [], parent: null, ownerDocument: doc, attrs: {}, listeners: {},
+        append(...k) { for (const c of k) { c.parent = el; el.children.push(c); } },
+        appendChild(k) { k.parent = el; el.children.push(k); return k; },
+        remove() { if (el.parent) { el.parent.children.splice(el.parent.children.indexOf(el), 1); el.parent = null; } },
+        setAttribute(n, v) { el.attrs[n] = v; },
+        getAttribute(n) { return el.attrs[n] ?? null; },
+        addEventListener(t, fn) { (el.listeners[t] ??= []).push(fn); },
+        async click() { for (const fn of el.listeners['click'] ?? []) await fn(); },
+      };
+      return el;
+    },
+  };
+  return doc;
+}
+
+const uidFor = (a: number) => (i: number) => new Uint8Array([a, 0, 0, i]);
+
+/** Archive `data` to mock cards and return the stored bytes per card. */
+async function archiveToCards(data: Uint8Array, opts: { compress: boolean; password?: string; fileName: string }): Promise<Uint8Array[]> {
+  const src = new MockTransport();
+  const ctrl = new ArchiveController(src);
+  const uid = uidFor(0xa0);
+  const total = await ctrl.prepare({ data, fileName: opts.fileName, compress: opts.compress, password: opts.password, payloadSize: 720 });
+  const stored: Uint8Array[] = [];
+  for (let i = 0; i < total; i++) {
+    src.enqueueTag(uid(i)); await ctrl.writeNextCard();
+    src.enqueueTag(uid(i)); await src.awaitTag(); stored.push(await src.readChunk());
+  }
+  return stored;
+}
+
+function makeIO(container: StubEl, over?: Partial<RestoreIO>) {
+  const downloads: Array<{ data: Uint8Array; name: string }> = [];
+  const saved: Array<{ id: string; isEncrypted: boolean }> = [];
+  const io: RestoreIO = {
+    container: container as unknown as HTMLElement,
+    files: { async saveRestored(e) { saved.push({ id: e.id, isEncrypted: e.isEncrypted }); } },
+    promptPassword: () => null,
+    download: (data, name) => downloads.push({ data, name }),
+    fallbackName: () => 'restored.bin',
+    setFileName: () => {},
+    setStatus: () => {},
+    log: new Logger(),
+    ...over,
+  };
+  return { io, downloads, saved };
+}
+
+const signal = () => new AbortController().signal;
+
+test('restore works for multiple archives, repeatedly, independent of the scan loop', async () => {
+  const plain = crypto.getRandomValues(new Uint8Array(1500));   // multi-card, incompressible
+  const secret = crypto.getRandomValues(new Uint8Array(1500));
+  const cardsA = await archiveToCards(plain, { compress: false, fileName: 'a.bin' });
+  const cardsB = await archiveToCards(secret, { compress: false, password: 'pw', fileName: 'b.bin' });
+
+  const doc = makeDoc();
+  const container = doc.createElement('div');
+  const { io, downloads, saved } = makeIO(container, { promptPassword: () => 'pw' });
+  const orch = new RestoreOrchestrator(io);
+
+  const rt = new MockTransport();
+  orch.startSession(rt);
+  cardsA.forEach((b, i) => rt.enqueueTag(new Uint8Array([1, 0, 0, i]), b));
+  cardsB.forEach((b, i) => rt.enqueueTag(new Uint8Array([2, 0, 0, i]), b));
+  // Drive detection deterministically (MockTransport.awaitTag throws when idle,
+  // so we never run the panel's unbounded loop).
+  for (let i = 0; i < cardsA.length + cardsB.length; i++) await orch.scanStep(signal());
+
+  const rows = (container as unknown as StubEl).children;
+  assert.equal(rows.length, 2, 'both archives detected as rows');
+  const btn = (rowIdx: number) => rows[rowIdx]!.children[1]!; // [span, Restore button]
+
+  // Click archive A's Restore button -> restores the plain archive.
+  await btn(0).click();
+  assert.equal(downloads.length, 1);
+  assert.deepEqual(downloads[0]!.data, plain);
+  assert.equal(downloads[0]!.name, 'a.bin');
+
+  // Click archive B's button -> encrypted, promptPassword supplies 'pw'.
+  await btn(1).click();
+  assert.equal(downloads.length, 2);
+  assert.deepEqual(downloads[1]!.data, secret);
+
+  // Regression: click archive A AGAIN -> restores a second time (the pre-fix
+  // one-shot handler restored only once; a dead re-click would leave length 2).
+  await btn(0).click();
+  assert.equal(downloads.length, 3);
+  assert.deepEqual(downloads[2]!.data, plain);
+
+  // Restore-after-"stop": no scanStep in between, direct call still works.
+  await orch.restoreArchive(rows[1]!.getAttribute('data-archive-id')!);
+  assert.equal(downloads.length, 4);
+  assert.deepEqual(downloads[3]!.data, secret);
+
+  assert.ok(saved.some((s) => !s.isEncrypted) && saved.some((s) => s.isEncrypted), 'both saved to history');
+});
+
+test('restoreArchive ignores a wrong-then-cancelled password without downloading', async () => {
+  const secret = crypto.getRandomValues(new Uint8Array(800));
+  const cards = await archiveToCards(secret, { compress: false, password: 'pw', fileName: 's.bin' });
+  const doc = makeDoc();
+  const container = doc.createElement('div');
+  // First prompt returns a wrong password, second returns null (cancel).
+  const answers = ['nope', null] as Array<string | null>;
+  const { io, downloads } = makeIO(container, { promptPassword: () => answers.shift() ?? null });
+  const orch = new RestoreOrchestrator(io);
+  const rt = new MockTransport();
+  orch.startSession(rt);
+  cards.forEach((b, i) => rt.enqueueTag(new Uint8Array([3, 0, 0, i]), b));
+  for (let i = 0; i < cards.length; i++) await orch.scanStep(signal());
+  await (container as unknown as StubEl).children[0]!.children[1]!.click();
+  assert.equal(downloads.length, 0, 'cancelled restore downloads nothing');
+});

--- a/webapp/test/restore-orchestrator.test.ts
+++ b/webapp/test/restore-orchestrator.test.ts
@@ -136,3 +136,20 @@ test('restoreArchive ignores a wrong-then-cancelled password without downloading
   await (container as unknown as StubEl).children[0]!.children[1]!.click();
   assert.equal(downloads.length, 0, 'cancelled restore downloads nothing');
 });
+
+test('restoreArchive tries the last entered password (no off-by-one)', async () => {
+  const secret = crypto.getRandomValues(new Uint8Array(800));
+  const cards = await archiveToCards(secret, { compress: false, password: 'pw', fileName: 's.bin' });
+  const doc = makeDoc();
+  const container = doc.createElement('div');
+  const answers = ['wrong', 'wrong', 'wrong', 'wrong', 'pw'] as Array<string | null>;
+  const { io, downloads } = makeIO(container, { promptPassword: () => answers.shift() ?? null });
+  const orch = new RestoreOrchestrator(io);
+  const rt = new MockTransport();
+  orch.startSession(rt);
+  cards.forEach((b, i) => rt.enqueueTag(new Uint8Array([4, 0, 0, i]), b));
+  for (let i = 0; i < cards.length; i++) await orch.scanStep(signal());
+  await (container as unknown as StubEl).children[0]!.children[1]!.click();
+  assert.equal(downloads.length, 1, 'the 5th (correct) password is actually tried');
+  assert.deepEqual(downloads[0]!.data, secret);
+});


### PR DESCRIPTION
## Summary

Two bundled deliverables, branched cleanly off `master`:

1. **Fix: Restore buttons stop working intermittently.** Root cause — the whole restore lived inside a one-shot scan-click handler, so only one archive could be restored per scan and the buttons went dead after the first restore or after Stop. Restore is now extracted into a standalone `RestoreOrchestrator` behind an injected IO seam; each Restore button works during a scan, after Stop, and repeatedly.
2. **Log tab** — an in-app diagnostic view of internal events, motivated by (and now confirming) the fix above.

Built via the brainstorm → spec → plan → subagent-driven loop (5 TDD tasks + final whole-branch review + a pre-merge fix wave). Spec: `docs/superpowers/specs/2026-07-28-webapp-log-tab-design.md`; plan: `docs/superpowers/plans/2026-07-28-webapp-log-tab.md`.

## The fix

- `app/ui/restore-orchestrator.ts` — `RestoreOrchestrator` with `startSession` / `scanStep` / `restoreArchive(id)`. `restoreArchive` is the `onPick` handler, callable anytime; a `restoring` guard (released in `finally`) prevents overlapping restores. It captures its controller locally so a new scan can't swap it mid-restore, and persists **ciphertext at rest** (`assembledPayload`, never the decrypted `result.data`).
- `app/ui/restore-panel.ts` — now a thin adapter: builds the real DOM/browser IO and runs the scan-step loop. All the old one-shot pick/abort logic is gone.
- **Regression test** (`test/restore-orchestrator.test.ts`) — drives detection via `MockTransport`+`scanStep`, then clicks **real rendered buttons** on a DOM stub to prove archive A → B → A restores repeatedly, and that a direct restore works with no scan in between. A dead re-click fails the test.

## Log tab

- `src/log/logger.ts` — dependency-free ring-buffer `Logger` (pub/sub, `formatLogLine`), console-mirror **off** by default (pristine test output).
- `app/ui/log-panel.ts` + `index.html` + `shell.ts` — Log tab (order: archive · restore · files · **log** · about): live view, min-level filter, auto-scroll, **Copy** / **Download .txt**, console-mirror toggle. DOM rows capped to the buffer size.
- Instrumentation at the UI/glue layer (device connect, archive prepare/complete, files download/delete/clear, restore lifecycle). Log `data` carries only ids/counts/names/error strings — **never file contents or passwords** (verified across every call site in review).

## Also fixed (password-retry off-by-one, both sites)

The retry loop prompted for a 5th password but never tried it. Fixed in the orchestrator (with a test) and, on review's recommendation, in its twin in `files-panel.ts download()`.

## Constraints held

- Core `src/` stays dependency-free; runtime deps unchanged (`chameleon-ultra.js` only).
- On-tag byte formats + restore pipeline unchanged (the fix only moved the invocation site).
- No `innerHTML=''` rebuilds in the restore flow.

## Testing

- **144/144** tests pass; tsc clean; esbuild bundle builds.
- New: 7 Logger tests + 3 RestoreOrchestrator tests (multi-restore/after-stop, cancelled-password, last-password-tried).
- `log-panel.ts` and the thin `restore-panel.ts` are untested glue by design.

## Manual browser smoke (needs a Chameleon over Web Bluetooth — deferred to reviewer)

Connect; scan 5–6 archives; open **Log** and watch events stream; restore A → B → A from one scan **without rescanning** (all succeed); hit **Stop**, restore another (succeeds); **Copy/Download** the trace. This is the acceptance test for the decoupling fix.

## Deferred (post-merge, tracked)

`Array.shift()` eviction O(n); scan-loop consecutive-error circuit breaker; Copy/Download honoring the level filter + clipboard rejection handling; a shared password-retry helper so the two sites can't drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)