### PR TITLE
feat(webapp): dynamic chip-capacity re-chunking (adapt to the tapped card)

### DIFF
--- a/docs/superpowers/plans/2026-07-29-webapp-dynamic-capacity.md
+++ b/docs/superpowers/plans/2026-07-29-webapp-dynamic-capacity.md
@@ -1,0 +1,401 @@
+# Web App Dynamic Chip-Capacity Re-chunking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make archiving adapt to the tapped chip's real capacity — on the first tap, auto-re-chunk to fit — so a card smaller than the selected tag type no longer fails with `CardCapacityError`.
+
+**Architecture:** The transport already knows each card's real per-card NFAR chunk-payload; expose it on `PresentedTag.maxChunkPayload`. `ArchiveController` gains `rechunkForCapacity(newPayloadSize)` that re-splits the already-processed payload (preserving `archiveId`, no re-encrypt), and `writeNextCard` auto-calls it on the first tap. The target-tag dropdown becomes an estimate hint with an Auto-detect default; the misleading capacity error is corrected.
+
+**Tech Stack:** TypeScript (ESM NodeNext — imports use `.js`), esbuild, `node --test`.
+
+## Global Constraints
+
+- Core (`src/`) stays dependency-free, web-platform globals only; no new runtime deps (`dependencies` stays exactly `{ "chameleon-ultra.js" }`).
+- ESM NodeNext: every intra-project import uses the compiled `.js` path.
+- On-tag NFAR byte format is unchanged; re-chunking uses `createChunks`/`assembleChunks` and preserves `archiveId`, flags, and the processed payload bytes exactly.
+- Re-chunk is valid ONLY before the first card is written (each chunk header carries `totalChunks`+index).
+- Independent of `feat/webapp-log-tab` (PR #38): do NOT import `src/log/logger.ts`. Surface the re-chunk via the archive status line.
+- Node ≥ 22 for tests/build: `source ~/.nvm/nvm.sh && nvm use --lts` first (shell default is Node 14). `rm -rf dist` before running tests: `rm -rf dist && npx tsc && node --test 'dist/test/**/*.test.js'`.
+
+---
+
+## File Structure
+
+- `src/transport/transport.ts` (modify) — add `maxChunkPayload` to `PresentedTag`.
+- `src/transport/chameleon-ble.ts` (modify) — return `maxChunkPayload: CARD_PAYLOAD_SIZE`.
+- `src/transport/ntag-transport.ts` (modify) — return `maxChunkPayload: ntagChunkPayloadSize(type)`.
+- `src/transport/mock-transport.ts` (modify) — settable `maxChunkPayload` (default `CARD_PAYLOAD_SIZE`).
+- `app/controller.ts` (modify) — `RechunkTooLateError`, `ArchiveController.rechunkForCapacity`, `writeNextCard` auto-rechunk + `rechunkedTo`.
+- `app/ui/archive-panel.ts` (modify) — Auto-detect payload size, estimate note, re-chunk status.
+- `app/index.html` (modify) — Auto-detect dropdown option.
+- `app/ui/errors.ts` (modify) — corrected `CardCapacityError` message.
+- Tests: `test/chameleon-ble.test.ts`, `test/ntag-transport.test.ts`, `test/controller.test.ts`, `test/errors.test.ts` (all extend existing files).
+
+---
+
+## Task 1: `PresentedTag.maxChunkPayload` on all transports
+
+**Files:**
+- Modify: `webapp/src/transport/transport.ts`, `webapp/src/transport/chameleon-ble.ts`, `webapp/src/transport/ntag-transport.ts`, `webapp/src/transport/mock-transport.ts`
+- Test: `webapp/test/chameleon-ble.test.ts`, `webapp/test/ntag-transport.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `CARD_PAYLOAD_SIZE` (`src/mifare/card-layout.ts`, value 720), `ntagChunkPayloadSize`/`ntagUserBytes` (`src/nfc/type2.ts`).
+- Produces: `PresentedTag.maxChunkPayload: number` on every `awaitTag`; `MockTransport.maxChunkPayload` public settable field.
+
+- [ ] **Step 1: Write the failing test**
+
+In `webapp/test/chameleon-ble.test.ts`, add `CARD_PAYLOAD_SIZE` to the card-layout import (it already imports `USABLE_BLOCK_INDEXES` from `'../src/mifare/card-layout.js'`):
+```ts
+import { USABLE_BLOCK_INDEXES, CARD_PAYLOAD_SIZE } from '../src/mifare/card-layout.js';
+```
+In the existing test `'connect delegates to the device; awaitTag polls scanTag'`, after the line `const tag = await transport.awaitTag();`, add:
+```ts
+  assert.equal(tag.maxChunkPayload, CARD_PAYLOAD_SIZE);
+```
+
+In `webapp/test/ntag-transport.test.ts`, in the existing test that does `device.placeNtag(uid, NtagType.NTAG215); const tag = await t.awaitTag();` and asserts `tag.capacityBytes === 504`, add right after that assertion:
+```ts
+  assert.equal(tag.maxChunkPayload, ntagChunkPayloadSize(NtagType.NTAG215));
+```
+(`ntagChunkPayloadSize` and `NtagType` are already imported there.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+source ~/.nvm/nvm.sh && nvm use --lts
+cd webapp && rm -rf dist && npx tsc
+```
+Expected: FAIL — `Property 'maxChunkPayload' does not exist on type 'PresentedTag'`.
+
+- [ ] **Step 3: Add the field to the interface and every implementation**
+
+In `webapp/src/transport/transport.ts`, change `PresentedTag`:
+```ts
+export interface PresentedTag {
+  uid: Uint8Array;
+  capacityBytes: number;   // raw user memory (informational)
+  maxChunkPayload: number; // max NFAR chunk-payload this card holds
+}
+```
+
+In `webapp/src/transport/chameleon-ble.ts`: add `CARD_PAYLOAD_SIZE` to the existing `../mifare/card-layout.js` import, and change the `awaitTag` return:
+```ts
+if (tag !== null) return { uid: tag.uid, capacityBytes: CARD_CAPACITY_BYTES, maxChunkPayload: CARD_PAYLOAD_SIZE };
+```
+
+In `webapp/src/transport/ntag-transport.ts`, change the `awaitTag` return (both `ntagUserBytes` and `ntagChunkPayloadSize` are already imported):
+```ts
+const type = await this.detectType();
+return { uid: tag.uid, capacityBytes: ntagUserBytes(type), maxChunkPayload: ntagChunkPayloadSize(type) };
+```
+
+In `webapp/src/transport/mock-transport.ts`: add `CARD_PAYLOAD_SIZE` to the existing `../mifare/card-layout.js` import, add a public field, and return it. Add the field near the top of the class:
+```ts
+  /** Simulated per-card NFAR chunk-payload capacity; tests set this to model a small chip. */
+  maxChunkPayload = CARD_PAYLOAD_SIZE;
+```
+and change the `awaitTag` success return to:
+```ts
+    this.active = next;
+    return { uid: Uint8Array.from(next.match(/../g)!.map((h) => parseInt(h, 16))), capacityBytes: CARD_CAPACITY_BYTES, maxChunkPayload: this.maxChunkPayload };
+```
+
+`AutoTransport.awaitTag` returns the delegate's `PresentedTag` unchanged, so it needs no edit.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd webapp && rm -rf dist && npx tsc && node --test 'dist/test/**/*.test.js'
+```
+Expected: PASS — the two new assertions plus all pre-existing tests (tsc now clean; every `awaitTag` return site provides `maxChunkPayload`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add webapp/src/transport/transport.ts webapp/src/transport/chameleon-ble.ts webapp/src/transport/ntag-transport.ts webapp/src/transport/mock-transport.ts webapp/test/chameleon-ble.test.ts webapp/test/ntag-transport.test.ts
+git commit -m "feat(webapp): PresentedTag.maxChunkPayload exposes each card's real per-card capacity"
+```
+
+---
+
+## Task 2: `ArchiveController` auto-rechunk
+
+**Files:**
+- Modify: `webapp/app/controller.ts`
+- Test: `webapp/test/controller.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `PresentedTag.maxChunkPayload` + `MockTransport.maxChunkPayload` (Task 1); `assembleChunks` (already imported in `controller.ts`), `createChunks` (`src/chunker.ts`).
+- Produces:
+  - `class RechunkTooLateError extends Error`
+  - `ArchiveController.rechunkForCapacity(newPayloadSize: number): number`
+  - `ArchiveController.writeNextCard(...)` return type gains `rechunkedTo?: { total: number; payloadSize: number }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `webapp/test/controller.test.ts` (it already imports `MockTransport`, `ArchiveController`, `RestoreController`, `decodeChunk`, and has `uid`, `multiCardData`; add `RechunkTooLateError` to the `../app/controller.js` import and `decodeChunk` is already imported from `../src/chunk.js`):
+
+```ts
+test('rechunkForCapacity grows the chunk count for a smaller card and refuses after a write', async () => {
+  const t = new MockTransport();
+  t.maxChunkPayload = 73; // simulate an NTAG213-sized card so writeNextCard won't re-rechunk
+  const ctrl = new ArchiveController(t);
+  const big = await ctrl.prepare({ data: multiCardData, fileName: 'x.bin', compress: false, payloadSize: 720 });
+  const small = ctrl.rechunkForCapacity(73);
+  assert.ok(small > big, `expected more chunks after shrinking: ${small} > ${big}`);
+  t.enqueueTag(uid(0));
+  await ctrl.writeNextCard(); // 73 === current payloadSize -> no auto-rechunk; writes card 0
+  assert.throws(() => ctrl.rechunkForCapacity(428), RechunkTooLateError);
+});
+
+test('writeNextCard auto-rechunks to the tapped card and still restores byte-identically', async () => {
+  const t = new MockTransport();
+  t.maxChunkPayload = 73; // the tapped card is much smaller than the selected NTAG216
+  const ctrl = new ArchiveController(t);
+  const originalTotal = await ctrl.prepare({ data: multiCardData, fileName: 'x.bin', compress: false, payloadSize: 812 });
+
+  const stored: Uint8Array[] = [];
+  let done = false, i = 0, guard = 0;
+  let firstRechunk: { total: number; payloadSize: number } | undefined;
+  while (!done && guard++ < 1000) {
+    t.enqueueTag(uid(i));
+    const res = await ctrl.writeNextCard();
+    if (res.rechunkedTo && firstRechunk === undefined) firstRechunk = res.rechunkedTo;
+    done = res.done;
+    t.enqueueTag(uid(i)); await t.awaitTag(); stored.push(await t.readChunk()); // read back this card
+    i++;
+  }
+  assert.ok(firstRechunk, 'the first tap reported a re-chunk');
+  assert.equal(firstRechunk!.payloadSize, 73);
+  assert.ok(firstRechunk!.total > originalTotal, `more, smaller cards: ${firstRechunk!.total} > ${originalTotal}`);
+  assert.equal(stored.length, firstRechunk!.total);
+  // all written cards share one archiveId (coherent archive)
+  const ids = new Set(stored.map((b) => decodeChunk(b).archiveId.join(',')));
+  assert.equal(ids.size, 1);
+
+  // restore the small-card pile -> byte-identical to the original data
+  const rt = new MockTransport();
+  const rctrl = new RestoreController(rt);
+  stored.forEach((b, j) => rt.enqueueTag(uid(j), b));
+  let list = await rctrl.scanNextCard();
+  for (let j = 1; j < stored.length; j++) list = await rctrl.scanNextCard();
+  assert.ok(list[0]!.complete);
+  const result = await rctrl.restore(list[0]!.archiveId);
+  assert.deepEqual(result.data, multiCardData);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd webapp && rm -rf dist && npx tsc
+```
+Expected: FAIL — `RechunkTooLateError` and `rechunkForCapacity` / `rechunkedTo` do not exist.
+
+- [ ] **Step 3: Implement**
+
+In `webapp/app/controller.ts`:
+
+1. Add `createChunks` to the chunker import (the file already imports `assembleChunks` from `'../src/chunker.js'`):
+```ts
+import { assembleChunks, createChunks } from '../src/chunker.js';
+```
+
+2. Add the error class next to `OverwriteRequiredError`:
+```ts
+export class RechunkTooLateError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RechunkTooLateError';
+  }
+}
+```
+
+3. In `class ArchiveController`, add a `payloadSize` field, set it in `prepare`, add `rechunkForCapacity`, and auto-rechunk in `writeNextCard`. Replace the class body's fields + `prepare` + `writeNextCard` with:
+```ts
+  private chunks: Chunk[] = [];
+  private written = 0;
+  private payloadSize = 0;
+  private readonly writtenUids = new Set<string>();
+
+  constructor(private readonly transport: Transport) {}
+
+  async prepare(req: ArchiveRequest): Promise<number> {
+    const wrapped = wrapWithFilename(req.data, req.fileName);
+    this.chunks = await archive(wrapped, {
+      payloadSize: req.payloadSize,
+      compress: req.compress,
+      password: req.password,
+    });
+    this.payloadSize = req.payloadSize;
+    this.written = 0;
+    this.writtenUids.clear();
+    return this.chunks.length;
+  }
+
+  /** Re-split the already-processed payload to a new per-card size, preserving the
+   *  archiveId (no re-encrypt). Only valid before any card is written. */
+  rechunkForCapacity(newPayloadSize: number): number {
+    if (this.written > 0) throw new RechunkTooLateError('Cannot re-chunk after writing has started');
+    const payload = assembleChunks(this.chunks);
+    const { flags, archiveId } = this.chunks[0]!;
+    this.chunks = createChunks(payload, newPayloadSize, flags, archiveId);
+    this.payloadSize = newPayloadSize;
+    return this.chunks.length;
+  }
+
+  private progress(awaiting: number | null): ArchiveProgress {
+    return { total: this.chunks.length, written: this.written, awaiting };
+  }
+
+  async writeNextCard(signal?: AbortSignal, confirmOverwrite = false): Promise<{ done: boolean; progress: ArchiveProgress; rechunkedTo?: { total: number; payloadSize: number } }> {
+    if (this.written >= this.chunks.length) return { done: true, progress: this.progress(null) };
+    const tag = await this.transport.awaitTag({ signal });
+    const key = uidHex(tag.uid);
+    if (this.writtenUids.has(key)) {
+      return { done: false, progress: this.progress(this.written) };
+    }
+    let rechunkedTo: { total: number; payloadSize: number } | undefined;
+    if (this.written === 0 && tag.maxChunkPayload !== this.payloadSize) {
+      const total = this.rechunkForCapacity(tag.maxChunkPayload);
+      rechunkedTo = { total, payloadSize: tag.maxChunkPayload };
+    }
+    if (!confirmOverwrite && (await this.transport.peekIsNfar())) {
+      throw new OverwriteRequiredError('This card already holds NFAR data; confirm to overwrite');
+    }
+    await this.transport.writeChunk(encodeChunk(this.chunks[this.written]!));
+    this.writtenUids.add(key);
+    this.written += 1;
+    const done = this.written >= this.chunks.length;
+    return { done, progress: this.progress(done ? null : this.written), ...(rechunkedTo ? { rechunkedTo } : {}) };
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd webapp && rm -rf dist && npx tsc && node --test dist/test/controller.test.js
+```
+Expected: PASS — the two new tests plus all pre-existing controller tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add webapp/app/controller.ts webapp/test/controller.test.ts
+git commit -m "feat(webapp): ArchiveController auto-rechunks to the tapped card's capacity"
+```
+
+---
+
+## Task 3: UI (Auto-detect dropdown, estimate note, re-chunk status) + corrected error
+
+**Files:**
+- Modify: `webapp/app/index.html`, `webapp/app/ui/archive-panel.ts`, `webapp/app/ui/errors.ts`
+- Test: `webapp/test/errors.test.ts` (update the CardCapacityError assertion)
+
+**Interfaces:**
+- Consumes: `writeNextCard`'s `rechunkedTo` (Task 2); `CARD_PAYLOAD_SIZE` (`src/mifare/card-layout.ts`).
+- Produces: no new exported interface.
+
+- [ ] **Step 1: Update the error-message test (failing)**
+
+`webapp/test/errors.test.ts` currently asserts the message with a regex: `assert.match(humanError(new CardCapacityError('x')), /too large/i);`. Change that regex to match the corrected message:
+```ts
+  assert.match(humanError(new CardCapacityError('x')), /smaller than the ones already written/i);
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd webapp && rm -rf dist && npx tsc && node --test dist/test/errors.test.js
+```
+Expected: FAIL — the corrected regex does not match the old "too large" message yet.
+
+- [ ] **Step 3: Correct the message**
+
+In `webapp/app/ui/errors.ts`, change the `CardCapacityError` branch:
+```ts
+  if (e instanceof CardCapacityError) return 'This card is smaller than the ones already written — use cards of the same type, or restart the archive.';
+```
+
+- [ ] **Step 4: Add the Auto-detect dropdown option**
+
+In `webapp/app/index.html`, in the `<select id="target-tag">`, add a new first option and remove any `selected` on the others (there is none today; `auto` becomes the default by being first + `selected`):
+```html
+            <select id="target-tag">
+              <option value="auto" selected>Auto-detect (adapts to the card)</option>
+              <option value="720">Mifare Classic 1K — 752 B</option>
+              <option value="NTAG213">NTAG213 — 144 B</option>
+              <option value="NTAG215">NTAG215 — 504 B</option>
+              <option value="NTAG216">NTAG216 — 888 B</option>
+            </select>
+```
+
+- [ ] **Step 5: Wire Auto-detect + estimate note + re-chunk status in archive-panel**
+
+In `webapp/app/ui/archive-panel.ts`:
+
+1. Add the `CARD_PAYLOAD_SIZE` import (near the other `../../src/...` imports):
+```ts
+import { CARD_PAYLOAD_SIZE } from '../../src/mifare/card-layout.js';
+```
+
+2. In `selectedPayloadSize()`, handle `'auto'` (add as the first check):
+```ts
+function selectedPayloadSize(): number {
+  const v = ($('target-tag') as HTMLSelectElement).value;
+  if (v === 'auto') return CARD_PAYLOAD_SIZE; // nominal preview size; the real card decides on tap
+  if (v === 'NTAG213') return ntagChunkPayloadSize(NtagType.NTAG213);
+  if (v === 'NTAG215') return ntagChunkPayloadSize(NtagType.NTAG215);
+  if (v === 'NTAG216') return ntagChunkPayloadSize(NtagType.NTAG216);
+  return Number(v); // "720" for Mifare Classic 1K
+}
+```
+
+3. In `updateCounter`, append the estimate note under Auto-detect. Replace the counter-text line:
+```ts
+    const count = await estimateCardCount(src.data, src.fileName, { compress, encrypted, payloadSize: selectedPayloadSize() });
+    const isAuto = ($('target-tag') as HTMLSelectElement).value === 'auto';
+    el.textContent = `≈ ${count} card(s)${isAuto ? ' (est.) — adapts to the tapped card' : ''}`;
+```
+
+4. In the `$('archive').click` handler, make `total` reassignable and show the re-chunk note. Change `const total = await ctrl.prepare(...)` to `let total = await ctrl.prepare(...)`, and inside the `while (!done)` loop, right after `const res = await ctrl.writeNextCard();`, add:
+```ts
+          if (res.rechunkedTo) {
+            const orig = total;
+            total = res.rechunkedTo.total;
+            setStatus(`Card holds ${res.rechunkedTo.payloadSize} B/chunk — writing ${total} card(s) instead of ${orig}.`);
+          }
+```
+(Leave the existing `done = res.done; render(res.progress.written, total, done);` lines after it — `render` now uses the updated `total`. The overwrite-confirm branch's `ctrl.writeNextCard(undefined, true)` needs no change: any re-chunk already happened on the first, throwing call.)
+
+- [ ] **Step 6: Type-check, run the full suite, build the bundle**
+
+```bash
+cd webapp && rm -rf dist && npx tsc && node --test 'dist/test/**/*.test.js'
+npx esbuild app/main.ts --bundle --format=esm --outfile=/tmp/capacity-bundle-check.js
+```
+Expected: `tsc` clean; all tests pass (the updated errors test + everything else); esbuild prints a size with no errors. (The archive-panel wiring is UI glue; its logic — `rechunkForCapacity`/`writeNextCard` — is covered by Task 2, and the corrected message by the errors test.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add webapp/app/index.html webapp/app/ui/archive-panel.ts webapp/app/ui/errors.ts webapp/test/errors.test.ts
+git commit -m "feat(webapp): Auto-detect target tag, re-chunk status note, corrected capacity error"
+```
+
+---
+
+## Final verification (after all tasks)
+
+```bash
+cd webapp && rm -rf dist && npx tsc && node --test 'dist/test/**/*.test.js'   # all pass
+npx esbuild app/main.ts --bundle --format=esm --outfile=/tmp/capacity-bundle-check.js  # builds
+node -e "console.log(Object.keys(require('./package.json').dependencies))"        # ['chameleon-ultra.js']
+grep -rn "log/logger" app/ui/archive-panel.ts app/controller.ts src/transport || echo "no logger dependency (independent of PR #38)"
+```
+
+**Manual browser smoke (Windows-host Chromium + Chameleon):** on the Archive tab with **Auto-detect** selected, choose a file that needs several cards; tap a card smaller than the estimate assumed → confirm the status shows "writing N cards instead of M" and the write proceeds and verifies; restore the pile and confirm the file is byte-identical. Also try selecting a concrete large type (NTAG216) then tapping a smaller card → same adaptive behavior.
+
+Then use **superpowers:finishing-a-development-branch** to open the PR (base `master`).

--- a/docs/superpowers/specs/2026-07-29-webapp-dynamic-capacity-design.md
+++ b/docs/superpowers/specs/2026-07-29-webapp-dynamic-capacity-design.md
@@ -1,0 +1,130 @@
+# Web App Dynamic Chip-Capacity Re-chunking — Design
+
+**Status:** approved (brainstorm) — 2026-07-29
+
+**Goal:** Make archiving adapt to the **actual** memory of the tapped NFC chip instead of trusting the target-tag dropdown, so a card smaller than the selected type no longer fails with `CardCapacityError`. On the first tap the archive auto-re-chunks to fit the real card; the dropdown becomes an estimate hint with an Auto-detect default.
+
+## Motivation
+
+`ArchiveController.prepare()` chunks the data once, up front, using the `payloadSize` derived from the **target-tag dropdown**. `writeNextCard()` then writes those pre-sized chunks and never inspects the tapped card's real capacity — even though the transport already provides it. So selecting NTAG216 (812 B/chunk) and tapping a smaller NTAG213/215 makes `writeChunk` reject the oversized chunk with `CardCapacityError`, surfaced as the misleading *"This is too large for the selected tag — pick a larger tag type."* (`app/ui/errors.ts:11`).
+
+The Flutter app already solves this with `ArchiveNotifier.rechunkForDetectedCapacity()` → `ArchiveRepository.rechunkForCapacity()`, which re-splits the already-processed payload to the detected capacity, **only before any chunk is written** (re-chunking after cards exist would invalidate their `totalChunks`/index headers). This design ports that behavior to the web app.
+
+## Decisions (locked during brainstorming)
+
+1. **Auto-rechunk + status note.** On the first tap, silently re-chunk to fit the real card and show a status line; no dialog. Safe because re-chunk only happens before any write.
+2. **Dropdown = estimate hint, with an Auto-detect default.** The dropdown only sizes the `≈ N cards` preview; the real chunking is decided by the tapped card.
+3. **Independent of PR #38 (Log tab).** This iteration branches off `master` and does **not** depend on the logger from `feat/webapp-log-tab`. The re-chunk is surfaced via the archive status line only. (A `log.info('archive','Re-chunked',…)` can be added as a one-line follow-up once PR #38 merges.)
+
+## Core invariant
+
+Each NFAR chunk header carries `totalChunks` and the chunk's index. Re-chunking changes both, so it is only valid **before the first card is written**. The first tapped card therefore *commits* the layout; subsequent cards must fit it. Re-chunking re-splits `assembleChunks(this.chunks)` (the already compressed+encrypted payload) — it never re-runs `archive()`, so the ciphertext and `archiveId` are unchanged; only the number/size of chunks differs.
+
+## Architecture
+
+### 1. Transport exposes the real per-card chunk-payload capacity (`src/transport/transport.ts` + implementations)
+
+`PresentedTag` gains one field:
+
+```ts
+export interface PresentedTag {
+  uid: Uint8Array;
+  capacityBytes: number;    // raw user memory (unchanged; informational)
+  maxChunkPayload: number;  // NEW: max NFAR chunk-payload this card holds
+}
+```
+
+`maxChunkPayload` is what the chunker needs (the value the dropdown's `payloadSize` represents), which each transport already computes internally:
+
+- `ChameleonBleTransport.awaitTag` → `maxChunkPayload: CARD_PAYLOAD_SIZE` (720) (`src/mifare/card-layout.ts`).
+- `NtagTransport.awaitTag` → `maxChunkPayload: ntagChunkPayloadSize(detectedType)` (73/428/812) (`src/nfc/type2.ts`). The type is already detected there via `GET_VERSION`.
+- `AutoTransport.awaitTag` returns the chosen delegate's `PresentedTag` unchanged, so the field passes through.
+- `MockTransport` gains a settable `maxChunkPayload` (constructor option or setter; default `CARD_PAYLOAD_SIZE` = 720) so tests can simulate a small card.
+
+`capacityBytes` is retained (informational, no current consumer depends on it as a payload size).
+
+### 2. Auto-rechunk in `ArchiveController` (`app/controller.ts`)
+
+- `prepare()` stores the payload size it chunked with: add a private `private payloadSize = 0;` set to `req.payloadSize` in `prepare`.
+- New method:
+
+```ts
+/** Re-split the already-processed payload to a new per-card size, preserving the
+ *  archiveId (no re-encrypt). Only valid before any card is written. Returns the
+ *  new chunk count. Throws if a card has already been written. */
+rechunkForCapacity(newPayloadSize: number): number {
+  if (this.written > 0) throw new RechunkTooLateError('Cannot re-chunk after writing has started');
+  const payload = assembleChunks(this.chunks);
+  const { flags, archiveId } = this.chunks[0]!;
+  this.chunks = createChunks(payload, newPayloadSize, flags, archiveId);
+  this.payloadSize = newPayloadSize;
+  return this.chunks.length;
+}
+```
+
+- `writeNextCard()` — after `awaitTag`, before the overwrite check / `writeChunk`, auto-rechunk on the first fitting tap:
+
+```ts
+const tag = await this.transport.awaitTag({ signal });
+const key = uidHex(tag.uid);
+if (this.writtenUids.has(key)) return { done: false, progress: this.progress(this.written) };
+
+let rechunkedTo: { total: number; payloadSize: number } | undefined;
+if (this.written === 0 && tag.maxChunkPayload !== this.payloadSize) {
+  const total = this.rechunkForCapacity(tag.maxChunkPayload);
+  rechunkedTo = { total, payloadSize: tag.maxChunkPayload };
+}
+// … existing overwrite check + writeChunk(this.chunks[this.written]) …
+return { done, progress: this.progress(...), ...(rechunkedTo ? { rechunkedTo } : {}) };
+```
+
+The return type gains an optional `rechunkedTo?: { total: number; payloadSize: number }`. `createChunks` throws `RangeError` if the data would exceed `MAX_CHUNKS` for a tiny card — that propagates as a normal archive error (the panel surfaces "file too large even for this card").
+
+New error type `RechunkTooLateError` (in `app/controller.ts`, alongside `OverwriteRequiredError`) for the guard.
+
+### 3. UI (`app/ui/archive-panel.ts` + `app/index.html`)
+
+- **Dropdown** (`#target-tag`): add a default first option `<option value="auto" selected>Auto-detect (adapts to the card)</option>`; keep the concrete type options for a preview. `selectedPayloadSize()` returns a nominal default for `auto` (use `CARD_PAYLOAD_SIZE` = 720 as the representative preview size) and the mapped size for concrete types.
+- **Estimate counter**: under `auto`, append " (est.) — adapts to the tapped card" to the `≈ N card(s)` text; concrete types read as today.
+- **Write flow**: when `writeNextCard` returns `rechunkedTo`, set a status like `Card holds ${payloadSize} B/chunk — writing ${total} card(s) instead of ${originalTotal}.` (`originalTotal` = the count returned by `prepare`). The existing progress `render()` continues from the new total.
+
+### 4. Corrected error message (`app/ui/errors.ts`)
+
+Auto-rechunk removes the common cause; the remaining `CardCapacityError` is a **mid-write** smaller card (card 1 written to an NTAG216, then an NTAG213 tapped). Change the mapping to a true statement:
+
+```
+This card is smaller than the ones already written — use cards of the same type, or restart the archive.
+```
+
+## Data flow
+
+Archive tab: pick file/text, dropdown (default Auto-detect) sizes the estimate → `prepare(payloadSize=nominal)` → tap first card → `writeNextCard` reads `tag.maxChunkPayload`, re-chunks to it (status note), writes → subsequent cards write against the committed layout. Restore is unchanged (chunks are self-describing).
+
+## Error handling
+
+- Re-chunk only before the first write (`RechunkTooLateError` guards misuse; the flow never calls it after `written>0`).
+- A card too small for even one chunk → `createChunks` `RangeError` → panel status "file too large for this card type".
+- Mid-write smaller card → `CardCapacityError` with the corrected message; the user can tap a matching card or restart.
+- `writeNextCard`'s existing `TagTimeoutError`/`UnsupportedTagError`/`OverwriteRequiredError` handling is unchanged.
+
+## Testing
+
+- **`ArchiveController.rechunkForCapacity`** (`test/controller.test.ts`): prepare at 812, `rechunkForCapacity(73)` → chunk count grows; `assembleChunks(newChunks)` byte-equals `assembleChunks` of the pre-rechunk chunks (payload preserved); `chunks[0].archiveId` unchanged; calling it after a simulated write throws `RechunkTooLateError`.
+- **`writeNextCard` auto-rechunk** (`test/controller.test.ts`): `MockTransport` with `maxChunkPayload = 73`; `prepare(payloadSize=812)`; first `writeNextCard` returns `rechunkedTo.total > originalTotal` and writes without throwing; a full archive→small-cards→`RestoreController` restore round-trips byte-identical.
+- **Transport `maxChunkPayload`**: `ChameleonBleTransport` reports 720 and `NtagTransport` reports `ntagChunkPayloadSize(type)` — asserted against `FakeChameleon` for one NTAG type (extend the existing `e2e-ntag`/transport tests). `MockTransport` default is 720 and the setter/option works.
+- **`estimate`/dropdown**: `selectedPayloadSize()` returns 720 for `auto` and the mapped size for concrete types (small DOM-free assertion if `selectedPayloadSize` is extractable; otherwise covered by the estimate test).
+
+## Out of scope (YAGNI)
+
+- Re-chunking to *fewer* cards purely for optimization when a larger card is tapped is handled for free (first tap always re-chunks to the tapped card's size), but no separate "optimize" UI.
+- A confirm dialog before re-chunking (decision: auto + status note).
+- Per-card heterogeneous capacities within one archive (the first card commits the layout; mixed-type piles are not supported — matches Flutter).
+- Logger integration (deferred until PR #38 merges).
+
+## Global constraints
+
+- Core (`src/`) stays dependency-free, web-platform globals only; no new runtime deps (`dependencies` stays `['chameleon-ultra.js']`).
+- ESM NodeNext: intra-project imports use `.js` paths.
+- On-tag NFAR byte format is unchanged; re-chunking uses the existing `createChunks`/`assembleChunks` and preserves `archiveId`, flags, and the processed payload bytes exactly.
+- Independent of `feat/webapp-log-tab` (PR #38): no import of `src/log/logger.ts`.
+- Node ≥ 22 for tests/build; `rm -rf dist` before `npm test`.

--- a/webapp/app/controller.ts
+++ b/webapp/app/controller.ts
@@ -7,7 +7,7 @@
 import { archive, restore } from '../src/pipeline.js';
 import { decodeChunk, encodeChunk, FLAG_COMPRESSED, FLAG_ENCRYPTED, type Chunk } from '../src/chunk.js';
 import { NfarFormatError } from '../src/chunk.js';
-import { assembleChunks } from '../src/chunker.js';
+import { assembleChunks, createChunks } from '../src/chunker.js';
 import { NdefFormatError } from '../src/nfc/ndef.js';
 import { wrapWithFilename, unwrapFilename } from '../src/filename.js';
 import { formatArchiveId } from '../src/archive-id.js';
@@ -51,6 +51,13 @@ export class PasswordRequiredError extends Error {
   }
 }
 
+export class RechunkTooLateError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RechunkTooLateError';
+  }
+}
+
 function uidHex(uid: Uint8Array): string {
   return Array.from(uid, (b) => b.toString(16).padStart(2, '0')).join('');
 }
@@ -58,6 +65,7 @@ function uidHex(uid: Uint8Array): string {
 export class ArchiveController {
   private chunks: Chunk[] = [];
   private written = 0;
+  private payloadSize = 0;
   private readonly writtenUids = new Set<string>();
 
   constructor(private readonly transport: Transport) {}
@@ -69,8 +77,20 @@ export class ArchiveController {
       compress: req.compress,
       password: req.password,
     });
+    this.payloadSize = req.payloadSize;
     this.written = 0;
     this.writtenUids.clear();
+    return this.chunks.length;
+  }
+
+  /** Re-split the already-processed payload to a new per-card size, preserving the
+   *  archiveId (no re-encrypt). Only valid before any card is written. */
+  rechunkForCapacity(newPayloadSize: number): number {
+    if (this.written > 0) throw new RechunkTooLateError('Cannot re-chunk after writing has started');
+    const payload = assembleChunks(this.chunks);
+    const { flags, archiveId } = this.chunks[0]!;
+    this.chunks = createChunks(payload, newPayloadSize, flags, archiveId);
+    this.payloadSize = newPayloadSize;
     return this.chunks.length;
   }
 
@@ -78,12 +98,17 @@ export class ArchiveController {
     return { total: this.chunks.length, written: this.written, awaiting };
   }
 
-  async writeNextCard(signal?: AbortSignal, confirmOverwrite = false): Promise<{ done: boolean; progress: ArchiveProgress }> {
+  async writeNextCard(signal?: AbortSignal, confirmOverwrite = false): Promise<{ done: boolean; progress: ArchiveProgress; rechunkedTo?: { total: number; payloadSize: number } }> {
     if (this.written >= this.chunks.length) return { done: true, progress: this.progress(null) };
     const tag = await this.transport.awaitTag({ signal });
     const key = uidHex(tag.uid);
     if (this.writtenUids.has(key)) {
       return { done: false, progress: this.progress(this.written) };
+    }
+    let rechunkedTo: { total: number; payloadSize: number } | undefined;
+    if (this.written === 0 && tag.maxChunkPayload !== this.payloadSize) {
+      const total = this.rechunkForCapacity(tag.maxChunkPayload);
+      rechunkedTo = { total, payloadSize: tag.maxChunkPayload };
     }
     if (!confirmOverwrite && (await this.transport.peekIsNfar())) {
       throw new OverwriteRequiredError('This card already holds NFAR data; confirm to overwrite');
@@ -92,7 +117,7 @@ export class ArchiveController {
     this.writtenUids.add(key);
     this.written += 1;
     const done = this.written >= this.chunks.length;
-    return { done, progress: this.progress(done ? null : this.written) };
+    return { done, progress: this.progress(done ? null : this.written), ...(rechunkedTo ? { rechunkedTo } : {}) };
   }
 }
 

--- a/webapp/app/index.html
+++ b/webapp/app/index.html
@@ -87,6 +87,7 @@
           <div style="margin-top:0.6rem"><label>or text:</label><br /><textarea id="text" rows="3" placeholder="Type text to archive as text_note.txt"></textarea></div>
           <div style="margin-top:0.6rem"><label>target tag
             <select id="target-tag">
+              <option value="auto" selected>Auto-detect (adapts to the card)</option>
               <option value="720">Mifare Classic 1K — 752 B</option>
               <option value="NTAG213">NTAG213 — 144 B</option>
               <option value="NTAG215">NTAG215 — 504 B</option>

--- a/webapp/app/ui/archive-panel.ts
+++ b/webapp/app/ui/archive-panel.ts
@@ -3,6 +3,7 @@ import { ArchiveController, OverwriteRequiredError } from '../controller.js';
 import { TagTimeoutError, UnsupportedTagError } from '../../src/transport/transport.js';
 import { estimateCardCount } from '../estimate.js';
 import { NtagType, ntagChunkPayloadSize } from '../../src/nfc/type2.js';
+import { CARD_PAYLOAD_SIZE } from '../../src/mifare/card-layout.js';
 import { currentTransport, onConnectionChange } from './device.js';
 import { humanError } from './errors.js';
 
@@ -10,6 +11,7 @@ const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as 
 
 function selectedPayloadSize(): number {
   const v = ($('target-tag') as HTMLSelectElement).value;
+  if (v === 'auto') return CARD_PAYLOAD_SIZE; // nominal preview size; the real card decides on tap
   if (v === 'NTAG213') return ntagChunkPayloadSize(NtagType.NTAG213);
   if (v === 'NTAG215') return ntagChunkPayloadSize(NtagType.NTAG215);
   if (v === 'NTAG216') return ntagChunkPayloadSize(NtagType.NTAG216);
@@ -43,7 +45,9 @@ export function initArchivePanel(): void {
     if (!src) { el.textContent = ''; return; }
     const compress = ($('compress') as HTMLInputElement).checked;
     const encrypted = ($('apass') as HTMLInputElement).value.length > 0;
-    el.textContent = `≈ ${await estimateCardCount(src.data, src.fileName, { compress, encrypted, payloadSize: selectedPayloadSize() })} card(s)`;
+    const count = await estimateCardCount(src.data, src.fileName, { compress, encrypted, payloadSize: selectedPayloadSize() });
+    const isAuto = ($('target-tag') as HTMLSelectElement).value === 'auto';
+    el.textContent = `≈ ${count} card(s)${isAuto ? ' (est.) — adapts to the tapped card' : ''}`;
   };
   const scheduleCounter = () => { clearTimeout(counterTimer); counterTimer = setTimeout(updateCounter, 200); };
 
@@ -77,12 +81,17 @@ export function initArchivePanel(): void {
       setStatus(done ? `Done — wrote and verified ${written} card(s).` : `Tap card ${written + 1} of ${total} on the reader…`);
     };
     try {
-      const total = await ctrl.prepare({ data: src.data, fileName: src.fileName, compress, password: pass || undefined, payloadSize: selectedPayloadSize() });
+      let total = await ctrl.prepare({ data: src.data, fileName: src.fileName, compress, password: pass || undefined, payloadSize: selectedPayloadSize() });
       render(0, total, false);
       let done = false;
       while (!done) {
         try {
           const res = await ctrl.writeNextCard();
+          if (res.rechunkedTo) {
+            const orig = total;
+            total = res.rechunkedTo.total;
+            setStatus(`Card holds ${res.rechunkedTo.payloadSize} B/chunk — writing ${total} card(s) instead of ${orig}.`);
+          }
           done = res.done;
           render(res.progress.written, total, done);
         } catch (e) {

--- a/webapp/app/ui/archive-panel.ts
+++ b/webapp/app/ui/archive-panel.ts
@@ -87,13 +87,14 @@ export function initArchivePanel(): void {
       while (!done) {
         try {
           const res = await ctrl.writeNextCard();
+          let rechunkNote: string | undefined;
           if (res.rechunkedTo) {
-            const orig = total;
+            rechunkNote = `Card holds ${res.rechunkedTo.payloadSize} B/chunk — writing ${res.rechunkedTo.total} card(s) instead of ${total}.`;
             total = res.rechunkedTo.total;
-            setStatus(`Card holds ${res.rechunkedTo.payloadSize} B/chunk — writing ${total} card(s) instead of ${orig}.`);
           }
           done = res.done;
           render(res.progress.written, total, done);
+          if (rechunkNote) setStatus(rechunkNote);
         } catch (e) {
           if (e instanceof TagTimeoutError) { setStatus('No card detected — tap a card (hold it a few mm off)…'); continue; }
           if (e instanceof UnsupportedTagError) { setStatus('Unsupported tag — tap a Mifare Classic 1K or NTAG.'); continue; }

--- a/webapp/app/ui/archive-panel.ts
+++ b/webapp/app/ui/archive-panel.ts
@@ -90,8 +90,8 @@ export function initArchivePanel(): void {
           let rechunkNote: string | undefined;
           if (res.rechunkedTo) {
             rechunkNote = `Card holds ${res.rechunkedTo.payloadSize} B/chunk — writing ${res.rechunkedTo.total} card(s) instead of ${total}.`;
-            total = res.rechunkedTo.total;
           }
+          total = res.progress.total;
           done = res.done;
           render(res.progress.written, total, done);
           if (rechunkNote) setStatus(rechunkNote);
@@ -101,6 +101,7 @@ export function initArchivePanel(): void {
           if (e instanceof OverwriteRequiredError) {
             if (confirm('This card already holds data. Overwrite it?')) {
               const res = await ctrl.writeNextCard(undefined, true);
+              total = res.progress.total;
               done = res.done;
               render(res.progress.written, total, done);
             } else { setStatus('Skipped. Tap a different card…'); }

--- a/webapp/app/ui/errors.ts
+++ b/webapp/app/ui/errors.ts
@@ -8,7 +8,7 @@ import { NdefFormatError } from '../../src/nfc/ndef.js';
 export function humanError(e: unknown): string {
   if (e instanceof CardAuthError) return 'Card keys are not factory defaults — this card cannot be used.';
   if (e instanceof WriteVerifyError) return 'Write verification failed — move the card closer and retry.';
-  if (e instanceof CardCapacityError) return 'This is too large for the selected tag — pick a larger tag type.';
+  if (e instanceof CardCapacityError) return 'This card is smaller than the ones already written — use cards of the same type, or restart the archive.';
   if (e instanceof TagTimeoutError) return 'No card detected — tap a card on the reader.';
   if (e instanceof NfarFormatError) return 'This card holds no NFAR archive data.';
   if (e instanceof OverwriteRequiredError) return 'This card already holds data.';

--- a/webapp/src/transport/chameleon-ble.ts
+++ b/webapp/src/transport/chameleon-ble.ts
@@ -6,7 +6,7 @@
 
 import { NfarFormatError } from '../chunk.js';
 import {
-  BLOCK_SIZE, CARD_CAPACITY_BYTES, USABLE_BLOCK_INDEXES,
+  BLOCK_SIZE, CARD_CAPACITY_BYTES, CARD_PAYLOAD_SIZE, USABLE_BLOCK_INDEXES,
   chunkToBlocks, firstBlockIsNfar, nfarTotalLength, assembleChunkFromBlocks,
 } from '../mifare/card-layout.js';
 import { FACTORY_KEY_A, type ChameleonDevice } from './chameleon-device.js';
@@ -44,7 +44,7 @@ export class ChameleonBleTransport implements Transport {
     for (;;) {
       if (opts?.signal?.aborted) throw new DOMException('Aborted', 'AbortError');
       const tag = await this.device.scanTag();
-      if (tag !== null) return { uid: tag.uid, capacityBytes: CARD_CAPACITY_BYTES };
+      if (tag !== null) return { uid: tag.uid, capacityBytes: CARD_CAPACITY_BYTES, maxChunkPayload: CARD_PAYLOAD_SIZE };
       if (Date.now() >= deadline) throw new TagTimeoutError(`No tag presented within ${timeoutMs}ms`);
       await delay(this.pollMs);
     }

--- a/webapp/src/transport/mock-transport.ts
+++ b/webapp/src/transport/mock-transport.ts
@@ -1,5 +1,5 @@
 import { NfarFormatError } from '../chunk.js';
-import { CARD_CAPACITY_BYTES, CardCapacityError, firstBlockIsNfar } from '../mifare/card-layout.js';
+import { CARD_CAPACITY_BYTES, CARD_PAYLOAD_SIZE, CardCapacityError, firstBlockIsNfar } from '../mifare/card-layout.js';
 import { TagTimeoutError, type PresentedTag, type Transport } from './transport.js';
 
 function toHexKey(uid: Uint8Array): string {
@@ -16,6 +16,8 @@ export class MockTransport implements Transport {
   private readonly queue: string[] = [];
   private readonly cards = new Map<string, Uint8Array>();
   private active: string | null = null;
+  /** Simulated per-card NFAR chunk-payload capacity; tests set this to model a small chip. */
+  maxChunkPayload = CARD_PAYLOAD_SIZE;
 
   /** Present `uid` on the next awaitTag; optionally pre-load its stored chunk bytes. */
   enqueueTag(uid: Uint8Array, chunkBytes?: Uint8Array): void {
@@ -34,7 +36,7 @@ export class MockTransport implements Transport {
       throw new TagTimeoutError(`No tag presented within ${opts?.timeoutMs ?? 0}ms`);
     }
     this.active = next;
-    return { uid: Uint8Array.from(next.match(/../g)!.map((h) => parseInt(h, 16))), capacityBytes: CARD_CAPACITY_BYTES };
+    return { uid: Uint8Array.from(next.match(/../g)!.map((h) => parseInt(h, 16))), capacityBytes: CARD_CAPACITY_BYTES, maxChunkPayload: this.maxChunkPayload };
   }
 
   private activeBytes(): Uint8Array | undefined {

--- a/webapp/src/transport/ntag-transport.ts
+++ b/webapp/src/transport/ntag-transport.ts
@@ -56,7 +56,7 @@ export class NtagTransport implements Transport {
       const tag = await this.device.scanTag();
       if (tag !== null) {
         const type = await this.detectType();
-        return { uid: tag.uid, capacityBytes: ntagUserBytes(type) };
+        return { uid: tag.uid, capacityBytes: ntagUserBytes(type), maxChunkPayload: ntagChunkPayloadSize(type) };
       }
       if (Date.now() >= deadline) throw new TagTimeoutError(`No tag presented within ${timeoutMs}ms`);
       await delay(this.pollMs);

--- a/webapp/src/transport/transport.ts
+++ b/webapp/src/transport/transport.ts
@@ -6,7 +6,8 @@
 
 export interface PresentedTag {
   uid: Uint8Array;
-  capacityBytes: number;
+  capacityBytes: number;   // raw user memory (informational)
+  maxChunkPayload: number; // max NFAR chunk-payload this card holds
 }
 
 export interface Transport {

--- a/webapp/test/chameleon-ble.test.ts
+++ b/webapp/test/chameleon-ble.test.ts
@@ -8,7 +8,7 @@ import { FakeChameleon } from './fake-chameleon.js';
 import { runTransportContract } from './transport-contract.js';
 import { encodeChunk, type Chunk } from '../src/chunk.js';
 import { crc32 } from '../src/crc32.js';
-import { USABLE_BLOCK_INDEXES } from '../src/mifare/card-layout.js';
+import { USABLE_BLOCK_INDEXES, CARD_PAYLOAD_SIZE } from '../src/mifare/card-layout.js';
 
 function chunkBytes(payloadLen: number): Uint8Array {
   const payload = new Uint8Array(payloadLen).map((_, i) => (i + 5) % 256);
@@ -34,6 +34,7 @@ test('connect delegates to the device; awaitTag polls scanTag', async () => {
   setTimeout(() => device.place(uid), 5); // tag arrives after a couple polls
   const tag = await transport.awaitTag();
   assert.deepEqual(tag.uid, uid);
+  assert.equal(tag.maxChunkPayload, CARD_PAYLOAD_SIZE);
 });
 
 test('awaitTag honors AbortSignal', async () => {

--- a/webapp/test/controller.test.ts
+++ b/webapp/test/controller.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { MockTransport } from '../src/transport/mock-transport.js';
 import { decodeChunk, encodeChunk } from '../src/chunk.js';
 import { crc32 } from '../src/crc32.js';
-import { ArchiveController, RestoreController, PasswordRequiredError, OverwriteRequiredError } from '../app/controller.js';
+import { ArchiveController, RestoreController, PasswordRequiredError, OverwriteRequiredError, RechunkTooLateError } from '../app/controller.js';
 import { DecryptionError } from '../src/crypto.js';
 import { NfarAssemblyError } from '../src/chunker.js';
 
@@ -195,6 +195,54 @@ test('assembledPayload returns the pre-decrypt bytes for a detected group', asyn
 test('assembledPayload throws for an unknown archive id', () => {
   const rctrl = new RestoreController(new MockTransport());
   assert.throws(() => rctrl.assembledPayload('does-not-exist'));
+});
+
+test('rechunkForCapacity grows the chunk count for a smaller card and refuses after a write', async () => {
+  const t = new MockTransport();
+  t.maxChunkPayload = 73; // simulate an NTAG213-sized card so writeNextCard won't re-rechunk
+  const ctrl = new ArchiveController(t);
+  const big = await ctrl.prepare({ data: multiCardData, fileName: 'x.bin', compress: false, payloadSize: 720 });
+  const small = ctrl.rechunkForCapacity(73);
+  assert.ok(small > big, `expected more chunks after shrinking: ${small} > ${big}`);
+  t.enqueueTag(uid(0));
+  await ctrl.writeNextCard(); // 73 === current payloadSize -> no auto-rechunk; writes card 0
+  assert.throws(() => ctrl.rechunkForCapacity(428), RechunkTooLateError);
+});
+
+test('writeNextCard auto-rechunks to the tapped card and still restores byte-identically', async () => {
+  const t = new MockTransport();
+  t.maxChunkPayload = 73; // the tapped card is much smaller than the selected NTAG216
+  const ctrl = new ArchiveController(t);
+  const originalTotal = await ctrl.prepare({ data: multiCardData, fileName: 'x.bin', compress: false, payloadSize: 812 });
+
+  const stored: Uint8Array[] = [];
+  let done = false, i = 0, guard = 0;
+  let firstRechunk: { total: number; payloadSize: number } | undefined;
+  while (!done && guard++ < 1000) {
+    t.enqueueTag(uid(i));
+    const res = await ctrl.writeNextCard();
+    if (res.rechunkedTo && firstRechunk === undefined) firstRechunk = res.rechunkedTo;
+    done = res.done;
+    t.enqueueTag(uid(i)); await t.awaitTag(); stored.push(await t.readChunk()); // read back this card
+    i++;
+  }
+  assert.ok(firstRechunk, 'the first tap reported a re-chunk');
+  assert.equal(firstRechunk!.payloadSize, 73);
+  assert.ok(firstRechunk!.total > originalTotal, `more, smaller cards: ${firstRechunk!.total} > ${originalTotal}`);
+  assert.equal(stored.length, firstRechunk!.total);
+  // all written cards share one archiveId (coherent archive)
+  const ids = new Set(stored.map((b) => decodeChunk(b).archiveId.join(',')));
+  assert.equal(ids.size, 1);
+
+  // restore the small-card pile -> byte-identical to the original data
+  const rt = new MockTransport();
+  const rctrl = new RestoreController(rt);
+  stored.forEach((b, j) => rt.enqueueTag(uid(j), b));
+  let list = await rctrl.scanNextCard();
+  for (let j = 1; j < stored.length; j++) list = await rctrl.scanNextCard();
+  assert.ok(list[0]!.complete);
+  const result = await rctrl.restore(list[0]!.archiveId);
+  assert.deepEqual(result.data, multiCardData);
 });
 
 test('writeNextCard/scanNextCard reject with AbortError when the signal is already aborted', async () => {

--- a/webapp/test/errors.test.ts
+++ b/webapp/test/errors.test.ts
@@ -10,7 +10,7 @@ import { NdefFormatError } from '../src/nfc/ndef.js';
 test('humanError maps each typed error to a plain-language message', () => {
   assert.match(humanError(new CardAuthError('x')), /factory defaults/i);
   assert.match(humanError(new WriteVerifyError('x')), /verification failed/i);
-  assert.match(humanError(new CardCapacityError('x')), /too large/i);
+  assert.match(humanError(new CardCapacityError('x')), /smaller than the ones already written/i);
   assert.match(humanError(new TagTimeoutError('x')), /no card detected/i);
   assert.match(humanError(new NfarFormatError('x')), /no nfar archive/i);
   assert.match(humanError(new OverwriteRequiredError('x')), /already holds data/i);

--- a/webapp/test/ntag-transport.test.ts
+++ b/webapp/test/ntag-transport.test.ts
@@ -49,6 +49,7 @@ test('write then read-back an NDEF-wrapped chunk on a simulated NTAG215', async 
   device.placeNtag(uid, NtagType.NTAG215);
   const tag = await t.awaitTag();
   assert.equal(tag.capacityBytes, 504);
+  assert.equal(tag.maxChunkPayload, ntagChunkPayloadSize(NtagType.NTAG215));
   assert.equal(await t.peekIsNfar(), false);
 
   const bytes = chunkBytes(200);


### PR DESCRIPTION
## Summary

Fixes the archiving failure where a card smaller than the selected tag type dies with *"This is too large for the selected tag — pick a larger tag type."* (`CardCapacityError`). Archiving now **adapts to the tapped chip**: on the first tap it auto-re-chunks to fit the real card. Ports the Flutter app's `rechunkForDetectedCapacity` behavior to the web app.

Built via the brainstorm → spec → plan → subagent-driven loop (3 TDD tasks + final review + two fix waves). Spec: `docs/superpowers/specs/2026-07-29-webapp-dynamic-capacity-design.md`; plan: `docs/superpowers/plans/2026-07-29-webapp-dynamic-capacity.md`.

## What changed

- **`PresentedTag.maxChunkPayload`** — the transport now exposes each card's real per-card NFAR chunk-payload (720 Classic; `ntagChunkPayloadSize` 73/428/812 NTAG), alongside the retained raw `capacityBytes`.
- **`ArchiveController.rechunkForCapacity(newPayloadSize)`** — re-splits the *already-processed* payload (`createChunks(assembleChunks(this.chunks), …, archiveId)`), preserving the `archiveId` with **no re-encrypt**; guarded to before-first-write (`RechunkTooLateError`), since each chunk header carries `totalChunks`+index. `writeNextCard` auto-rechunks on the first tap when the tapped card differs, returning `rechunkedTo`.
- **UI** — the target-tag dropdown gains an **Auto-detect** default (an estimate hint only; the real card decides the split); the write loop shows *"Card holds N B/chunk — writing X cards instead of Y"*; the misleading capacity error is corrected.

## Correctness

- Re-chunk only before the first card is written — the first tapped card commits the layout.
- The e2e test proves it: archive at 812 B/chunk → tap a card reporting 73 B/chunk → first tap re-chunks, all cards share one `archiveId`, and the small-card pile restores **byte-identical** to the original.
- On-tag NFAR byte format unchanged; no new runtime deps; independent of PR #38 (no logger import).

## Two review-caught fixes included

- The re-chunk status note was being clobbered by the progress render in the same tick (invisible) → reordered so it survives.
- The progress `total` went stale in the overwrite-then-rechunk path → now synced to the controller's `progress.total` on every write.

## Testing

- **136/136** tests pass; tsc clean; esbuild bundle builds.
- New: transport `maxChunkPayload` assertions, `rechunkForCapacity` (grows count / refuses after write), and the archive→small-cards→restore round-trip.

## Manual browser smoke (needs a Chameleon over Web Bluetooth — deferred to reviewer)

Archive tab, **Auto-detect**: pick a multi-card file, tap a card smaller than the estimate assumed → confirm the "writing N cards instead of M" note, the write completes and verifies, and the pile restores byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)