### PR TITLE
fix(webapp): a short card read is transient, not a "no NFAR data" verdict

### DIFF
--- a/webapp/app/controller.ts
+++ b/webapp/app/controller.ts
@@ -11,6 +11,7 @@ import { assembleChunks, createChunks } from '../src/chunker.js';
 import { NdefFormatError } from '../src/nfc/ndef.js';
 import { wrapWithFilename, unwrapFilename } from '../src/filename.js';
 import { formatArchiveId } from '../src/archive-id.js';
+import { log } from '../src/log/logger.js';
 import type { Transport } from '../src/transport/transport.js';
 
 export interface ArchiveRequest {
@@ -149,9 +150,13 @@ export class RestoreController {
         chunk = decodeChunk(await this.transport.readChunk());
       } catch (e) {
         // A blank/foreign/undecodable card in the pile shouldn't end the scan:
-        // remember its UID (so it isn't re-read on a re-tap) and skip it.
+        // remember its UID (so it isn't re-read on a re-tap) and skip it. This
+        // verdict is sticky, so only a healthy full read may produce it — the
+        // transports reject a short read as CardReadError, which falls through
+        // to the caller and leaves the UID re-tappable.
         if (e instanceof NfarFormatError || e instanceof NdefFormatError) {
           this.seenUids.add(uid);
+          log.debug('scan', 'Card skipped — holds no NFAR data', { uid, error: String(e) });
           return this.detectedArchives();
         }
         throw e; // a transient I/O failure — let the caller decide

--- a/webapp/app/ui/errors.ts
+++ b/webapp/app/ui/errors.ts
@@ -1,5 +1,5 @@
 /** Maps a caught error to a plain-language, user-facing message. */
-import { CardAuthError, WriteVerifyError, TagTimeoutError, UnsupportedTagError } from '../../src/transport/transport.js';
+import { CardAuthError, CardReadError, WriteVerifyError, TagTimeoutError, UnsupportedTagError } from '../../src/transport/transport.js';
 import { CardCapacityError } from '../../src/mifare/card-layout.js';
 import { DecryptionError } from '../../src/crypto.js';
 import { OverwriteRequiredError, PasswordRequiredError, NfarFormatError } from '../controller.js';
@@ -7,6 +7,7 @@ import { NdefFormatError } from '../../src/nfc/ndef.js';
 
 export function humanError(e: unknown): string {
   if (e instanceof CardAuthError) return 'Card keys are not factory defaults — this card cannot be used.';
+  if (e instanceof CardReadError) return 'Card read was incomplete — hold the card steady on the reader and tap again.';
   if (e instanceof WriteVerifyError) return 'Write verification failed — move the card closer and retry.';
   if (e instanceof CardCapacityError) return 'This card is smaller than the ones already written — use cards of the same type, or restart the archive.';
   if (e instanceof TagTimeoutError) return 'No card detected — tap a card on the reader.';

--- a/webapp/src/transport/chameleon-ble.ts
+++ b/webapp/src/transport/chameleon-ble.ts
@@ -10,7 +10,7 @@ import {
   chunkToBlocks, firstBlockIsNfar, nfarTotalLength, assembleChunkFromBlocks,
 } from '../mifare/card-layout.js';
 import { FACTORY_KEY_A, type ChameleonDevice } from './chameleon-device.js';
-import { TagTimeoutError, WriteVerifyError, type PresentedTag, type Transport } from './transport.js';
+import { CardReadError, TagTimeoutError, WriteVerifyError, type PresentedTag, type Transport } from './transport.js';
 
 function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
   if (a.length !== b.length) return false;
@@ -50,8 +50,19 @@ export class ChameleonBleTransport implements Transport {
     }
   }
 
+  /** Every read goes through here: a short response is a marginal RF read, not
+   *  card content, so it is rejected as transient instead of being treated as
+   *  (zero-padded) data — which would read as "this card holds no NFAR chunk". */
+  private async readBlockStrict(block: number): Promise<Uint8Array> {
+    const data = await this.device.readBlock(block, FACTORY_KEY_A);
+    if (data.length !== BLOCK_SIZE) {
+      throw new CardReadError(`Short read on block ${block}: got ${data.length} of ${BLOCK_SIZE} bytes`);
+    }
+    return data;
+  }
+
   private readUsable(i: number): Promise<Uint8Array> {
-    return this.device.readBlock(USABLE_BLOCK_INDEXES[i]!, FACTORY_KEY_A);
+    return this.readBlockStrict(USABLE_BLOCK_INDEXES[i]!);
   }
 
   async peekIsNfar(): Promise<boolean> {
@@ -78,7 +89,7 @@ export class ChameleonBleTransport implements Transport {
     const blocks = chunkToBlocks(bytes); // throws CardCapacityError if > 752
     for (const { block, data } of blocks) await this.device.writeBlock(block, FACTORY_KEY_A, data);
     for (const { block, data } of blocks) {
-      const readBack = await this.device.readBlock(block, FACTORY_KEY_A);
+      const readBack = await this.readBlockStrict(block);
       if (!bytesEqual(readBack, data)) {
         throw new WriteVerifyError(`Verification failed on block ${block}: read-back does not match`);
       }

--- a/webapp/src/transport/ntag-transport.ts
+++ b/webapp/src/transport/ntag-transport.ts
@@ -8,7 +8,7 @@ import { encodeNdefMime, decodeNdefMime, NdefFormatError } from '../nfc/ndef.js'
 import { wrapType2Tlv, readType2Ndef, detectNtagType, ntagUserBytes, ndefCapacityFromCC, chunkPayloadForCapacity, type NtagType } from '../nfc/type2.js';
 import type { ChameleonDevice } from './chameleon-device.js';
 import { NfarFormatError, TOTAL_OVERHEAD } from '../chunk.js';
-import { TagTimeoutError, UnsupportedTagError, WriteVerifyError, type PresentedTag, type Transport } from './transport.js';
+import { CardReadError, TagTimeoutError, UnsupportedTagError, WriteVerifyError, type PresentedTag, type Transport } from './transport.js';
 
 const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
 const NDEF_START_PAGE = 4;
@@ -78,11 +78,17 @@ export class NtagTransport implements Transport {
     return cap;
   }
 
-  /** Read `pages` starting at `startPage`, 16 bytes per READ. */
+  /** Read `pages` starting at `startPage`, 16 bytes per READ. A READ that comes
+   *  back short is a marginal RF read, not tag content: rejecting it as transient
+   *  keeps a zero-filled buffer from being parsed as "no NDEF TLV on this tag". */
   private async readMemory(startPage: number, byteCount: number): Promise<Uint8Array> {
     const out = new Uint8Array(Math.ceil(byteCount / 16) * 16);
     for (let off = 0; off < out.length; off += 16) {
-      const resp = await this.device.transceive14a(new Uint8Array([0x30, startPage + off / 4]), { autoSelect: true, appendCrc: true, checkResponseCrc: true });
+      const page = startPage + off / 4;
+      const resp = await this.device.transceive14a(new Uint8Array([0x30, page]), { autoSelect: true, appendCrc: true, checkResponseCrc: true });
+      if (resp.length < 16) {
+        throw new CardReadError(`Short READ at page ${page}: got ${resp.length} of 16 bytes`);
+      }
       out.set(resp.subarray(0, 16), off);
     }
     return out.subarray(0, byteCount);

--- a/webapp/src/transport/transport.ts
+++ b/webapp/src/transport/transport.ts
@@ -31,6 +31,20 @@ export class CardAuthError extends Error {
   }
 }
 
+/**
+ * A block/page read came back short — the reader returned fewer bytes than the
+ * card layer asked for without reporting an error, which the Chameleon does on
+ * marginal coupling. Such a read says NOTHING about what the card holds, so it
+ * must never be mistaken for a non-NFAR verdict: it is transient and a re-tap
+ * (or an immediate retry) can succeed.
+ */
+export class CardReadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CardReadError';
+  }
+}
+
 export class WriteVerifyError extends Error {
   constructor(message: string) {
     super(message);

--- a/webapp/test/fake-chameleon.ts
+++ b/webapp/test/fake-chameleon.ts
@@ -24,6 +24,7 @@ export class FakeChameleon implements ChameleonDevice {
   private connected = false;
   private field: string | null = null;
   private corruptNext = false;
+  private truncateNext: number | null = null;
   private readonly cards = new Map<string, Card>();
 
   defineCard(uid: Uint8Array, opts?: { keyA?: Uint8Array; sak?: number }): void {
@@ -58,6 +59,12 @@ export class FakeChameleon implements ChameleonDevice {
   corruptNextWrite(): void {
     this.corruptNext = true;
   }
+  /** Simulate one marginal RF read: the reader returns fewer bytes than a full
+   *  block/page-group without reporting an error, as the Chameleon does when
+   *  coupling is poor. */
+  truncateNextRead(keepBytes = 4): void {
+    this.truncateNext = keepBytes;
+  }
   blockOf(uid: Uint8Array, block: number): Uint8Array {
     return this.cards.get(hex(uid))!.image.slice(block * 16, block * 16 + 16);
   }
@@ -87,7 +94,13 @@ export class FakeChameleon implements ChameleonDevice {
     }
     if (cmd === 0x30) { // READ page..page+3 (16 bytes)
       const page = data[1]!;
-      return ntag.pages.slice(page * 4, page * 4 + 16);
+      const full = ntag.pages.slice(page * 4, page * 4 + 16);
+      if (this.truncateNext !== null) {
+        const keep = this.truncateNext;
+        this.truncateNext = null;
+        return full.slice(0, keep);
+      }
+      return full;
     }
     if (cmd === 0xa2) { // WRITE one page
       const page = data[1]!;
@@ -105,7 +118,13 @@ export class FakeChameleon implements ChameleonDevice {
   async readBlock(block: number, key: Uint8Array): Promise<Uint8Array> {
     const card = this.current();
     if (!keysEqual(key, card.keyA)) throw new CardAuthError(`Auth failed on block ${block}`);
-    return card.image.slice(block * 16, block * 16 + 16);
+    const full = card.image.slice(block * 16, block * 16 + 16);
+    if (this.truncateNext !== null) {
+      const keep = this.truncateNext;
+      this.truncateNext = null;
+      return full.slice(0, keep);
+    }
+    return full;
   }
 
   async writeBlock(block: number, key: Uint8Array, data: Uint8Array): Promise<void> {

--- a/webapp/test/marginal-read.test.ts
+++ b/webapp/test/marginal-read.test.ts
@@ -1,0 +1,104 @@
+/**
+ * A marginal RF read returns fewer bytes than a full block/page-group without the
+ * reader reporting an error. Such a read carries no verdict about the card: it
+ * must surface as a transient CardReadError, NOT as "this card holds no NFAR
+ * data" — otherwise the scan blacklists the card's UID and no re-tap can ever
+ * recover it (the card silently disappears from the scan for the whole session).
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { ArchiveController, RestoreController } from '../app/controller.js';
+import { NfarFormatError } from '../src/chunk.js';
+import { CARD_PAYLOAD_SIZE } from '../src/mifare/card-layout.js';
+import { ChameleonBleTransport } from '../src/transport/chameleon-ble.js';
+import { NtagTransport } from '../src/transport/ntag-transport.js';
+import { AutoTransport } from '../src/transport/auto-transport.js';
+import { CardReadError } from '../src/transport/transport.js';
+import { NtagType, ntagChunkPayloadSize } from '../src/nfc/type2.js';
+import { FakeChameleon } from './fake-chameleon.js';
+
+const MIFARE_UID = new Uint8Array([0xb9, 0x16, 0x27, 0x51]);
+const NTAG_UID = new Uint8Array([0x04, 0xaa, 0xbb, 0xcc]);
+const NOTE = { data: new TextEncoder().encode('Test'), fileName: 'text_note.txt', compress: true };
+
+/** Archive the one-word note onto the presented card through the real controller. */
+async function writeNote(transport: AutoTransport, payloadSize: number): Promise<void> {
+  const ctrl = new ArchiveController(transport);
+  assert.equal(await ctrl.prepare({ ...NOTE, payloadSize }), 1);
+  assert.equal((await ctrl.writeNextCard(undefined, true)).done, true);
+}
+
+test('Mifare: a truncated block read is a transient CardReadError, not a non-NFAR verdict', async () => {
+  const device = new FakeChameleon();
+  const transport = new ChameleonBleTransport(device, { pollMs: 1, defaultTimeoutMs: 300 });
+  await transport.connect();
+  device.place(MIFARE_UID);
+  await writeNote(new AutoTransport(device, { pollMs: 1, defaultTimeoutMs: 300 }), CARD_PAYLOAD_SIZE);
+
+  await transport.awaitTag();
+  device.truncateNextRead();
+  await assert.rejects(() => transport.readChunk(), CardReadError);
+
+  // The card itself is fine: the very next read succeeds.
+  assert.ok((await transport.readChunk()).length > 0);
+});
+
+test('NTAG: a truncated page read is a transient CardReadError, not a non-NFAR verdict', async () => {
+  const device = new FakeChameleon();
+  const transport = new NtagTransport(device, { pollMs: 1, defaultTimeoutMs: 300 });
+  await transport.connect();
+  device.placeNtag(NTAG_UID, NtagType.NTAG213);
+  await writeNote(new AutoTransport(device, { pollMs: 1, defaultTimeoutMs: 300 }), ntagChunkPayloadSize(NtagType.NTAG213));
+
+  await transport.awaitTag();
+  device.truncateNextRead();
+  await assert.rejects(() => transport.readChunk(), CardReadError);
+  assert.ok((await transport.readChunk()).length > 0);
+});
+
+test('scan: a card misread once is still detected on a re-tap', async () => {
+  const device = new FakeChameleon();
+  const transport = new AutoTransport(device, { pollMs: 1, defaultTimeoutMs: 300 });
+  await transport.connect();
+  device.place(MIFARE_UID);
+  await writeNote(transport, CARD_PAYLOAD_SIZE);
+
+  const rc = new RestoreController(transport);
+  device.truncateNextRead();
+  await assert.rejects(() => rc.scanNextCard(), CardReadError);
+  assert.deepEqual(rc.detectedArchives(), []);
+
+  // Re-tap: the misread must not have blacklisted the UID.
+  const list = await rc.scanNextCard();
+  assert.equal(list.length, 1, 'archive must be detected after a re-tap');
+  assert.equal(list[0]!.complete, true);
+  const out = await rc.restore(list[0]!.archiveId);
+  assert.equal(out.fileName, 'text_note.txt');
+  assert.equal(new TextDecoder().decode(out.data), 'Test');
+});
+
+test('scan: a genuinely blank card is still skipped once and not re-read', async () => {
+  const device = new FakeChameleon();
+  const transport = new AutoTransport(device, { pollMs: 1, defaultTimeoutMs: 300 });
+  await transport.connect();
+  device.place(MIFARE_UID); // never written — all zeros
+
+  const rc = new RestoreController(transport);
+  assert.deepEqual(await rc.scanNextCard(), []);
+  // Blank verdict came from a full, healthy read, so it is trustworthy and sticky:
+  // a second tap must not re-read the card.
+  let reads = 0;
+  const orig = device.readBlock.bind(device);
+  device.readBlock = async (b, k) => { reads++; return orig(b, k); };
+  assert.deepEqual(await rc.scanNextCard(), []);
+  assert.equal(reads, 0, 'an already-skipped blank card must not be re-read');
+});
+
+test('a full read of a blank Mifare card still reports NfarFormatError', async () => {
+  const device = new FakeChameleon();
+  const transport = new ChameleonBleTransport(device, { pollMs: 1, defaultTimeoutMs: 300 });
+  await transport.connect();
+  device.place(MIFARE_UID);
+  await transport.awaitTag();
+  await assert.rejects(() => transport.readChunk(), NfarFormatError);
+});


### PR DESCRIPTION
Found during a hardware smoke test: a Mifare card written with a valid archive stopped being detected on restore, and the scan log showed nothing but an endless run of `Detection {"archives":0,"complete":0}` every ~300 ms.

## Root cause

A marginal RF read returns fewer bytes than a full block/page-group **without the reader reporting an error**. Both transports converted that non-answer into a confident verdict about the card's contents:

- `ChameleonBleTransport` passed the short buffer straight through, so `firstBlockIsNfar()` failed its length check and `readChunk` threw `NfarFormatError`.
- `NtagTransport` was worse: `readMemory()` zero-filled the missing bytes via `out.set(resp.subarray(0, 16))`, so the TLV parse saw `0x00` and reported "No NDEF TLV on this tag".

`RestoreController` treats that verdict as **sticky** — it adds the UID to `seenUids` so a blank/foreign card in a pile isn't re-read on every poll. Combined, one bad read blacklisted a perfectly good card for the rest of the scan session: no re-tap could recover it, and nothing was logged.

The bug is a category error — "I couldn't read this" collapsed into "this is blank." Dangerous specifically *because* the blank verdict is sticky: a sticky conclusion must only be drawn from trustworthy evidence.

## Fix

Reject a short read as a new transient `CardReadError` rather than interpreting it.

- `chameleon-ble.ts` — all reads funnel through `readBlockStrict()`, requiring a full 16-byte block (write-verification reads included).
- `ntag-transport.ts` — `readMemory()` rejects a short READ instead of zero-filling.
- `CardReadError` propagates out of `scanNextCard`, so `restore-panel` reports "Skipped a card" and the UID **stays re-tappable**. The sticky blank-card verdict survives, but now only a healthy full read can produce it.
- The skip is now logged with its UID and reason. The silence is what made this undiagnosable from a user's log.

## Ruled out

The report correlated the failure with picking an explicit target-tag size instead of auto-detect. That is **not** the cause: `index.html` gives the Mifare option `value="720"` and `archive-panel.ts:15` maps `auto` to `CARD_PAYLOAD_SIZE`, which is also 720. Writing the same note through both paths produced byte-identical card images — matching the user's raw card dump exactly, down to the CRC (`c40308a8`). The card on the reader was valid and readable; the read of it was not.

The NTAG NDEF-capacity issue from #41 also does not apply to Mifare Classic: it has no Capability Container and no NDEF framing, so there is no second source of truth about usable size.

## Tests

`test/marginal-read.test.ts`, plus a `truncateNextRead()` seam on `FakeChameleon` that simulates a marginal read on both media:

- Mifare and NTAG: a truncated read raises `CardReadError`, not a non-NFAR verdict, and the next read succeeds
- a card misread once is still detected on a re-tap
- a genuinely blank card is still skipped once and not re-read
- a full read of a blank Mifare card still reports `NfarFormatError`

Verified the two key tests fail with the fix neutralised. Full suite: **159 pass, 0 fail**.

Not yet exercised on real hardware — the failure mode is an RF phenomenon the fake only simulates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)