### PR TITLE
feat(webapp): resilient archive write — retry bad cards, pause/resume on disconnect

### DIFF
--- a/docs/superpowers/plans/2026-07-29-webapp-resilient-archive-write.md
+++ b/docs/superpowers/plans/2026-07-29-webapp-resilient-archive-write.md
@@ -1,0 +1,656 @@
+# Resilient webapp archive write flow — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the webapp's multi-card archive write survive a bad/misplaced card (retry, never abort) and a reader disconnect (pause, then resume the same session on reconnect).
+
+**Architecture:** Extract the write loop from the `archive-panel.ts` click handler into a DOM-free `ArchiveOrchestrator` behind an injected `ArchiveIO` seam, mirroring the existing `RestoreOrchestrator`. The loop exits only when all chunks are written; every per-card error retries, and a disconnect pauses on `await io.awaitReconnect()` then swaps a fresh transport into the controller via a new `ArchiveController.setTransport()`. `device.ts` gains the missing disconnect sensor.
+
+**Tech Stack:** TypeScript + esbuild, `node --test`, dependency-free core (`chameleon-ultra.js` stays confined to `device.ts` / `sdk-chameleon-device.ts`).
+
+## Global Constraints
+
+- **Node ≥ 22 via nvm.** Before any npm/node command: `source ~/.nvm/nvm.sh && nvm use --lts` (default shell Node is 14).
+- **Run tests with a clean build:** `rm -rf dist && npm test` (the `tsc && node --test` chain does not clean stale compiled tests). Run from `webapp/`.
+- **Dependency fence:** `chameleon-ultra.js` may be imported ONLY in `src/transport/sdk-chameleon-device.ts` and `app/ui/device.ts`. The orchestrator and controller stay SDK-free.
+- **On-tag byte format is unchanged.** No touching chunk/NDEF/filename encoding.
+- **No localization** — webapp has no l10n; user-facing strings are inline English.
+- **Existing `ArchiveController` public surface must not break:** constructor `new ArchiveController(transport)` and `writeNextCard(signal?, confirmOverwrite?)` are used by 7 call-sites in `test/controller.test.ts` and must keep working.
+
+---
+
+### Task 1: `ArchiveController.setTransport()`
+
+Add the ability to swap the transport on a live controller without losing session state. This is what lets a paused write resume on a freshly-built transport after reconnect.
+
+**Files:**
+- Modify: `webapp/app/controller.ts` (class `ArchiveController`, around lines 65-122)
+- Test: `webapp/test/controller.test.ts` (append one test)
+
+**Interfaces:**
+- Consumes: existing `ArchiveController`, `MockTransport`, `Transport`.
+- Produces: `ArchiveController.setTransport(t: Transport): void` — replaces the transport used by subsequent `writeNextCard` calls; leaves `chunks`, `written`, `writtenUids`, `payloadSize` untouched.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `webapp/test/controller.test.ts`:
+
+```ts
+test('setTransport swaps the transport mid-session and preserves written state', async () => {
+  const t1 = new MockTransport();
+  const ctrl = new ArchiveController(t1);
+  const total = await ctrl.prepare({ data: multiCardData, fileName: 'blob.bin', compress: false, payloadSize: 720 });
+  assert.ok(total >= 3, `need >=3 cards, got ${total}`);
+
+  // Write the first two cards on t1.
+  t1.enqueueTag(uid(0)); await ctrl.writeNextCard();
+  t1.enqueueTag(uid(1)); const afterTwo = await ctrl.writeNextCard();
+  assert.equal(afterTwo.progress.written, 2);
+
+  // Swap in a fresh transport; the controller must resume at chunk index 2.
+  const t2 = new MockTransport();
+  ctrl.setTransport(t2);
+  t2.enqueueTag(uid(2));
+  const afterSwap = await ctrl.writeNextCard();
+  assert.equal(afterSwap.progress.written, 3, 'continues counting from the preserved state');
+
+  // The chunk written on t2 is card index 2 (distinct UID, real NFAR bytes).
+  t2.enqueueTag(uid(2)); await t2.awaitTag();
+  const stored = decodeChunk(await t2.readChunk());
+  assert.equal(stored.chunkIndex, 2, 'wrote the correct next chunk after the swap');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+source ~/.nvm/nvm.sh && nvm use --lts && cd webapp && rm -rf dist && npm test 2>&1 | grep -A3 'setTransport swaps'
+```
+Expected: FAIL — `ctrl.setTransport is not a function`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `webapp/app/controller.ts`, change the `transport` from a `readonly` constructor param to a mutable field and add the setter. Replace the constructor line:
+
+```ts
+  constructor(private readonly transport: Transport) {}
+```
+with:
+```ts
+  private transport: Transport;
+  constructor(transport: Transport) { this.transport = transport; }
+
+  /** Swap the transport used by subsequent writeNextCard calls. Session state
+   *  (chunks, written count, written UIDs, payload size) is preserved — used to
+   *  resume a paused write on a freshly-built transport after a reconnect. */
+  setTransport(t: Transport): void { this.transport = t; }
+```
+
+(All existing `this.transport.*` references inside the class are unchanged.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd webapp && rm -rf dist && npm test 2>&1 | tail -20
+```
+Expected: PASS, whole suite green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/mezinster/nfcarchiver && git add webapp/app/controller.ts webapp/test/controller.test.ts && \
+git commit -m "$(cat <<'EOF'
+feat(webapp): ArchiveController.setTransport for reconnect-safe resume
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: `ArchiveOrchestrator` — retry-only per-card resilience
+
+Extract the write loop into a DOM-free orchestrator behind an IO seam. This task delivers the core "a bad card never aborts the session" behavior. Disconnect handling is added in Task 3.
+
+**Files:**
+- Create: `webapp/app/ui/archive-orchestrator.ts`
+- Test: `webapp/test/archive-orchestrator.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `ArchiveController`, `ArchiveRequest`, `OverwriteRequiredError` from `../controller.js`; `TagTimeoutError`, `UnsupportedTagError`, `Transport` from `../../src/transport/transport.js`; `humanError` from `./errors.js`; `Logger` from `../../src/log/logger.js`.
+- Produces:
+  - `interface ArchiveIO { setStatus(msg: string): void; showProgress(label: string, value: number | null, max: number): void; hideProgress(): void; confirmOverwrite(): boolean; isConnected(): boolean; awaitReconnect(): Promise<Transport>; log: Logger; }`
+  - `class ArchiveOrchestrator { constructor(io: ArchiveIO); run(transport: Transport, req: ArchiveRequest): Promise<void>; }`
+  - `run` resolves only when every chunk is written; it never rejects for a per-card failure.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `webapp/test/archive-orchestrator.test.ts`:
+
+```ts
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { MockTransport } from '../src/transport/mock-transport.js';
+import { WriteVerifyError, type PresentedTag, type Transport } from '../src/transport/transport.js';
+import { ArchiveOrchestrator, type ArchiveIO } from '../app/ui/archive-orchestrator.js';
+import { Logger } from '../src/log/logger.js';
+
+const uid = (n: number) => new Uint8Array([0xa0, 0, 0, n]);
+const multiCardData = crypto.getRandomValues(new Uint8Array(2000)); // incompressible -> many cards
+
+/** Wraps a MockTransport and throws WriteVerifyError on the Nth writeChunk (1-based). */
+class FlakyWriteTransport implements Transport {
+  readonly name = 'flaky';
+  private writes = 0;
+  constructor(private readonly inner: MockTransport, private readonly failOnWrite: number) {}
+  connect() { return this.inner.connect(); }
+  disconnect() { return this.inner.disconnect(); }
+  awaitTag(opts?: { timeoutMs?: number; signal?: AbortSignal }): Promise<PresentedTag> { return this.inner.awaitTag(opts); }
+  peekIsNfar() { return this.inner.peekIsNfar(); }
+  readChunk() { return this.inner.readChunk(); }
+  async writeChunk(bytes: Uint8Array): Promise<void> {
+    this.writes += 1;
+    if (this.writes === this.failOnWrite) throw new WriteVerifyError('simulated verify failure');
+    return this.inner.writeChunk(bytes);
+  }
+}
+
+function makeIO(over?: Partial<ArchiveIO>) {
+  const statuses: string[] = [];
+  let hidden = false;
+  const io: ArchiveIO = {
+    setStatus: (m) => statuses.push(m),
+    showProgress: () => {},
+    hideProgress: () => { hidden = true; },
+    confirmOverwrite: () => true,
+    isConnected: () => true,
+    awaitReconnect: async () => { throw new Error('awaitReconnect should not be called in this test'); },
+    log: new Logger(),
+    ...over,
+  };
+  return { io, statuses, wasHidden: () => hidden };
+}
+
+test('a bad card retries instead of aborting the whole session', async () => {
+  const inner = new MockTransport();
+  const { io, wasHidden } = makeIO();
+  const orch = new ArchiveOrchestrator(io);
+
+  // The 2nd write fails (card yanked / verify mismatch), then the same card is re-tapped.
+  const t = new FlakyWriteTransport(inner, 2);
+  const req = { data: multiCardData, fileName: 'blob.bin', compress: false, payloadSize: 720 };
+
+  // Pre-tap enough cards: one extra tap of card index 1 covers the retry.
+  const total = 3; // multiCardData at 720 B/chunk => 3 cards
+  inner.enqueueTag(uid(0));
+  inner.enqueueTag(uid(1)); // this write fails
+  inner.enqueueTag(uid(1)); // re-tap same card -> retry succeeds
+  inner.enqueueTag(uid(2));
+
+  await orch.run(t, req);
+
+  assert.equal(wasHidden(), false, 'progress is never hidden — the session did not abort');
+  // All three distinct cards hold real NFAR chunks now.
+  for (let i = 0; i < total; i++) {
+    inner.enqueueTag(uid(i)); await inner.awaitTag();
+    assert.ok((await inner.readChunk()).length > 0, `card ${i} written`);
+  }
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd webapp && rm -rf dist && npm test 2>&1 | grep -iE 'archive-orchestrator|Cannot find'
+```
+Expected: FAIL — module `../app/ui/archive-orchestrator.js` not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `webapp/app/ui/archive-orchestrator.ts`:
+
+```ts
+/**
+ * DOM-free archive write loop behind an injected IO seam, mirroring
+ * RestoreOrchestrator. The loop NEVER aborts on a per-card failure: any error
+ * from writing one card leaves the session state intact and prompts a re-tap.
+ * A reader disconnect pauses on awaitReconnect() and resumes the same session
+ * on a fresh transport (see setTransport on the controller). The panel supplies
+ * real DOM/browser IO; tests supply a stub IO + MockTransport.
+ */
+import { ArchiveController, OverwriteRequiredError, type ArchiveRequest } from '../controller.js';
+import { TagTimeoutError, UnsupportedTagError, type Transport } from '../../src/transport/transport.js';
+import { humanError } from './errors.js';
+import type { Logger } from '../../src/log/logger.js';
+
+export interface ArchiveIO {
+  setStatus(msg: string): void;
+  showProgress(label: string, value: number | null, max: number): void;
+  hideProgress(): void;
+  confirmOverwrite(): boolean;
+  isConnected(): boolean;
+  awaitReconnect(): Promise<Transport>;
+  log: Logger;
+}
+
+export class ArchiveOrchestrator {
+  constructor(private readonly io: ArchiveIO) {}
+
+  private render(written: number, total: number, done: boolean): void {
+    this.io.showProgress(
+      done ? `✓ ${written} of ${total} cards written & verified`
+           : `✓ ${written} of ${total} written & verified — tap the next card`,
+      written, total,
+    );
+    this.io.setStatus(done
+      ? `Done — wrote and verified ${written} card(s).`
+      : `Tap card ${written + 1} of ${total} on the reader…`);
+  }
+
+  async run(transport: Transport, req: ArchiveRequest): Promise<void> {
+    const ctrl = new ArchiveController(transport);
+    let total = await ctrl.prepare(req);
+    this.render(0, total, false);
+    this.io.log.info('archive', 'Prepared', { cards: total });
+
+    let done = false;
+    while (!done) {
+      if (!this.io.isConnected()) {
+        this.io.setStatus('Reader disconnected — reconnect to resume.');
+        this.io.log.warn('archive', 'Reader disconnected — awaiting reconnect');
+        ctrl.setTransport(await this.io.awaitReconnect());
+        this.io.log.info('archive', 'Reconnected — resuming');
+        continue;
+      }
+      try {
+        const res = await ctrl.writeNextCard();
+        total = res.progress.total;
+        done = res.done;
+        this.render(res.progress.written, total, done);
+        if (res.rechunkedTo) {
+          this.io.setStatus(`Card holds ${res.rechunkedTo.payloadSize} B/chunk — writing ${res.rechunkedTo.total} card(s) instead.`);
+        }
+      } catch (e) {
+        if (!this.io.isConnected()) continue; // disconnect — handled at the loop top
+        if (e instanceof TagTimeoutError) { this.io.setStatus('No card detected — tap a card (hold it a few mm off)…'); continue; }
+        if (e instanceof UnsupportedTagError) { this.io.setStatus('Unsupported tag — tap a Mifare Classic 1K or NTAG.'); continue; }
+        if (e instanceof OverwriteRequiredError) {
+          if (this.io.confirmOverwrite()) {
+            try {
+              const res = await ctrl.writeNextCard(undefined, true);
+              total = res.progress.total;
+              done = res.done;
+              this.render(res.progress.written, total, done);
+            } catch (e2) {
+              if (!this.io.isConnected()) continue;
+              this.io.setStatus(`${humanError(e2)} — re-tap to retry.`);
+              this.io.log.warn('archive', 'Overwrite write failed — will retry', { error: String(e2) });
+            }
+          } else {
+            this.io.setStatus('Skipped. Tap a different card…');
+          }
+          continue;
+        }
+        // Any other per-card failure (verify/auth/capacity/mid-write I-O): retry, never abort.
+        this.io.setStatus(`${humanError(e)} — re-tap to retry.`);
+        this.io.log.warn('archive', 'Card write failed — will retry', { error: String(e) });
+        continue;
+      }
+    }
+    this.io.log.info('archive', 'Write complete', { cards: total });
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd webapp && rm -rf dist && npm test 2>&1 | grep -A2 'bad card retries'
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/mezinster/nfcarchiver && git add webapp/app/ui/archive-orchestrator.ts webapp/test/archive-orchestrator.test.ts && \
+git commit -m "$(cat <<'EOF'
+feat(webapp): ArchiveOrchestrator with retry-only per-card resilience
+
+A bad or misplaced card no longer aborts the multi-card write; the loop
+retries the same chunk on the next tap and only exits when all cards are
+written.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Pause & resume on reader disconnect
+
+Prove and lock in the disconnect path: when the injected IO reports a disconnect, the loop pauses on `awaitReconnect()`, swaps the fresh transport into the controller, and resumes at the correct chunk — with a byte-identical restore of the finished set.
+
+**Files:**
+- Modify: `webapp/test/archive-orchestrator.test.ts` (append one test; the disconnect logic already exists in the orchestrator from Task 2)
+
+**Interfaces:**
+- Consumes: `ArchiveOrchestrator`, `ArchiveIO`, `MockTransport`, `RestoreController` from `../app/controller.js`, `decodeChunk` unnecessary (RestoreController reads cards).
+
+- [ ] **Step 1: Write the failing test**
+
+First confirm the resume path is exercised. Append to `webapp/test/archive-orchestrator.test.ts`:
+
+```ts
+import { RestoreController } from '../app/controller.js';
+
+test('a disconnect pauses and resumes the same session on a fresh transport', async () => {
+  const original = crypto.getRandomValues(new Uint8Array(2000)); // 3 cards at 720 B
+  const tA = new MockTransport();
+  const tB = new MockTransport();
+
+  let connected = true;
+  let reconnects = 0;
+  const io: ArchiveIO = {
+    setStatus: () => {},
+    // Drop the connection right after the 2nd card is verified.
+    showProgress: (_label, value) => { if (value === 2 && connected) connected = false; },
+    hideProgress: () => { throw new Error('must not hide progress — session must not abort'); },
+    confirmOverwrite: () => true,
+    isConnected: () => connected,
+    awaitReconnect: async () => { connected = true; reconnects += 1; return tB; },
+    log: new Logger(),
+  };
+
+  // tA presents cards 0 and 1; tB presents the remaining cards after reconnect.
+  tA.enqueueTag(uid(0));
+  tA.enqueueTag(uid(1));
+  for (let i = 2; i < 8; i++) tB.enqueueTag(uid(i)); // plenty for the remainder
+
+  const orch = new ArchiveOrchestrator(io);
+  await orch.run(tA, { data: original, fileName: 'blob.bin', compress: false, payloadSize: 720 });
+
+  assert.equal(reconnects, 1, 'resumed exactly once');
+
+  // Reassemble from the cards actually written across BOTH transports.
+  const restoreT = new MockTransport();
+  const readBack = async (t: MockTransport, n: number) => {
+    t.enqueueTag(uid(n)); await t.awaitTag(); return t.readChunk();
+  };
+  restoreT.enqueueTag(uid(0), await readBack(tA, 0));
+  restoreT.enqueueTag(uid(1), await readBack(tA, 1));
+  restoreT.enqueueTag(uid(2), await readBack(tB, 2));
+
+  const rctrl = new RestoreController(restoreT);
+  let detected = await rctrl.scanNextCard(new AbortController().signal);
+  detected = await rctrl.scanNextCard(new AbortController().signal);
+  detected = await rctrl.scanNextCard(new AbortController().signal);
+  assert.equal(detected.length, 1);
+  assert.equal(detected[0]!.complete, true, 'all 3 chunks present across the two transports');
+
+  const { data } = await rctrl.restore(detected[0]!.archiveId, undefined);
+  assert.deepEqual(data, original, 'resumed session restores byte-identically');
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes (logic already present)**
+
+```bash
+cd webapp && rm -rf dist && npm test 2>&1 | grep -A2 'disconnect pauses and resumes'
+```
+Expected: PASS (the orchestrator's disconnect branch from Task 2 handles it). If it FAILS, fix the orchestrator's loop-top `isConnected()` / `awaitReconnect()` / `setTransport()` sequence until green — this test is the specification for that path.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/mezinster/nfcarchiver && git add webapp/test/archive-orchestrator.test.ts && \
+git commit -m "$(cat <<'EOF'
+test(webapp): disconnect pauses and resumes archive write byte-identically
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Disconnect sensor in `device.ts`
+
+Wire the real disconnect signal so the panel's `awaitReconnect` can ever resolve and buttons reflect the true connection state. `device.ts` imports the SDK and is not unit-tested; verification is type-check + code review + (if hardware available) a manual smoke test.
+
+**Files:**
+- Modify: `webapp/app/ui/device.ts`
+
+**Interfaces:**
+- Consumes: `ChameleonUltra` (`.emitter.on('disconnected', …)`, per the SDK dts: "`disconnected`: Emitted when device is disconnected").
+- Produces: `isConnected(): boolean` export; `onConnectionChange` listeners now also receive `false` on disconnect; `currentTransport()` returns `null` while disconnected.
+
+- [ ] **Step 1: Add the connection flag and export**
+
+In `webapp/app/ui/device.ts`, add a module-level flag next to the existing `let transport` (line ~20):
+
+```ts
+let connected = false;
+```
+
+Add an exported accessor next to `currentTransport` (line ~23):
+
+```ts
+export function isConnected(): boolean {
+  return connected;
+}
+```
+
+- [ ] **Step 2: Set the flag on connect and wire the disconnect event**
+
+In the `$('connect')` click handler, immediately after `ultra = new ChameleonUltra();`, attach the disconnect listener:
+
+```ts
+      ultra = new ChameleonUltra();
+      // Fires when the BLE link drops (device powered off, out of range, GATT
+      // lost). Flip connection state, drop the dead transport, and notify
+      // listeners so the archive loop can pause and later resume.
+      ultra.emitter.on('disconnected', () => {
+        connected = false;
+        transport = null;
+        ($('diagnose') as HTMLButtonElement).disabled = true;
+        $('conn').textContent = 'disconnected';
+        deviceStatus.textContent = 'Reader disconnected — click Connect to resume.';
+        log.warn('device', 'Disconnected');
+        for (const cb of listeners) cb(false);
+      });
+```
+
+Then in the same handler, after the existing successful-connect lines (`$('conn').textContent = 'connected';` … `for (const cb of listeners) cb(true);`), set the flag. Add immediately before `for (const cb of listeners) cb(true);`:
+
+```ts
+      connected = true;
+```
+
+(If `ultra.emitter.on(...)` produces a TypeScript error about the event name or listener type, cast the event arg: `ultra.emitter.on('disconnected' as never, () => { … })`. Do not change any SDK types.)
+
+- [ ] **Step 3: Type-check / build**
+
+```bash
+cd webapp && rm -rf dist && npm test 2>&1 | tail -15
+```
+Expected: `tsc` compiles with no errors and the full suite stays green (this change adds no new tests but must not break compilation).
+
+- [ ] **Step 4: Code-review checklist (manual, no automated test — device.ts imports the SDK)**
+
+Confirm by reading the diff:
+- `connected` is set `true` only on a fully successful connect, and `false` in the `disconnected` handler.
+- `transport` is nulled in the `disconnected` handler (so `currentTransport()` returns `null` while down).
+- Listeners receive `cb(false)` on disconnect and `cb(true)` on (re)connect.
+- The dependency fence holds: the only new SDK usage is `ultra.emitter.on` inside `device.ts`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/mezinster/nfcarchiver && git add webapp/app/ui/device.ts && \
+git commit -m "$(cat <<'EOF'
+feat(webapp): detect Chameleon BLE disconnect and expose isConnected
+
+Wires ultra.emitter 'disconnected' to flip connection state, drop the dead
+transport, and notify onConnectionChange listeners — the sensor the archive
+pause/resume loop needs.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Wire `archive-panel.ts` to the orchestrator
+
+Replace the inline `while (!done)` loop with the orchestrator, supplying real DOM/browser IO — including `awaitReconnect` built on `onConnectionChange` and `confirmOverwrite` via `window.confirm`. This is the integration task; after it, the feature works end-to-end in the browser.
+
+**Files:**
+- Modify: `webapp/app/ui/archive-panel.ts` (replace the `$('archive').addEventListener('click', …)` body, lines ~69-118; keep the source/counter/`selectedPayloadSize` code above it)
+
+**Interfaces:**
+- Consumes: `ArchiveOrchestrator`, `ArchiveIO` from `./archive-orchestrator.js`; `isConnected`, `currentTransport`, `onConnectionChange` from `./device.js`; `log` from `../../src/log/logger.js`.
+- Produces: no exports change (`initArchivePanel` stays the entry point).
+
+- [ ] **Step 1: Update imports**
+
+At the top of `webapp/app/ui/archive-panel.ts`, replace:
+
+```ts
+import { ArchiveController, OverwriteRequiredError } from '../controller.js';
+import { TagTimeoutError, UnsupportedTagError } from '../../src/transport/transport.js';
+```
+with:
+```ts
+import { ArchiveOrchestrator, type ArchiveIO } from './archive-orchestrator.js';
+import type { Transport } from '../../src/transport/transport.js';
+```
+
+And update the device import to include `isConnected`:
+
+```ts
+import { currentTransport, isConnected, onConnectionChange } from './device.js';
+```
+
+- [ ] **Step 2: Replace the click handler body**
+
+Replace the entire `$('archive').addEventListener('click', async () => { … });` block (the `try { … prepare … while(!done) … } catch { hideProgress(); setStatus(humanError(e)); }`) with:
+
+```ts
+  $('archive').addEventListener('click', async () => {
+    const transport = currentTransport();
+    if (!transport) return;
+    const src = currentSource();
+    if (!src) { setStatus('Pick a file or type some text first.'); return; }
+    const compress = ($('compress') as HTMLInputElement).checked;
+    const pass = ($('apass') as HTMLInputElement).value;
+
+    const io: ArchiveIO = {
+      setStatus,
+      showProgress,
+      hideProgress,
+      confirmOverwrite: () => window.confirm('This card already holds data. Overwrite it?'),
+      isConnected,
+      // Resolve with the freshly-built transport the next time we connect.
+      awaitReconnect: () => new Promise<Transport>((resolve) => {
+        const off = onConnectionChange((connected) => {
+          const t = currentTransport();
+          if (connected && t) { off(); resolve(t); }
+        });
+      }),
+      log,
+    };
+
+    ($('archive') as HTMLButtonElement).disabled = true;
+    try {
+      await new ArchiveOrchestrator(io).run(transport, {
+        data: src.data, fileName: src.fileName, compress,
+        password: pass || undefined, payloadSize: selectedPayloadSize(),
+      });
+    } finally {
+      ($('archive') as HTMLButtonElement).disabled = !isConnected();
+    }
+  });
+```
+
+- [ ] **Step 3: Make `onConnectionChange` return an unsubscribe function**
+
+`awaitReconnect` above calls `off()` to detach its one-shot listener. Update `onConnectionChange` in `webapp/app/ui/device.ts`. Replace:
+
+```ts
+export function onConnectionChange(cb: (connected: boolean) => void): void {
+  listeners.push(cb);
+}
+```
+with:
+```ts
+export function onConnectionChange(cb: (connected: boolean) => void): () => void {
+  listeners.push(cb);
+  return () => {
+    const i = listeners.indexOf(cb);
+    if (i >= 0) listeners.splice(i, 1);
+  };
+}
+```
+
+(Existing callers in `restore-panel.ts` and `archive-panel.ts`'s own `onConnectionChange((connected) => …)` at line ~64 ignore the return value — still valid.)
+
+- [ ] **Step 4: Verify the existing panel-level connection listener still compiles**
+
+The pre-existing `onConnectionChange((connected) => { ($('archive') …).disabled = !connected; … })` near line 64 is unchanged and now also fires on disconnect (disabling the button) — desired. Leave it as is.
+
+- [ ] **Step 5: Build, type-check, full test suite**
+
+```bash
+cd webapp && rm -rf dist && npm test 2>&1 | tail -20
+```
+Expected: `tsc` clean, ALL tests pass (controller + archive-orchestrator + restore-orchestrator + the rest).
+
+- [ ] **Step 6: Manual smoke (if a Chameleon + browser on the Windows host is available)**
+
+```bash
+cd webapp && source ~/.nvm/nvm.sh && nvm use --lts && npm run app
+```
+In Chromium on the Windows host, open `localhost:8000`:
+1. Connect the Chameleon, pick a small file that spans ≥3 cards.
+2. Mid-write, pull a card away early → status shows "…re-tap to retry", progress is NOT lost; re-tap completes that card.
+3. Present a wrong-format card → "Unsupported tag…", loop continues.
+4. Power off the Chameleon mid-write → "Reader disconnected — reconnect to resume"; power on + Connect → writing resumes from the next card. Finishes to "Done".
+
+(Skip if no hardware; the automated tests cover the logic. Note in the PR that the manual smoke was or wasn't run.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/mezinster/nfcarchiver && git add webapp/app/ui/archive-panel.ts webapp/app/ui/device.ts && \
+git commit -m "$(cat <<'EOF'
+feat(webapp): drive archive write via ArchiveOrchestrator (retry + resume)
+
+The archive panel is now a thin adapter: a bad/misplaced card retries and a
+reader disconnect pauses then resumes on reconnect, instead of aborting the
+whole multi-card session. onConnectionChange returns an unsubscribe fn for the
+one-shot reconnect wait.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Retry-only per-card failure → Task 2 (orchestrator generic-error branch) + test; wrong-format already handled and preserved (`UnsupportedTagError` branch). ✓
+- Pause & resume on disconnect → Task 1 (`setTransport`) + Task 2 (loop-top pause branch) + Task 3 (resume test) + Task 4 (disconnect sensor) + Task 5 (`awaitReconnect` wiring). ✓
+- "Loop exits only on done" → orchestrator has no path that rethrows out of the loop; only `done` ends it. ✓
+- Disconnect detection was missing → Task 4. ✓
+- Byte format unchanged → no chunk/NDEF/filename edits anywhere. ✓
+- Controller public surface preserved → Task 1 keeps constructor + `writeNextCard` signature; only adds `setTransport`. ✓
+- Edge cases (partial-write overwrite prompt, `CardAuthError` retry, idempotent first-card rechunk) → all fall through the generic retry branch or the existing overwrite/unsupported branches; no special code needed, consistent with spec's "acceptable" notes. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code; every command has expected output. ✓
+
+**Type consistency:** `ArchiveIO` shape identical in Task 2 definition, Task 3 test, and Task 5 wiring (`setStatus`, `showProgress(label,value,max)`, `hideProgress`, `confirmOverwrite(): boolean`, `isConnected(): boolean`, `awaitReconnect(): Promise<Transport>`, `log`). `ArchiveOrchestrator.run(transport, req)` used identically in tests and panel. `setTransport(t)` defined in Task 1, called in Task 2 orchestrator. `onConnectionChange` return type changed in Task 5 Step 3 and only its new return value is consumed (by `awaitReconnect`); existing callers ignore it. ✓

--- a/docs/superpowers/plans/2026-07-29-webapp-resilient-archive-write.md
+++ b/docs/superpowers/plans/2026-07-29-webapp-resilient-archive-write.md
@@ -363,10 +363,14 @@ test('a disconnect pauses and resumes the same session on a fresh transport', as
     log: new Logger(),
   };
 
-  // tA presents cards 0 and 1; tB presents the remaining cards after reconnect.
+  // total === 3 for 2000 incompressible bytes at 720 B/chunk (deterministic).
+  // tA presents cards 0 and 1 (written before the drop); tB presents the one
+  // remaining card after reconnect. Enqueue EXACTLY the remainder on tB — any
+  // extra leftover tags would shift the post-run readback (awaitTag drains the
+  // queue FIFO, so a pushed-behind uid(2) would return a leftover instead).
   tA.enqueueTag(uid(0));
   tA.enqueueTag(uid(1));
-  for (let i = 2; i < 8; i++) tB.enqueueTag(uid(i)); // plenty for the remainder
+  tB.enqueueTag(uid(2));
 
   const orch = new ArchiveOrchestrator(io);
   await orch.run(tA, { data: original, fileName: 'blob.bin', compress: false, payloadSize: 720 });

--- a/docs/superpowers/specs/2026-07-29-webapp-resilient-archive-write-design.md
+++ b/docs/superpowers/specs/2026-07-29-webapp-resilient-archive-write-design.md
@@ -1,0 +1,189 @@
+# Resilient webapp archive write flow
+
+**Date:** 2026-07-29
+**Scope:** `webapp/` (Chameleon Ultra browser app) only. The Flutter app is out of scope.
+
+## Problem
+
+When writing an archive across many cards (e.g. 12 NTAG chips), a single bad
+event aborts the entire session and discards all progress — the user must
+re-prepare and re-tap from card 1. The two triggers reported:
+
+- **Wrong-format / unusable card** presented mid-session.
+- **Misplaced card** — pulled off the reader before the write-and-verify
+  completes.
+
+### Root cause
+
+`webapp/app/ui/archive-panel.ts` runs a `while (!done)` loop. It already
+survives three cases by looping back to "tap the next card":
+
+- `TagTimeoutError` (no card detected) → `continue`
+- `UnsupportedTagError` (wrong tag type) → `continue`
+- `OverwriteRequiredError` (card already holds NFAR data) → confirm → overwrite/skip
+
+But **any other thrown error** — `WriteVerifyError`, `CardAuthError`, a card
+yanked mid-write (I/O failure), a decode glitch, or a Bluetooth disconnect —
+falls through to the outer `catch`, which calls `hideProgress()` and ends the
+session. All previously written cards' progress is lost.
+
+Separately, **BLE disconnects are never detected**: `onConnectionChange`
+listeners only ever receive `true` (on connect). Nothing fires `false`, even
+though the SDK's `ChameleonUltra.emitter` emits a `'disconnected'` event and
+`isConnected()` is available.
+
+## Requirements (confirmed with user)
+
+1. **Target:** webapp only.
+2. **On a per-card failure:** retry only. Stay on the same chunk, prompt a
+   re-tap. The session must never abort from an error; the only way the loop
+   ends is all chunks written. (No "skip" and no error-triggered "stop".)
+3. **On reader disconnect mid-session:** pause and resume. Reconnecting
+   continues the *same* session from the next unwritten card — nothing
+   re-prepared, nothing re-tapped.
+
+## Approach
+
+**Extract an `ArchiveOrchestrator`** (approach A, chosen). Move the write loop
+out of the `archive-panel.ts` click handler into a DOM-free class behind an
+injected IO seam, mirroring the existing `RestoreOrchestrator` /
+`restore-orchestrator.test.ts` pattern. This is the only approach that makes
+the new retry/pause logic unit-testable, and it matches the pattern the
+codebase adopted in the Log-tab iteration.
+
+Rejected:
+- **B — patch the loop inline in `archive-panel.ts`:** smaller diff, but the
+  resilience logic (most likely to regress) stays untestable inside a click
+  handler — exactly what the restore refactor existed to avoid.
+- **C — push resilience into `ArchiveController`:** wrong layer. The controller
+  is the transactional "write one card" unit; retry/pause/reconnect is a
+  loop-and-UI concern.
+
+## Design
+
+### Component 1 — Connection truth + disconnect signal (`device.ts`)
+
+- Track internal `connected: boolean`.
+- On successful connect: `connected = true`, fire `cb(true)` (unchanged).
+- Wire `ultra.emitter.on('disconnected', …)`: set `connected = false`, null the
+  shared `transport`, update the device bar text, and notify listeners
+  `cb(false)`.
+- Export `isConnected(): boolean`.
+
+This is the missing sensor for pause/resume, and correct behavior on its own.
+
+**Dependency fence:** all `chameleon-ultra.js` / `emitter` access stays inside
+`device.ts` (already one of the two files allowed to import the SDK). The
+orchestrator never touches the SDK.
+
+### Component 2 — Reconnect-friendly controller (`controller.ts`)
+
+Add one method to `ArchiveController`:
+
+```ts
+setTransport(t: Transport): void
+```
+
+The controller retains all session state (`chunks`, `written`, `writtenUids`,
+`payloadSize`); only the transport reference is swapped in on reconnect. The
+constructor and `writeNextCard(signal?, confirmOverwrite?)` signature are
+unchanged, so all 7 existing `controller.test.ts` call-sites keep compiling.
+
+### Component 3 — `ArchiveOrchestrator` (new `app/ui/archive-orchestrator.ts`)
+
+Owns the loop behind an `ArchiveIO` seam:
+
+```ts
+export interface ArchiveIO {
+  setStatus(msg: string): void;
+  showProgress(label: string, value: number | null, max: number): void;
+  hideProgress(): void;
+  confirmOverwrite(): boolean;      // wraps window.confirm in the panel
+  isConnected(): boolean;
+  awaitReconnect(): Promise<Transport>; // resolves with the fresh transport
+  log: Logger;
+}
+```
+
+Loop contract: **the loop exits only on `done` (all chunks written) — never on
+an error.**
+
+At the top of each iteration and after any throw, check `io.isConnected()`:
+
+- **Disconnected** → `setStatus("Reader disconnected — reconnect to resume")`,
+  `const t = await io.awaitReconnect()`, `ctrl.setTransport(t)`, `continue`
+  from the same chunk.
+
+Otherwise dispatch on the error from `writeNextCard`:
+
+- `TagTimeoutError` → status hint ("tap a card…"), `continue`.
+- `UnsupportedTagError` → status hint ("unsupported tag…"), `continue`.
+- `OverwriteRequiredError` → `io.confirmOverwrite()`: if yes, retry with
+  `confirmOverwrite = true`; if no, status "Skipped. Tap a different card…",
+  `continue`.
+- **Any other error** (`WriteVerifyError`, `CardAuthError`, mid-write I/O,
+  decode) → `log.warn(...)`, `setStatus("Card N didn't take — <reason>. Re-tap
+  to retry.")`, `continue`. **This replaces the removed outer `catch` that
+  aborted the session.**
+
+On success: update progress via `io.showProgress` / `io.setStatus`, surface any
+`rechunkedTo` note (unchanged from current behavior), set `done`.
+
+### Component 4 — `archive-panel.ts` (thin)
+
+Gather source + options, `prepare`, construct an `ArchiveOrchestrator` with real
+IO, run it. `awaitReconnect` is implemented via `onConnectionChange`: register a
+one-shot listener that resolves with `currentTransport()` on the next `true`.
+`confirmOverwrite` wraps `window.confirm`. The `showProgress` / `hideProgress` /
+`setStatus` DOM helpers move into the IO implementation.
+
+## Data flow
+
+**Happy path:** prepare → loop { awaitTag → (first card: maybe rechunk) →
+peekIsNfar guard → writeChunk (write+verify) → mark written → render } → done.
+
+**Bad card:** writeNextCard throws (verify/auth/I-O) → still connected → log +
+status "re-tap to retry" → `written` unchanged, card not in `writtenUids` →
+next tap retries the same chunk index (overwriting a partial write).
+
+**Disconnect at card k:** writeNextCard throws or loop-top check sees
+`!isConnected()` → status "reconnect to resume" → `await awaitReconnect()` →
+user clicks Connect → new AutoTransport built in `device.ts` → listener resolves
+→ `ctrl.setTransport(newTransport)` → loop continues at card k. Prepared chunks
+and `written`/`writtenUids` are intact; no re-prepare, no re-tap of done cards.
+
+## Edge cases
+
+- **Partial-write then verify-fail:** re-tapping the same card may trip
+  `OverwriteRequiredError` (partial NFAR now present) → user confirms overwrite
+  → completes. Acceptable.
+- **`CardAuthError` on a non-factory Classic card:** that specific card can
+  never succeed; retry-only naturally covers it — the user taps a different
+  card (same UX as `UnsupportedTagError`).
+- **First-card auto-rechunk on repeated retries:** `rechunkForCapacity` is
+  idempotent for a given payload size (assemble → re-split), so re-tapping a
+  failing first card re-runs it harmlessly.
+
+## Testing (`test/archive-orchestrator.test.ts`)
+
+Mirror `restore-orchestrator.test.ts` — DOM/IO stub + `MockTransport`:
+
+1. **Bad card doesn't abort:** a `MockTransport` that throws
+   `WriteVerifyError` once mid-session, then succeeds on re-tap → the loop
+   completes all chunks; progress is never hidden.
+2. **Disconnect pauses and resumes:** IO reports `isConnected() === false`
+   after card k and `awaitReconnect()` resolves with a fresh `MockTransport`
+   pre-loaded to continue → the loop resumes at card k and finishes; the
+   assembled cards restore byte-identically.
+3. **Controller `setTransport`:** swapping the transport mid-session on the
+   controller preserves `written` / `writtenUids` and writes the correct next
+   chunk.
+
+Full suite (`rm -rf dist && npm test`, Node ≥ 22 via `nvm use --lts`) stays
+green.
+
+## Out of scope
+
+- Any change to the Flutter app.
+- "Skip this card" and error-triggered "stop" (explicitly declined).
+- Localization of the new strings (webapp has no l10n yet).

--- a/webapp/app/controller.ts
+++ b/webapp/app/controller.ts
@@ -67,8 +67,14 @@ export class ArchiveController {
   private written = 0;
   private payloadSize = 0;
   private readonly writtenUids = new Set<string>();
+  private transport: Transport;
 
-  constructor(private readonly transport: Transport) {}
+  constructor(transport: Transport) { this.transport = transport; }
+
+  /** Swap the transport used by subsequent writeNextCard calls. Session state
+   *  (chunks, written count, written UIDs, payload size) is preserved — used to
+   *  resume a paused write on a freshly-built transport after a reconnect. */
+  setTransport(t: Transport): void { this.transport = t; }
 
   async prepare(req: ArchiveRequest): Promise<number> {
     const wrapped = wrapWithFilename(req.data, req.fileName);

--- a/webapp/app/index.html
+++ b/webapp/app/index.html
@@ -57,6 +57,12 @@
       #about-content h3 { margin: 1rem 0 0.3rem; }
       .muted { color: var(--outline); }
       label { display: inline-flex; align-items: center; gap: 0.35rem; }
+      dialog { border: 1px solid var(--outline); border-radius: 16px; background: var(--surface); color: var(--on-surface); padding: 1.2rem; max-width: 22rem; width: calc(100% - 2rem); }
+      dialog::backdrop { background: rgba(0, 0, 0, 0.45); }
+      dialog p { margin: 0; }
+      .dialog-actions { display: flex; flex-direction: column; gap: 0.5rem; margin-top: 1rem; }
+      .dialog-actions button { border-radius: 12px; padding: 0.7rem 1rem; width: 100%; cursor: pointer; }
+      #overwrite-skip { background: var(--surface); color: var(--on-surface); border: 1px solid var(--outline); }
     </style>
   </head>
   <body>
@@ -148,6 +154,16 @@
         <div id="about-content"></div>
       </section>
     </main>
+
+    <dialog id="overwrite-dialog">
+      <p id="overwrite-message">This card already holds data.</p>
+      <form method="dialog" class="dialog-actions">
+        <button value="once" class="filled">Overwrite</button>
+        <button value="all" class="filled">Overwrite all remaining</button>
+        <button id="overwrite-skip" value="skip">Skip</button>
+      </form>
+    </dialog>
+
     <script type="module" src="./dist/main.js"></script>
   </body>
 </html>

--- a/webapp/app/ui/archive-orchestrator.ts
+++ b/webapp/app/ui/archive-orchestrator.ts
@@ -12,11 +12,16 @@ import { TagTimeoutError, UnsupportedTagError, type Transport } from '../../src/
 import { humanError } from './errors.js';
 import type { Logger } from '../../src/log/logger.js';
 
+/** The user's answer when a tapped card already holds NFAR data:
+ *  'once' = overwrite just this card, 'all' = overwrite this and every
+ *  remaining card without asking again, 'skip' = leave it and tap another. */
+export type OverwriteChoice = 'once' | 'all' | 'skip';
+
 export interface ArchiveIO {
   setStatus(msg: string): void;
   showProgress(label: string, value: number | null, max: number): void;
   hideProgress(): void;
-  confirmOverwrite(): boolean;
+  confirmOverwrite(): Promise<OverwriteChoice>;
   isConnected(): boolean;
   awaitReconnect(): Promise<Transport>;
   log: Logger;
@@ -51,6 +56,10 @@ export class ArchiveOrchestrator {
     this.io.log.info('archive', 'Prepared', { cards: total });
 
     let done = false;
+    // Once the user picks "overwrite all remaining", every subsequent already-
+    // NFAR card is overwritten without prompting (passed straight into
+    // writeNextCard so it never even throws OverwriteRequiredError).
+    let overwriteAll = false;
     while (!done) {
       if (!this.io.isConnected()) {
         this.io.setStatus('Reader disconnected — reconnect to resume.');
@@ -60,7 +69,7 @@ export class ArchiveOrchestrator {
         continue;
       }
       try {
-        const res = await ctrl.writeNextCard();
+        const res = await ctrl.writeNextCard(undefined, overwriteAll);
         total = res.progress.total;
         done = res.done;
         this.render(res.progress.written, total, done);
@@ -72,19 +81,18 @@ export class ArchiveOrchestrator {
         if (e instanceof TagTimeoutError) { this.io.setStatus('No card detected — tap a card (hold it a few mm off)…'); continue; }
         if (e instanceof UnsupportedTagError) { this.io.setStatus('Unsupported tag — tap a Mifare Classic 1K or NTAG.'); continue; }
         if (e instanceof OverwriteRequiredError) {
-          if (this.io.confirmOverwrite()) {
-            try {
-              const res = await ctrl.writeNextCard(undefined, true);
-              total = res.progress.total;
-              done = res.done;
-              this.render(res.progress.written, total, done);
-            } catch (e2) {
-              if (!this.io.isConnected()) continue;
-              this.io.setStatus(`${humanError(e2)} — re-tap to retry.`);
-              this.io.log.warn('archive', 'Overwrite write failed — will retry', { error: String(e2) });
-            }
-          } else {
-            this.io.setStatus('Skipped. Tap a different card…');
+          const choice = await this.io.confirmOverwrite();
+          if (choice === 'skip') { this.io.setStatus('Skipped. Tap a different card…'); continue; }
+          if (choice === 'all') { overwriteAll = true; this.io.log.info('archive', 'Overwrite all remaining'); }
+          try {
+            const res = await ctrl.writeNextCard(undefined, true);
+            total = res.progress.total;
+            done = res.done;
+            this.render(res.progress.written, total, done);
+          } catch (e2) {
+            if (!this.io.isConnected()) continue;
+            this.io.setStatus(`${humanError(e2)} — re-tap to retry.`);
+            this.io.log.warn('archive', 'Overwrite write failed — will retry', { error: String(e2) });
           }
           continue;
         }

--- a/webapp/app/ui/archive-orchestrator.ts
+++ b/webapp/app/ui/archive-orchestrator.ts
@@ -37,7 +37,15 @@ export class ArchiveOrchestrator {
 
   async run(transport: Transport, req: ArchiveRequest): Promise<void> {
     const ctrl = new ArchiveController(transport);
-    let total = await ctrl.prepare(req);
+    let total: number;
+    try {
+      total = await ctrl.prepare(req);
+    } catch (e) {
+      this.io.hideProgress();
+      this.io.setStatus(humanError(e));
+      this.io.log.error('archive', 'Prepare failed', { error: String(e) });
+      return;
+    }
     this.render(0, total, false);
     this.io.log.info('archive', 'Prepared', { cards: total });
 

--- a/webapp/app/ui/archive-orchestrator.ts
+++ b/webapp/app/ui/archive-orchestrator.ts
@@ -1,0 +1,90 @@
+/**
+ * DOM-free archive write loop behind an injected IO seam, mirroring
+ * RestoreOrchestrator. The loop NEVER aborts on a per-card failure: any error
+ * from writing one card leaves the session state intact and prompts a re-tap.
+ * A reader disconnect pauses on awaitReconnect() and resumes the same session
+ * on a fresh transport (see setTransport on the controller). The panel supplies
+ * real DOM/browser IO; tests supply a stub IO + MockTransport.
+ */
+import { ArchiveController, OverwriteRequiredError, type ArchiveRequest } from '../controller.js';
+import { TagTimeoutError, UnsupportedTagError, type Transport } from '../../src/transport/transport.js';
+import { humanError } from './errors.js';
+import type { Logger } from '../../src/log/logger.js';
+
+export interface ArchiveIO {
+  setStatus(msg: string): void;
+  showProgress(label: string, value: number | null, max: number): void;
+  hideProgress(): void;
+  confirmOverwrite(): boolean;
+  isConnected(): boolean;
+  awaitReconnect(): Promise<Transport>;
+  log: Logger;
+}
+
+export class ArchiveOrchestrator {
+  constructor(private readonly io: ArchiveIO) {}
+
+  private render(written: number, total: number, done: boolean): void {
+    this.io.showProgress(
+      done ? `✓ ${written} of ${total} cards written & verified`
+           : `✓ ${written} of ${total} written & verified — tap the next card`,
+      written, total,
+    );
+    this.io.setStatus(done
+      ? `Done — wrote and verified ${written} card(s).`
+      : `Tap card ${written + 1} of ${total} on the reader…`);
+  }
+
+  async run(transport: Transport, req: ArchiveRequest): Promise<void> {
+    const ctrl = new ArchiveController(transport);
+    let total = await ctrl.prepare(req);
+    this.render(0, total, false);
+    this.io.log.info('archive', 'Prepared', { cards: total });
+
+    let done = false;
+    while (!done) {
+      if (!this.io.isConnected()) {
+        this.io.setStatus('Reader disconnected — reconnect to resume.');
+        this.io.log.warn('archive', 'Reader disconnected — awaiting reconnect');
+        ctrl.setTransport(await this.io.awaitReconnect());
+        this.io.log.info('archive', 'Reconnected — resuming');
+        continue;
+      }
+      try {
+        const res = await ctrl.writeNextCard();
+        total = res.progress.total;
+        done = res.done;
+        this.render(res.progress.written, total, done);
+        if (res.rechunkedTo) {
+          this.io.setStatus(`Card holds ${res.rechunkedTo.payloadSize} B/chunk — writing ${res.rechunkedTo.total} card(s) instead.`);
+        }
+      } catch (e) {
+        if (!this.io.isConnected()) continue; // disconnect — handled at the loop top
+        if (e instanceof TagTimeoutError) { this.io.setStatus('No card detected — tap a card (hold it a few mm off)…'); continue; }
+        if (e instanceof UnsupportedTagError) { this.io.setStatus('Unsupported tag — tap a Mifare Classic 1K or NTAG.'); continue; }
+        if (e instanceof OverwriteRequiredError) {
+          if (this.io.confirmOverwrite()) {
+            try {
+              const res = await ctrl.writeNextCard(undefined, true);
+              total = res.progress.total;
+              done = res.done;
+              this.render(res.progress.written, total, done);
+            } catch (e2) {
+              if (!this.io.isConnected()) continue;
+              this.io.setStatus(`${humanError(e2)} — re-tap to retry.`);
+              this.io.log.warn('archive', 'Overwrite write failed — will retry', { error: String(e2) });
+            }
+          } else {
+            this.io.setStatus('Skipped. Tap a different card…');
+          }
+          continue;
+        }
+        // Any other per-card failure (verify/auth/capacity/mid-write I-O): retry, never abort.
+        this.io.setStatus(`${humanError(e)} — re-tap to retry.`);
+        this.io.log.warn('archive', 'Card write failed — will retry', { error: String(e) });
+        continue;
+      }
+    }
+    this.io.log.info('archive', 'Write complete', { cards: total });
+  }
+}

--- a/webapp/app/ui/archive-orchestrator.ts
+++ b/webapp/app/ui/archive-orchestrator.ts
@@ -1,6 +1,7 @@
 /**
- * DOM-free archive write loop behind an injected IO seam, mirroring
- * RestoreOrchestrator. The loop NEVER aborts on a per-card failure: any error
+ * DOM-free archive write loop behind an injected IO seam, following the same
+ * orchestrator-behind-an-IO-seam pattern as RestoreOrchestrator (with its own
+ * ArchiveIO seam). The loop NEVER aborts on a per-card failure: any error
  * from writing one card leaves the session state intact and prompts a re-tap.
  * A reader disconnect pauses on awaitReconnect() and resumes the same session
  * on a fresh transport (see setTransport on the controller). The panel supplies

--- a/webapp/app/ui/archive-panel.ts
+++ b/webapp/app/ui/archive-panel.ts
@@ -1,10 +1,10 @@
 /** Archive tab: file/text source, live card counter, write-and-verify with progress. */
-import { ArchiveController, OverwriteRequiredError } from '../controller.js';
-import { TagTimeoutError, UnsupportedTagError } from '../../src/transport/transport.js';
+import { ArchiveOrchestrator, type ArchiveIO } from './archive-orchestrator.js';
+import type { Transport } from '../../src/transport/transport.js';
 import { estimateCardCount } from '../estimate.js';
 import { NtagType, ntagChunkPayloadSize } from '../../src/nfc/type2.js';
 import { CARD_PAYLOAD_SIZE } from '../../src/mifare/card-layout.js';
-import { currentTransport, onConnectionChange } from './device.js';
+import { currentTransport, isConnected, onConnectionChange } from './device.js';
 import { humanError } from './errors.js';
 import { log } from '../../src/log/logger.js';
 
@@ -73,47 +73,31 @@ export function initArchivePanel(): void {
     if (!src) { setStatus('Pick a file or type some text first.'); return; }
     const compress = ($('compress') as HTMLInputElement).checked;
     const pass = ($('apass') as HTMLInputElement).value;
-    const ctrl = new ArchiveController(transport);
-    const render = (written: number, total: number, done: boolean) => {
-      showProgress(
-        done ? `✓ ${written} of ${total} cards written & verified` : `✓ ${written} of ${total} written & verified — tap the next card`,
-        written, total,
-      );
-      setStatus(done ? `Done — wrote and verified ${written} card(s).` : `Tap card ${written + 1} of ${total} on the reader…`);
+
+    const io: ArchiveIO = {
+      setStatus,
+      showProgress,
+      hideProgress,
+      confirmOverwrite: () => window.confirm('This card already holds data. Overwrite it?'),
+      isConnected,
+      // Resolve with the freshly-built transport the next time we connect.
+      awaitReconnect: () => new Promise<Transport>((resolve) => {
+        const off = onConnectionChange((connected) => {
+          const t = currentTransport();
+          if (connected && t) { off(); resolve(t); }
+        });
+      }),
+      log,
     };
+
+    ($('archive') as HTMLButtonElement).disabled = true;
     try {
-      let total = await ctrl.prepare({ data: src.data, fileName: src.fileName, compress, password: pass || undefined, payloadSize: selectedPayloadSize() });
-      render(0, total, false);
-      log.info('archive', 'Prepared', { cards: total });
-      let done = false;
-      while (!done) {
-        try {
-          const res = await ctrl.writeNextCard();
-          let rechunkNote: string | undefined;
-          if (res.rechunkedTo) {
-            rechunkNote = `Card holds ${res.rechunkedTo.payloadSize} B/chunk — writing ${res.rechunkedTo.total} card(s) instead of ${total}.`;
-          }
-          total = res.progress.total;
-          done = res.done;
-          render(res.progress.written, total, done);
-          if (rechunkNote) setStatus(rechunkNote);
-        } catch (e) {
-          if (e instanceof TagTimeoutError) { setStatus('No card detected — tap a card (hold it a few mm off)…'); continue; }
-          if (e instanceof UnsupportedTagError) { setStatus('Unsupported tag — tap a Mifare Classic 1K or NTAG.'); continue; }
-          if (e instanceof OverwriteRequiredError) {
-            if (confirm('This card already holds data. Overwrite it?')) {
-              const res = await ctrl.writeNextCard(undefined, true);
-              total = res.progress.total;
-              done = res.done;
-              render(res.progress.written, total, done);
-            } else { setStatus('Skipped. Tap a different card…'); }
-          } else { throw e; }
-        }
-      }
-      log.info('archive', 'Write complete', { cards: total });
-    } catch (e) {
-      hideProgress();
-      setStatus(humanError(e));
+      await new ArchiveOrchestrator(io).run(transport, {
+        data: src.data, fileName: src.fileName, compress,
+        password: pass || undefined, payloadSize: selectedPayloadSize(),
+      });
+    } finally {
+      ($('archive') as HTMLButtonElement).disabled = !isConnected();
     }
   });
 }

--- a/webapp/app/ui/archive-panel.ts
+++ b/webapp/app/ui/archive-panel.ts
@@ -5,7 +5,6 @@ import { estimateCardCount } from '../estimate.js';
 import { NtagType, ntagChunkPayloadSize } from '../../src/nfc/type2.js';
 import { CARD_PAYLOAD_SIZE } from '../../src/mifare/card-layout.js';
 import { currentTransport, isConnected, onConnectionChange } from './device.js';
-import { humanError } from './errors.js';
 import { log } from '../../src/log/logger.js';
 
 const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
@@ -29,6 +28,8 @@ export function initArchivePanel(): void {
     $('archive-progress-label').textContent = label;
   };
   const hideProgress = () => { $('archive-progress-row').hidden = true; };
+
+  let archiving = false;
 
   let fileBytes: Uint8Array | null = null;
   let fileName = '';
@@ -62,11 +63,12 @@ export function initArchivePanel(): void {
   $('target-tag').addEventListener('change', scheduleCounter);
 
   onConnectionChange((connected) => {
-    ($('archive') as HTMLButtonElement).disabled = !connected;
-    if (connected) setStatus('Choose a file or type text, then Archive to cards.');
+    ($('archive') as HTMLButtonElement).disabled = !connected || archiving;
+    if (connected && !archiving) setStatus('Choose a file or type text, then Archive to cards.');
   });
 
   $('archive').addEventListener('click', async () => {
+    if (archiving) return;
     const transport = currentTransport();
     if (!transport) return;
     const src = currentSource();
@@ -90,6 +92,7 @@ export function initArchivePanel(): void {
       log,
     };
 
+    archiving = true;
     ($('archive') as HTMLButtonElement).disabled = true;
     try {
       await new ArchiveOrchestrator(io).run(transport, {
@@ -97,6 +100,7 @@ export function initArchivePanel(): void {
         password: pass || undefined, payloadSize: selectedPayloadSize(),
       });
     } finally {
+      archiving = false;
       ($('archive') as HTMLButtonElement).disabled = !isConnected();
     }
   });

--- a/webapp/app/ui/archive-panel.ts
+++ b/webapp/app/ui/archive-panel.ts
@@ -1,5 +1,5 @@
 /** Archive tab: file/text source, live card counter, write-and-verify with progress. */
-import { ArchiveOrchestrator, type ArchiveIO } from './archive-orchestrator.js';
+import { ArchiveOrchestrator, type ArchiveIO, type OverwriteChoice } from './archive-orchestrator.js';
 import type { Transport } from '../../src/transport/transport.js';
 import { estimateCardCount } from '../estimate.js';
 import { NtagType, ntagChunkPayloadSize } from '../../src/nfc/type2.js';
@@ -29,6 +29,18 @@ export function initArchivePanel(): void {
     $('archive-progress-label').textContent = label;
   };
   const hideProgress = () => { $('archive-progress-row').hidden = true; };
+
+  // Native <dialog> confirm with three choices. Resolves 'once' | 'all' | 'skip'
+  // ('skip' if dismissed via Esc, so an accidental dismiss never overwrites).
+  const overwriteDialog = $('overwrite-dialog') as HTMLDialogElement;
+  const confirmOverwrite = (): Promise<OverwriteChoice> => new Promise((resolve) => {
+    overwriteDialog.returnValue = '';
+    overwriteDialog.addEventListener('close', () => {
+      const v = overwriteDialog.returnValue;
+      resolve(v === 'all' ? 'all' : v === 'once' ? 'once' : 'skip');
+    }, { once: true });
+    overwriteDialog.showModal();
+  });
 
   let archiving = false;
 
@@ -81,7 +93,7 @@ export function initArchivePanel(): void {
       setStatus,
       showProgress,
       hideProgress,
-      confirmOverwrite: () => window.confirm('This card already holds data. Overwrite it?'),
+      confirmOverwrite,
       isConnected,
       // Resolve with the freshly-built transport the next time we connect.
       awaitReconnect: () => new Promise<Transport>((resolve) => {

--- a/webapp/app/ui/archive-panel.ts
+++ b/webapp/app/ui/archive-panel.ts
@@ -5,6 +5,7 @@ import { estimateCardCount } from '../estimate.js';
 import { NtagType, ntagChunkPayloadSize } from '../../src/nfc/type2.js';
 import { CARD_PAYLOAD_SIZE } from '../../src/mifare/card-layout.js';
 import { currentTransport, isConnected, onConnectionChange } from './device.js';
+import { humanError } from './errors.js';
 import { log } from '../../src/log/logger.js';
 
 const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
@@ -99,6 +100,9 @@ export function initArchivePanel(): void {
         data: src.data, fileName: src.fileName, compress,
         password: pass || undefined, payloadSize: selectedPayloadSize(),
       });
+    } catch (e) {
+      hideProgress();
+      setStatus(humanError(e));
     } finally {
       archiving = false;
       ($('archive') as HTMLButtonElement).disabled = !isConnected();

--- a/webapp/app/ui/device.ts
+++ b/webapp/app/ui/device.ts
@@ -18,10 +18,15 @@ const hex = (b: Uint8Array): string =>
 
 let ultra: ChameleonUltra | null = null;
 let transport: AutoTransport | null = null;
+let connected = false;
 const listeners: Array<(connected: boolean) => void> = [];
 
 export function currentTransport(): AutoTransport | null {
   return transport;
+}
+
+export function isConnected(): boolean {
+  return connected;
 }
 
 export function onConnectionChange(cb: (connected: boolean) => void): void {
@@ -35,6 +40,18 @@ export function initDeviceBar(): void {
     log.info('device', 'Connecting');
     try {
       ultra = new ChameleonUltra();
+      // Fires when the BLE link drops (device powered off, out of range, GATT
+      // lost). Flip connection state, drop the dead transport, and notify
+      // listeners so the archive loop can pause and later resume.
+      ultra.emitter.on('disconnected', () => {
+        connected = false;
+        transport = null;
+        ($('diagnose') as HTMLButtonElement).disabled = true;
+        $('conn').textContent = 'disconnected';
+        deviceStatus.textContent = 'Reader disconnected — click Connect to resume.';
+        log.warn('device', 'Disconnected');
+        for (const cb of listeners) cb(false);
+      });
       // use() is async (the adapter's install() runs availability checks etc.);
       // it MUST be awaited before connect(), or this.port is still undefined.
       await ultra.use(new WebbleAdapter());
@@ -42,6 +59,7 @@ export function initDeviceBar(): void {
       await transport.connect();
       $('conn').textContent = 'connected';
       ($('diagnose') as HTMLButtonElement).disabled = false;
+      connected = true;
       for (const cb of listeners) cb(true);
       deviceStatus.textContent = 'Connected.';
       log.info('device', 'Connected');

--- a/webapp/app/ui/device.ts
+++ b/webapp/app/ui/device.ts
@@ -50,6 +50,7 @@ export function initDeviceBar(): void {
       ultra.emitter.on('disconnected', () => {
         connected = false;
         transport = null;
+        ultra = null;
         ($('diagnose') as HTMLButtonElement).disabled = true;
         $('conn').textContent = 'disconnected';
         deviceStatus.textContent = 'Reader disconnected — click Connect to resume.';

--- a/webapp/app/ui/device.ts
+++ b/webapp/app/ui/device.ts
@@ -29,8 +29,12 @@ export function isConnected(): boolean {
   return connected;
 }
 
-export function onConnectionChange(cb: (connected: boolean) => void): void {
+export function onConnectionChange(cb: (connected: boolean) => void): () => void {
   listeners.push(cb);
+  return () => {
+    const i = listeners.indexOf(cb);
+    if (i >= 0) listeners.splice(i, 1);
+  };
 }
 
 export function initDeviceBar(): void {

--- a/webapp/test/archive-orchestrator.test.ts
+++ b/webapp/test/archive-orchestrator.test.ts
@@ -1,0 +1,68 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { MockTransport } from '../src/transport/mock-transport.js';
+import { WriteVerifyError, type PresentedTag, type Transport } from '../src/transport/transport.js';
+import { ArchiveOrchestrator, type ArchiveIO } from '../app/ui/archive-orchestrator.js';
+import { Logger } from '../src/log/logger.js';
+
+const uid = (n: number) => new Uint8Array([0xa0, 0, 0, n]);
+const multiCardData = crypto.getRandomValues(new Uint8Array(2000)); // incompressible -> many cards
+
+/** Wraps a MockTransport and throws WriteVerifyError on the Nth writeChunk (1-based). */
+class FlakyWriteTransport implements Transport {
+  readonly name = 'flaky';
+  private writes = 0;
+  constructor(private readonly inner: MockTransport, private readonly failOnWrite: number) {}
+  connect() { return this.inner.connect(); }
+  disconnect() { return this.inner.disconnect(); }
+  awaitTag(opts?: { timeoutMs?: number; signal?: AbortSignal }): Promise<PresentedTag> { return this.inner.awaitTag(opts); }
+  peekIsNfar() { return this.inner.peekIsNfar(); }
+  readChunk() { return this.inner.readChunk(); }
+  async writeChunk(bytes: Uint8Array): Promise<void> {
+    this.writes += 1;
+    if (this.writes === this.failOnWrite) throw new WriteVerifyError('simulated verify failure');
+    return this.inner.writeChunk(bytes);
+  }
+}
+
+function makeIO(over?: Partial<ArchiveIO>) {
+  const statuses: string[] = [];
+  let hidden = false;
+  const io: ArchiveIO = {
+    setStatus: (m) => statuses.push(m),
+    showProgress: () => {},
+    hideProgress: () => { hidden = true; },
+    confirmOverwrite: () => true,
+    isConnected: () => true,
+    awaitReconnect: async () => { throw new Error('awaitReconnect should not be called in this test'); },
+    log: new Logger(),
+    ...over,
+  };
+  return { io, statuses, wasHidden: () => hidden };
+}
+
+test('a bad card retries instead of aborting the whole session', async () => {
+  const inner = new MockTransport();
+  const { io, wasHidden } = makeIO();
+  const orch = new ArchiveOrchestrator(io);
+
+  // The 2nd write fails (card yanked / verify mismatch), then the same card is re-tapped.
+  const t = new FlakyWriteTransport(inner, 2);
+  const req = { data: multiCardData, fileName: 'blob.bin', compress: false, payloadSize: 720 };
+
+  // Pre-tap enough cards: one extra tap of card index 1 covers the retry.
+  const total = 3; // multiCardData at 720 B/chunk => 3 cards
+  inner.enqueueTag(uid(0));
+  inner.enqueueTag(uid(1)); // this write fails
+  inner.enqueueTag(uid(1)); // re-tap same card -> retry succeeds
+  inner.enqueueTag(uid(2));
+
+  await orch.run(t, req);
+
+  assert.equal(wasHidden(), false, 'progress is never hidden — the session did not abort');
+  // All three distinct cards hold real NFAR chunks now.
+  for (let i = 0; i < total; i++) {
+    inner.enqueueTag(uid(i)); await inner.awaitTag();
+    assert.ok((await inner.readChunk()).length > 0, `card ${i} written`);
+  }
+});

--- a/webapp/test/archive-orchestrator.test.ts
+++ b/webapp/test/archive-orchestrator.test.ts
@@ -4,6 +4,7 @@ import { MockTransport } from '../src/transport/mock-transport.js';
 import { WriteVerifyError, type PresentedTag, type Transport } from '../src/transport/transport.js';
 import { ArchiveOrchestrator, type ArchiveIO } from '../app/ui/archive-orchestrator.js';
 import { RestoreController } from '../app/controller.js';
+import { decodeChunk, encodeChunk } from '../src/chunk.js';
 import { Logger } from '../src/log/logger.js';
 
 const uid = (n: number) => new Uint8Array([0xa0, 0, 0, n]);
@@ -33,7 +34,7 @@ function makeIO(over?: Partial<ArchiveIO>) {
     setStatus: (m) => statuses.push(m),
     showProgress: () => {},
     hideProgress: () => { hidden = true; },
-    confirmOverwrite: () => true,
+    confirmOverwrite: async () => 'once',
     isConnected: () => true,
     awaitReconnect: async () => { throw new Error('awaitReconnect should not be called in this test'); },
     log: new Logger(),
@@ -80,7 +81,7 @@ test('a disconnect pauses and resumes the same session on a fresh transport', as
     // Drop the connection right after the 2nd card is verified.
     showProgress: (_label, value) => { if (value === 2 && connected) connected = false; },
     hideProgress: () => { throw new Error('must not hide progress — session must not abort'); },
-    confirmOverwrite: () => true,
+    confirmOverwrite: async () => 'once',
     isConnected: () => connected,
     awaitReconnect: async () => { connected = true; reconnects += 1; return tB; },
     log: new Logger(),
@@ -127,4 +128,39 @@ test('a prepare failure aborts cleanly with a message (no unhandled rejection)',
   await orch.run(t, { data: new Uint8Array(70000), fileName: 'big.bin', compress: false, payloadSize: 1 });
   assert.equal(wasHidden(), true, 'progress hidden on a prepare failure');
   assert.ok(statuses.some((s) => s.length > 0), 'a human-readable status was shown');
+});
+
+test('"overwrite all remaining" prompts once, then overwrites the rest silently', async () => {
+  const inner = new MockTransport();
+  let prompts = 0;
+  const { io } = makeIO({ confirmOverwrite: async () => { prompts += 1; return 'all'; } });
+  const orch = new ArchiveOrchestrator(io);
+
+  // Every one of the 3 tapped cards already holds NFAR data, so each would
+  // normally raise its own overwrite prompt.
+  const existing = encodeChunk({
+    archiveId: new Uint8Array(16).fill(9), totalChunks: 1, chunkIndex: 0,
+    payload: new Uint8Array([1]), crc32: 0, flags: 0,
+  });
+  const total = 3; // multiCardData at 720 B/chunk => 3 cards
+  // The FIRST card is tapped twice: writeNextCard consumes a tap via awaitTag and
+  // then throws OverwriteRequiredError (no write), so the overwrite retry needs
+  // the card presented again. Once "overwrite all" is chosen, the remaining
+  // already-NFAR cards write on a single tap each (no re-throw).
+  inner.enqueueTag(uid(0), existing); // 1st tap → prompt (throws, tag consumed)
+  inner.enqueueTag(uid(0), existing); // re-tap → the "overwrite all" retry writes chunk 0
+  inner.enqueueTag(uid(1), existing); // overwriteAll set → no prompt, writes chunk 1
+  inner.enqueueTag(uid(2), existing); // writes chunk 2 → done
+
+  await orch.run(inner, { data: multiCardData, fileName: 'blob.bin', compress: false, payloadSize: 720 });
+
+  assert.equal(prompts, 1, 'prompted exactly once; "overwrite all" silenced the rest');
+
+  // All 3 cards were overwritten with the NEW archive (chunk indices 0,1,2).
+  const indices: number[] = [];
+  for (let i = 0; i < total; i++) {
+    inner.enqueueTag(uid(i)); await inner.awaitTag();
+    indices.push(decodeChunk(await inner.readChunk()).chunkIndex);
+  }
+  assert.deepEqual([...indices].sort((a, b) => a - b), [0, 1, 2], 'every card holds a new chunk');
 });

--- a/webapp/test/archive-orchestrator.test.ts
+++ b/webapp/test/archive-orchestrator.test.ts
@@ -86,10 +86,13 @@ test('a disconnect pauses and resumes the same session on a fresh transport', as
     log: new Logger(),
   };
 
-  // tA presents cards 0 and 1; tB presents the remaining cards after reconnect.
+  // total === 3 for 2000 incompressible bytes at 720 B/chunk (deterministic).
+  // tA presents cards 0 and 1 (written before the drop); tB presents the one
+  // remaining card after reconnect. Enqueue EXACTLY the remainder on tB — extra
+  // leftover tags would shift the FIFO readback below and return a blank card.
   tA.enqueueTag(uid(0));
   tA.enqueueTag(uid(1));
-  for (let i = 2; i < 8; i++) tB.enqueueTag(uid(i)); // plenty for the remainder
+  tB.enqueueTag(uid(2));
 
   const orch = new ArchiveOrchestrator(io);
   await orch.run(tA, { data: original, fileName: 'blob.bin', compress: false, payloadSize: 720 });

--- a/webapp/test/archive-orchestrator.test.ts
+++ b/webapp/test/archive-orchestrator.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { MockTransport } from '../src/transport/mock-transport.js';
 import { WriteVerifyError, type PresentedTag, type Transport } from '../src/transport/transport.js';
 import { ArchiveOrchestrator, type ArchiveIO } from '../app/ui/archive-orchestrator.js';
+import { RestoreController } from '../app/controller.js';
 import { Logger } from '../src/log/logger.js';
 
 const uid = (n: number) => new Uint8Array([0xa0, 0, 0, n]);
@@ -65,4 +66,52 @@ test('a bad card retries instead of aborting the whole session', async () => {
     inner.enqueueTag(uid(i)); await inner.awaitTag();
     assert.ok((await inner.readChunk()).length > 0, `card ${i} written`);
   }
+});
+
+test('a disconnect pauses and resumes the same session on a fresh transport', async () => {
+  const original = crypto.getRandomValues(new Uint8Array(2000)); // 3 cards at 720 B
+  const tA = new MockTransport();
+  const tB = new MockTransport();
+
+  let connected = true;
+  let reconnects = 0;
+  const io: ArchiveIO = {
+    setStatus: () => {},
+    // Drop the connection right after the 2nd card is verified.
+    showProgress: (_label, value) => { if (value === 2 && connected) connected = false; },
+    hideProgress: () => { throw new Error('must not hide progress — session must not abort'); },
+    confirmOverwrite: () => true,
+    isConnected: () => connected,
+    awaitReconnect: async () => { connected = true; reconnects += 1; return tB; },
+    log: new Logger(),
+  };
+
+  // tA presents cards 0 and 1; tB presents the remaining cards after reconnect.
+  tA.enqueueTag(uid(0));
+  tA.enqueueTag(uid(1));
+  for (let i = 2; i < 8; i++) tB.enqueueTag(uid(i)); // plenty for the remainder
+
+  const orch = new ArchiveOrchestrator(io);
+  await orch.run(tA, { data: original, fileName: 'blob.bin', compress: false, payloadSize: 720 });
+
+  assert.equal(reconnects, 1, 'resumed exactly once');
+
+  // Reassemble from the cards actually written across BOTH transports.
+  const restoreT = new MockTransport();
+  const readBack = async (t: MockTransport, n: number) => {
+    t.enqueueTag(uid(n)); await t.awaitTag(); return t.readChunk();
+  };
+  restoreT.enqueueTag(uid(0), await readBack(tA, 0));
+  restoreT.enqueueTag(uid(1), await readBack(tA, 1));
+  restoreT.enqueueTag(uid(2), await readBack(tB, 2));
+
+  const rctrl = new RestoreController(restoreT);
+  let detected = await rctrl.scanNextCard(new AbortController().signal);
+  detected = await rctrl.scanNextCard(new AbortController().signal);
+  detected = await rctrl.scanNextCard(new AbortController().signal);
+  assert.equal(detected.length, 1);
+  assert.equal(detected[0]!.complete, true, 'all 3 chunks present across the two transports');
+
+  const { data } = await rctrl.restore(detected[0]!.archiveId, undefined);
+  assert.deepEqual(data, original, 'resumed session restores byte-identically');
 });

--- a/webapp/test/archive-orchestrator.test.ts
+++ b/webapp/test/archive-orchestrator.test.ts
@@ -118,3 +118,13 @@ test('a disconnect pauses and resumes the same session on a fresh transport', as
   const { data } = await rctrl.restore(detected[0]!.archiveId, undefined);
   assert.deepEqual(data, original, 'resumed session restores byte-identically');
 });
+
+test('a prepare failure aborts cleanly with a message (no unhandled rejection)', async () => {
+  const { io, statuses, wasHidden } = makeIO();
+  const t = new MockTransport();
+  const orch = new ArchiveOrchestrator(io);
+  // payloadSize 1 over 70000 bytes forces > MAX_CHUNKS (65535) -> createChunks throws in prepare().
+  await orch.run(t, { data: new Uint8Array(70000), fileName: 'big.bin', compress: false, payloadSize: 1 });
+  assert.equal(wasHidden(), true, 'progress hidden on a prepare failure');
+  assert.ok(statuses.some((s) => s.length > 0), 'a human-readable status was shown');
+});

--- a/webapp/test/controller.test.ts
+++ b/webapp/test/controller.test.ts
@@ -264,3 +264,27 @@ test('writeNextCard/scanNextCard reject with AbortError when the signal is alrea
     (e: unknown) => e instanceof DOMException && e.name === 'AbortError',
   );
 });
+
+test('setTransport swaps the transport mid-session and preserves written state', async () => {
+  const t1 = new MockTransport();
+  const ctrl = new ArchiveController(t1);
+  const total = await ctrl.prepare({ data: multiCardData, fileName: 'blob.bin', compress: false, payloadSize: 720 });
+  assert.ok(total >= 3, `need >=3 cards, got ${total}`);
+
+  // Write the first two cards on t1.
+  t1.enqueueTag(uid(0)); await ctrl.writeNextCard();
+  t1.enqueueTag(uid(1)); const afterTwo = await ctrl.writeNextCard();
+  assert.equal(afterTwo.progress.written, 2);
+
+  // Swap in a fresh transport; the controller must resume at chunk index 2.
+  const t2 = new MockTransport();
+  ctrl.setTransport(t2);
+  t2.enqueueTag(uid(2));
+  const afterSwap = await ctrl.writeNextCard();
+  assert.equal(afterSwap.progress.written, 3, 'continues counting from the preserved state');
+
+  // The chunk written on t2 is card index 2 (distinct UID, real NFAR bytes).
+  t2.enqueueTag(uid(2)); await t2.awaitTag();
+  const stored = decodeChunk(await t2.readChunk());
+  assert.equal(stored.chunkIndex, 2, 'wrote the correct next chunk after the swap');
+});


### PR DESCRIPTION
## Problem

Writing an archive across many cards (e.g. 12 NTAG chips) aborted the **entire** session the moment one card was the wrong format, was pulled off the reader mid-write, or the Chameleon dropped its Bluetooth link — discarding all progress and forcing a re-prepare and re-tap from card 1.

## What changed

The write loop now **only ever ends when every chunk is written**:

- **Retry-only per-card failure.** A verify mismatch, auth failure, capacity error, or a card yanked mid-write no longer aborts — the loop stays on the same chunk and prompts a re-tap. (Wrong-format and already-written-card handling is preserved.) The one clean-abort is a `prepare()` failure *before* the loop (e.g. file too large for the card), which surfaces a message.
- **Pause & resume on reader disconnect.** A BLE disconnect is now detected (`device.ts` wires the SDK's `emitter.on('disconnected')` and exposes `isConnected()`), the loop pauses on `awaitReconnect()`, and on reconnect it swaps the fresh transport into the controller and resumes at the next unwritten card — nothing re-prepared, nothing re-tapped.

## Architecture

Mirrors the existing `RestoreOrchestrator`: the loop moved out of the `archive-panel.ts` click handler into a DOM-free `ArchiveOrchestrator` behind an injected `ArchiveIO` seam, so the retry/pause logic is unit-testable.

- `ArchiveController.setTransport()` — swap the transport without losing `written`/`writtenUids` state (the resume enabler).
- `ArchiveOrchestrator` (new) — the retry-only + pause/resume loop.
- `device.ts` — disconnect sensor + `onConnectionChange` returns an unsubscribe fn.
- `archive-panel.ts` — thin adapter; an `archiving` guard blocks a second concurrent write on the same transport after a reconnect.

On-tag byte format and the `chameleon-ultra.js` dependency fence are unchanged.

## Testing

- `ArchiveOrchestrator` tests drive a **real** failed write followed by a successful retry that completes the set; a disconnect that pauses and resumes on a fresh transport with a **byte-identical restore**; and a `prepare()` failure that aborts cleanly.
- `ArchiveController.setTransport` test proves state is preserved across a mid-session swap.
- Full suite: **150/150**, tsc clean, esbuild bundle builds.
- Hardware smoke on a physical Chameleon was **not** run (no device available); the automated tests + type-check cover the logic.

Spec: `docs/superpowers/specs/2026-07-29-webapp-resilient-archive-write-design.md`
Plan: `docs/superpowers/plans/2026-07-29-webapp-resilient-archive-write.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)