### PR TITLE
fix(webapp): NTAG chunks overflow the CC NDEF area → Android CRC failures

### DIFF
--- a/webapp/src/nfc/type2.ts
+++ b/webapp/src/nfc/type2.ts
@@ -72,14 +72,37 @@ export function detectNtagType(getVersion: Uint8Array): NtagType | null {
   return null;
 }
 
-/** Largest NFAR chunk payload whose NDEF+TLV-wrapped form fits this tag's user memory. */
-export function ntagChunkPayloadSize(t: NtagType): number {
-  const cap = USER_BYTES[t];
+/** Largest NFAR chunk payload whose NDEF+TLV-wrapped form fits `capacity` bytes.
+ *  `capacity` is the NDEF data area available for the whole TLV (T + L + record +
+ *  terminator) — for a real tag that is the Capability-Container-declared area
+ *  (see ndefCapacityFromCC), NOT the raw user memory, which is what Android
+ *  enforces when it reads the tag. */
+export function chunkPayloadForCapacity(capacity: number): number {
   const wrappedLen = (payload: number): number =>
     wrapType2Tlv(encodeNdefMime(new Uint8Array(TOTAL_OVERHEAD + payload))).length;
-  // Search downward from the raw capacity; overhead is < 80 bytes so this is cheap.
-  for (let p = cap; p > 0; p--) {
-    if (wrappedLen(p) <= cap) return p;
+  // Search downward; overhead is < 80 bytes so this is cheap.
+  for (let p = capacity; p > 0; p--) {
+    if (wrappedLen(p) <= capacity) return p;
   }
   return 0;
+}
+
+/** Pre-tap estimate only: max chunk payload for a tag TYPE using its raw user
+ *  memory. The authoritative per-card capacity comes from the tag's Capability
+ *  Container at write time (ndefCapacityFromCC → chunkPayloadForCapacity), which
+ *  can be smaller (NTAG215: CC 496 B vs 504 B raw; NTAG216: 872 vs 888). */
+export function ntagChunkPayloadSize(t: NtagType): number {
+  return chunkPayloadForCapacity(USER_BYTES[t]);
+}
+
+/**
+ * The NFC-Forum Type-2 Capability Container is 4 bytes at page 3:
+ * [0]=0xE1 magic, [1]=version, [2]=MLEN (memory size / 8), [3]=access.
+ * The NDEF data area available for the TLV is MLEN × 8 bytes. Android reads a
+ * tag bounded by this area, so it is the capacity the writer must respect.
+ * Returns null when the CC is absent/invalid (not an NDEF-formatted tag).
+ */
+export function ndefCapacityFromCC(cc: Uint8Array): number | null {
+  if (cc.length < 4 || cc[0] !== 0xe1 || cc[2] === 0) return null;
+  return cc[2]! * 8;
 }

--- a/webapp/src/transport/ntag-transport.ts
+++ b/webapp/src/transport/ntag-transport.ts
@@ -5,7 +5,7 @@
 
 import { CardCapacityError } from '../mifare/card-layout.js';
 import { encodeNdefMime, decodeNdefMime, NdefFormatError } from '../nfc/ndef.js';
-import { wrapType2Tlv, readType2Ndef, detectNtagType, ntagUserBytes, ntagChunkPayloadSize, type NtagType } from '../nfc/type2.js';
+import { wrapType2Tlv, readType2Ndef, detectNtagType, ntagUserBytes, ndefCapacityFromCC, chunkPayloadForCapacity, type NtagType } from '../nfc/type2.js';
 import type { ChameleonDevice } from './chameleon-device.js';
 import { NfarFormatError, TOTAL_OVERHEAD } from '../chunk.js';
 import { TagTimeoutError, UnsupportedTagError, WriteVerifyError, type PresentedTag, type Transport } from './transport.js';
@@ -56,11 +56,26 @@ export class NtagTransport implements Transport {
       const tag = await this.device.scanTag();
       if (tag !== null) {
         const type = await this.detectType();
-        return { uid: tag.uid, capacityBytes: ntagUserBytes(type), maxChunkPayload: ntagChunkPayloadSize(type) };
+        // Size chunks to the NDEF area the tag's Capability Container declares —
+        // NOT raw user memory — so the whole TLV fits within what Android reads.
+        const capacity = await this.readNdefCapacity();
+        return { uid: tag.uid, capacityBytes: ntagUserBytes(type), maxChunkPayload: chunkPayloadForCapacity(capacity) };
       }
       if (Date.now() >= deadline) throw new TagTimeoutError(`No tag presented within ${timeoutMs}ms`);
       await delay(this.pollMs);
     }
+  }
+
+  /** Read the tag's Capability Container (page 3) and return the NDEF data area
+   *  (in bytes) it declares — MLEN×8. This is the capacity Android honors when
+   *  reading, so the writer must keep the whole TLV within it. */
+  private async readNdefCapacity(): Promise<number> {
+    const cc = (await this.readMemory(3, 4)).subarray(0, 4);
+    const cap = ndefCapacityFromCC(cc);
+    if (cap === null) {
+      throw new UnsupportedTagError('Tag is not NDEF-formatted (missing/invalid Capability Container)');
+    }
+    return cap;
   }
 
   /** Read `pages` starting at `startPage`, 16 bytes per READ. */
@@ -99,9 +114,9 @@ export class NtagTransport implements Transport {
   }
 
   async writeChunk(bytes: Uint8Array): Promise<void> {
-    const type = await this.detectType();
-    if (bytes.length > TOTAL_OVERHEAD + ntagChunkPayloadSize(type)) {
-      throw new CardCapacityError(`Chunk ${bytes.length} B exceeds ${type} capacity`);
+    const capacity = await this.readNdefCapacity();
+    if (bytes.length > TOTAL_OVERHEAD + chunkPayloadForCapacity(capacity)) {
+      throw new CardCapacityError(`Chunk ${bytes.length} B exceeds the tag's ${capacity} B NDEF area`);
     }
     const tlv = wrapType2Tlv(encodeNdefMime(bytes));
     const padded = new Uint8Array(Math.ceil(tlv.length / 4) * 4);

--- a/webapp/test/e2e-ntag.test.ts
+++ b/webapp/test/e2e-ntag.test.ts
@@ -4,7 +4,7 @@ import { archive, restore } from '../src/pipeline.js';
 import { encodeChunk, decodeChunk, type Chunk } from '../src/chunk.js';
 import { AutoTransport } from '../src/transport/auto-transport.js';
 import { FakeChameleon } from './fake-chameleon.js';
-import { NtagType, ntagChunkPayloadSize } from '../src/nfc/type2.js';
+import { NtagType, chunkPayloadForCapacity } from '../src/nfc/type2.js';
 
 test('archive to NTAG215 tags via AutoTransport, then restore byte-identical', async () => {
   const original = new TextEncoder().encode('ntag payload '.repeat(120));
@@ -12,7 +12,13 @@ test('archive to NTAG215 tags via AutoTransport, then restore byte-identical', a
   const transport = new AutoTransport(device, { pollMs: 1, defaultTimeoutMs: 500 });
   await transport.connect();
 
-  const payloadSize = ntagChunkPayloadSize(NtagType.NTAG215);
+  // Size chunks to the tag's real per-card NDEF capacity read from its CC (496 B
+  // for NTAG215, not the 504 B raw memory) — mirroring the app's auto-rechunk.
+  const probeUid = new Uint8Array([0x04, 0, 0, 0, 0, 0, 0xff]);
+  device.placeNtag(probeUid, NtagType.NTAG215);
+  const payloadSize = (await transport.awaitTag()).maxChunkPayload;
+  assert.equal(payloadSize, chunkPayloadForCapacity(496));
+
   const chunks = await archive(original, { payloadSize, compress: false, password: 'ntag-pw' });
   assert.ok(chunks.length >= 2, `expected multiple NTAGs, got ${chunks.length}`);
 

--- a/webapp/test/fake-chameleon.ts
+++ b/webapp/test/fake-chameleon.ts
@@ -13,6 +13,9 @@ function keysEqual(a: Uint8Array, b: Uint8Array): boolean {
 // page counts: 213=45, 215=135, 216=231
 const NTAG_PAGES: Record<NtagType, number> = { NTAG213: 45, NTAG215: 135, NTAG216: 231 };
 const NTAG_STORAGE: Record<NtagType, number> = { NTAG213: 0x0f, NTAG215: 0x11, NTAG216: 0x13 };
+// Factory Capability Container MLEN (NDEF data area / 8) programmed at page 3.
+// NTAG213 144 B (== raw), NTAG215 496 B (< 504 raw), NTAG216 872 B (< 888 raw).
+const NTAG_CC_MLEN: Record<NtagType, number> = { NTAG213: 0x12, NTAG215: 0x3e, NTAG216: 0x6d };
 
 interface Card { image: Uint8Array; keyA: Uint8Array; sak: number; ntag?: { type: NtagType; pages: Uint8Array } }
 
@@ -40,9 +43,11 @@ export class FakeChameleon implements ChameleonDevice {
   placeNtag(uid: Uint8Array, type: NtagType): void {
     const key = hex(uid);
     if (!this.cards.has(key)) {
+      const pages = new Uint8Array(NTAG_PAGES[type] * 4);
+      pages.set([0xe1, 0x10, NTAG_CC_MLEN[type], 0x00], 3 * 4); // Capability Container at page 3
       this.cards.set(key, {
         image: new Uint8Array(64 * 16), keyA: FACTORY_KEY_A, sak: 0x00,
-        ntag: { type, pages: new Uint8Array(NTAG_PAGES[type] * 4) },
+        ntag: { type, pages },
       });
     }
     this.field = key;

--- a/webapp/test/ntag-transport.test.ts
+++ b/webapp/test/ntag-transport.test.ts
@@ -2,7 +2,9 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { NtagTransport } from '../src/transport/ntag-transport.js';
 import { FakeChameleon } from './fake-chameleon.js';
-import { NtagType, ntagChunkPayloadSize } from '../src/nfc/type2.js';
+import { NtagType, ntagChunkPayloadSize, chunkPayloadForCapacity } from '../src/nfc/type2.js';
+import { wrapType2Tlv } from '../src/nfc/type2.js';
+import { encodeNdefMime } from '../src/nfc/ndef.js';
 import { encodeChunk, decodeChunk, type Chunk } from '../src/chunk.js';
 import { crc32 } from '../src/crc32.js';
 import { UnsupportedTagError } from '../src/transport/transport.js';
@@ -27,7 +29,12 @@ function stubDevice(opts: { onRead: (data: Uint8Array) => Promise<Uint8Array>; g
     transceive14a: async (data: Uint8Array) => {
       const cmd = data[0];
       if (cmd === 0x60) return opts.getVersion ?? new Uint8Array([0, 4, 4, 2, 1, 0, 0x11, 3]); // NTAG215
-      if (cmd === 0x30) return opts.onRead(data);
+      if (cmd === 0x30) {
+        // awaitTag reads the Capability Container at page 3; return a valid NTAG215
+        // CC so tag presentation succeeds and per-test onRead governs page >= 4.
+        if (data[1] === 3) { const cc = new Uint8Array(16); cc.set([0xe1, 0x10, 0x3e, 0x00]); return cc; }
+        return opts.onRead(data);
+      }
       throw new Error(`stub does not implement command 0x${cmd?.toString(16)}`);
     },
     readBlock: async () => { throw new Error('not used'); },
@@ -48,8 +55,11 @@ test('write then read-back an NDEF-wrapped chunk on a simulated NTAG215', async 
   const uid = new Uint8Array([0x04, 1, 2, 3, 4, 5, 6]);
   device.placeNtag(uid, NtagType.NTAG215);
   const tag = await t.awaitTag();
-  assert.equal(tag.capacityBytes, 504);
-  assert.equal(tag.maxChunkPayload, ntagChunkPayloadSize(NtagType.NTAG215));
+  assert.equal(tag.capacityBytes, 504); // raw user memory (informational)
+  // maxChunkPayload comes from the CC-declared NDEF area (496 B), NOT raw memory
+  // (504 B) — smaller, so the whole TLV stays within what Android reads back.
+  assert.equal(tag.maxChunkPayload, chunkPayloadForCapacity(496));
+  assert.ok(tag.maxChunkPayload < ntagChunkPayloadSize(NtagType.NTAG215), 'CC area is below raw user memory');
   assert.equal(await t.peekIsNfar(), false);
 
   const bytes = chunkBytes(200);
@@ -58,6 +68,33 @@ test('write then read-back an NDEF-wrapped chunk on a simulated NTAG215', async 
   await t.awaitTag();
   assert.equal(await t.peekIsNfar(), true);
   assert.deepEqual(await t.readChunk(), bytes);
+});
+
+test('a full-size chunk stays within the CC-declared NDEF area so Android can read it back', async () => {
+  const device = new FakeChameleon();
+  const t = new NtagTransport(device, { pollMs: 1, defaultTimeoutMs: 500 });
+  await t.connect();
+  const uid = new Uint8Array([0x04, 5, 5, 5, 5, 5, 5]);
+  device.placeNtag(uid, NtagType.NTAG215);
+  const tag = await t.awaitTag();
+
+  // The whole NDEF+TLV of a maximum chunk must fit the 496 B the NTAG215 CC
+  // declares. The pre-fix bug sized to 504 B raw memory, overflowing by 8 B, so
+  // Android's CC-bounded read truncated every full chunk and CRC failed.
+  const full = chunkBytes(tag.maxChunkPayload);
+  const wrapped = wrapType2Tlv(encodeNdefMime(full)).length;
+  assert.ok(wrapped <= 496, `full chunk wraps to ${wrapped} B; must fit the 496 B CC area`);
+
+  // The transport rejects a chunk sized to raw user memory (the old maximum)
+  // rather than silently writing a tag Android cannot read.
+  const rawSized = chunkBytes(ntagChunkPayloadSize(NtagType.NTAG215));
+  await assert.rejects(() => t.writeChunk(rawSized), /NDEF area/);
+
+  // A CC-sized chunk writes and reads back intact.
+  await t.writeChunk(full);
+  device.placeNtag(uid, NtagType.NTAG215);
+  await t.awaitTag();
+  assert.deepEqual(await t.readChunk(), full);
 });
 
 test('a chunk larger than the tag capacity is rejected', async () => {

--- a/webapp/test/type2.test.ts
+++ b/webapp/test/type2.test.ts
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   wrapType2Tlv, readType2Ndef, NtagType, ntagUserBytes, detectNtagType, ntagChunkPayloadSize,
+  chunkPayloadForCapacity, ndefCapacityFromCC,
 } from '../src/nfc/type2.js';
 import { encodeNdefMime, NdefFormatError } from '../src/nfc/ndef.js';
 import { TOTAL_OVERHEAD } from '../src/chunk.js';
@@ -52,4 +53,26 @@ test('ntagChunkPayloadSize is the max payload whose wrapped chunk fits user memo
     assert.ok(wrappedLen(p + 1) > cap, `${t}: payload ${p + 1} should overflow ${cap}`);
     assert.ok(p > 0);
   }
+});
+
+test('chunkPayloadForCapacity keeps the whole wrapped chunk within the capacity, and is maximal', () => {
+  const wrappedLen = (payload: number) => wrapType2Tlv(encodeNdefMime(new Uint8Array(TOTAL_OVERHEAD + payload))).length;
+  for (const cap of [144, 496, 872]) { // the real NTAG213/215/216 CC-declared NDEF areas
+    const p = chunkPayloadForCapacity(cap);
+    assert.ok(p > 0);
+    assert.ok(wrappedLen(p) <= cap, `cap ${cap}: payload ${p} wraps to ${wrappedLen(p)} > ${cap}`);
+    assert.ok(wrappedLen(p + 1) > cap, `cap ${cap}: payload ${p + 1} should overflow ${cap}`);
+  }
+  // The CC areas of NTAG215/216 are below their raw user memory, so the safe
+  // payload is strictly smaller than the raw-memory estimate — the bug's crux.
+  assert.ok(chunkPayloadForCapacity(496) < ntagChunkPayloadSize(NtagType.NTAG215));
+  assert.ok(chunkPayloadForCapacity(872) < ntagChunkPayloadSize(NtagType.NTAG216));
+});
+
+test('ndefCapacityFromCC reads MLEN×8 from a valid CC and rejects an invalid one', () => {
+  assert.equal(ndefCapacityFromCC(new Uint8Array([0xe1, 0x10, 0x3e, 0x00])), 496); // NTAG215
+  assert.equal(ndefCapacityFromCC(new Uint8Array([0xe1, 0x10, 0x6d, 0x00])), 872); // NTAG216
+  assert.equal(ndefCapacityFromCC(new Uint8Array([0xe1, 0x10, 0x12, 0x00])), 144); // NTAG213
+  assert.equal(ndefCapacityFromCC(new Uint8Array([0x00, 0x00, 0x00, 0x00])), null); // blank/unformatted
+  assert.equal(ndefCapacityFromCC(new Uint8Array([0xe1, 0x10])), null); // too short
 });


### PR DESCRIPTION
## Symptom

A file written to NTAG cards by the webapp (Chameleon) restored **fine over Chameleon/webapp**, but the **Android app failed CRC on every full-size chunk** — e.g. 8 cards → "CRC validation failed for 7 chunks: 7,6,5,4,3,2,1", only the short last chunk (8) OK.

## Root cause

The webapp sized NTAG chunks to **raw user memory** (`USER_BYTES` = 144 / 504 / 888), but Android reads NDEF **bounded by the tag's Capability Container**, whose declared NDEF area is smaller:

| Tag | raw user mem | CC NDEF area | full-chunk overflow |
|-----|--------------|--------------|---------------------|
| NTAG213 | 144 | 144 | 0 B (unaffected) |
| NTAG215 | 504 | **496** | **8 B** |
| NTAG216 | 888 | **872** | **16 B** |

A full chunk's NDEF+TLV overflowed the CC area, so Android truncated the tail (payload end + CRC + `0xFE` terminator) of every full chunk → CRC failed. The short last chunk fit under the limit → OK. The webapp's own reader and the Chameleon read by the **TLV length field** (not the CC), so they round-tripped and masked the bug — matching the "Chameleon restores, Android doesn't" report exactly.

The Flutter app never hit this because it sizes chunks to the tag's runtime-reported `ndef.maxSize` (`nfc_repository.dart`), i.e. the CC area.

## Fix

Read the Capability Container (page 3) at tap/write time and size chunks to `MLEN×8` — self-correcting per tag, mirroring the Flutter app.

- **`type2.ts`**: `chunkPayloadForCapacity(cap)` + `ndefCapacityFromCC(cc)`. `ntagChunkPayloadSize` now derives from the former using raw memory (pre-tap **estimate only**; the real write uses the CC).
- **`ntag-transport.ts`**: `awaitTag` reports `maxChunkPayload` from the CC (feeding the existing auto-rechunk); `writeChunk` guards against the CC area and **rejects** (rather than silently writing) an over-area chunk.
- **Tests**: `FakeChameleon` bakes a factory CC into simulated NTAGs; a regression test proves a full chunk's wrapped TLV fits the CC area and a raw-sized chunk is rejected; unit tests cover both new functions.

## Verification

- Full suite **149/149**, tsc clean, esbuild bundle builds.
- Empirically confirmed: NTAG215 chunk payload 428→**420** (wraps 504→**496**), NTAG216 812→**796** (wraps 888→**872**); NTAG213 unchanged.
- Hardware smoke on a real NTAG + Android read was **not** run here (no device).

## ⚠️ Note for existing cards

Cards already written by the webapp to **NTAG215/216** are over-area and must be **re-written** after this fix to be Android-readable. NTAG213 cards are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)