### PR TITLE
feat(webapp): S3 + CloudFront deploy pipeline implementation (Tasks 1-4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,28 @@ jobs:
           name: debug-apk
           path: build/app/outputs/flutter-apk/app-debug.apk
           retention-days: 7
+
+  webapp:
+    name: Web app core (TypeScript)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: webapp/package-lock.json
+
+      - name: Install dependencies
+        working-directory: webapp
+        run: npm ci
+
+      - name: Typecheck and run tests
+        working-directory: webapp
+        # rm -rf dist because the `tsc && node --test` chain does not clean
+        # stale compiled tests.
+        run: rm -rf dist && npm test

--- a/.github/workflows/deploy-webapp.yml
+++ b/.github/workflows/deploy-webapp.yml
@@ -1,0 +1,245 @@
+name: Deploy web app
+
+# Manual only. Never on push or tag.
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Print the S3 sync plan and stop — uploads nothing'
+        type: boolean
+        default: false
+
+# No ambient permissions anywhere. The deploy job opts in to id-token below.
+permissions: {}
+
+concurrency:
+  # Queue, never cancel: a run cancelled mid-sync would leave app/ half-updated.
+  group: deploy-webapp
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build & verify bundle
+    runs-on: ubuntu-latest
+    # This job runs `npm ci`, which executes third-party package code. It holds
+    # no AWS credential, so a compromised dependency cannot reach S3.
+    permissions: {}
+    outputs:
+      sha: ${{ steps.stamp.outputs.sha }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: webapp/package-lock.json
+
+      - name: Install dependencies
+        working-directory: webapp
+        run: npm ci
+
+      - name: Typecheck and run tests
+        working-directory: webapp
+        run: rm -rf dist && npm test
+
+      - name: Compute build stamp
+        id: stamp
+        run: echo "sha=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Build site
+        working-directory: webapp
+        env:
+          BUILD_SHA: ${{ steps.stamp.outputs.sha }}
+        # build-site.ts asserts its own output: non-empty files, the
+        # nfar-build:<sha> banner present, BUILD_SHA substituted, and index.html
+        # still pointing at ./dist/main.js.
+        run: npm run build:site
+
+      - name: Upload deployable site
+        uses: actions/upload-artifact@v7
+        with:
+          name: site
+          path: webapp/site/
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload healthcheck tool
+        # Shipped as its own artifact so the credentialed job can verify the
+        # deploy without checking out the repo or running `npm ci`. The whole
+        # directory goes up because healthcheck.js imports ./build-marker.js.
+        uses: actions/upload-artifact@v7
+        with:
+          name: deploy-tools
+          path: webapp/dist/scripts/
+          if-no-files-found: error
+          retention-days: 7
+
+  deploy:
+    name: Deploy to S3 + CloudFront
+    needs: build
+    runs-on: ubuntu-latest
+    # Zero required reviewers — this exists to pin the OIDC trust policy on
+    # `environment:production` and to restrict deploys to master.
+    environment: production
+    permissions:
+      id-token: write   # mint the OIDC token used to assume the AWS role
+      contents: read
+    env:
+      BUCKET: ${{ vars.S3_BUCKET }}
+      PREFIX: ${{ vars.S3_PREFIX }}
+      DIST_ID: ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }}
+      BASE_URL: ${{ vars.SITE_BASE_URL }}
+      BUILD_SHA: ${{ needs.build.outputs.sha }}
+    steps:
+      - name: Download deployable site
+        uses: actions/download-artifact@v8
+        with:
+          name: site
+          path: site
+
+      - name: Download healthcheck tool
+        uses: actions/download-artifact@v8
+        with:
+          name: deploy-tools
+          path: tools
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
+      - name: Check configuration is present
+        # Fail loudly and early rather than letting an empty variable turn into
+        # `s3:///` or a masked-out path deep in a sync command.
+        run: |
+          set -euo pipefail
+          missing=0
+          for v in BUCKET PREFIX DIST_ID BASE_URL BUILD_SHA; do
+            if [ -z "${!v:-}" ]; then echo "::error::$v is empty — check the repository variables"; missing=1; fi
+          done
+          case "${PREFIX}" in
+            */) ;;
+            *) echo "::error::S3_PREFIX must end with a slash (got '${PREFIX}')"; missing=1 ;;
+          esac
+          [ "$missing" -eq 0 ] || exit 1
+          echo "target s3://${BUCKET}/${PREFIX} | distribution ${DIST_ID} | build ${BUILD_SHA}"
+
+      - name: Assume the AWS deploy role via OIDC
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          role-session-name: gha-webapp-deploy-${{ github.run_id }}
+
+      - name: Show what would be uploaded, then stop
+        if: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          aws s3 sync ./site/ "s3://${BUCKET}/${PREFIX}" --delete --dryrun
+          echo "dry_run: nothing was uploaded."
+
+      - name: Snapshot the live files for rollback
+        id: snapshot
+        if: ${{ !inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          mkdir -p previous
+          aws s3 sync "s3://${BUCKET}/${PREFIX}" ./previous/
+          echo "snapshot taken:"
+          find previous -type f | sort
+
+      - name: Upload assets (long-lived cache)
+        id: upload_assets
+        if: ${{ !inputs.dry_run }}
+        # --delete is confined to ${PREFIX}; it can never consider another
+        # application's keys. index.html is excluded here (and so is exempt from
+        # --delete) because it is uploaded last, with different headers.
+        # The non-HTML tree is JavaScript only today — add a pass if another
+        # asset type ever ships.
+        run: |
+          set -euo pipefail
+          aws s3 sync ./site/ "s3://${BUCKET}/${PREFIX}" \
+            --delete \
+            --exclude 'index.html' \
+            --content-type 'text/javascript; charset=utf-8' \
+            --cache-control 'public, max-age=3600'
+
+      - name: Upload index.html last (no-cache)
+        id: upload_html
+        if: ${{ !inputs.dry_run }}
+        # Written last so the entry point never references a bundle that has not
+        # landed. Explicit content-type: S3's guessing is not trusted here.
+        run: |
+          set -euo pipefail
+          aws s3 cp ./site/index.html "s3://${BUCKET}/${PREFIX}index.html" \
+            --content-type 'text/html; charset=utf-8' \
+            --cache-control 'no-cache'
+
+      - name: Invalidate the app prefix and wait
+        id: invalidate
+        if: ${{ !inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          id=$(aws cloudfront create-invalidation \
+                 --distribution-id "${DIST_ID}" \
+                 --paths "/${PREFIX}*" \
+                 --query 'Invalidation.Id' --output text)
+          echo "invalidation=${id}" >> "$GITHUB_OUTPUT"
+          echo "created invalidation ${id} for /${PREFIX}*"
+          # The healthcheck must not run before propagation finishes, or it
+          # would test the old edge copy and trigger a spurious rollback.
+          aws cloudfront wait invalidation-completed \
+            --distribution-id "${DIST_ID}" --id "${id}"
+          echo "invalidation ${id} completed"
+
+      - name: Verify the live site serves this build
+        id: verify
+        if: ${{ !inputs.dry_run }}
+        run: node tools/healthcheck.js "${BASE_URL}" "${BUILD_SHA}"
+
+      - name: Roll back to the previous version
+        # Runs only when something after the snapshot failed. Guarded on the
+        # snapshot having succeeded — without it there is nothing trustworthy to
+        # restore — and on the upload having at least been attempted.
+        if: ${{ failure() && !inputs.dry_run && steps.snapshot.outcome == 'success' && steps.upload_assets.outcome != 'skipped' }}
+        run: |
+          set -euo pipefail
+          echo "::error::Deploy verification failed — restoring the previous version."
+          # Same two-pass header treatment as a good deploy: a plain sync would
+          # let S3 guess content types and lose the cache policy.
+          aws s3 sync ./previous/ "s3://${BUCKET}/${PREFIX}" \
+            --delete \
+            --exclude 'index.html' \
+            --content-type 'text/javascript; charset=utf-8' \
+            --cache-control 'public, max-age=3600'
+          if [ -f ./previous/index.html ]; then
+            aws s3 cp ./previous/index.html "s3://${BUCKET}/${PREFIX}index.html" \
+              --content-type 'text/html; charset=utf-8' \
+              --cache-control 'no-cache'
+          fi
+          rollback_id=$(aws cloudfront create-invalidation \
+                          --distribution-id "${DIST_ID}" \
+                          --paths "/${PREFIX}*" \
+                          --query 'Invalidation.Id' --output text)
+          aws cloudfront wait invalidation-completed \
+            --distribution-id "${DIST_ID}" --id "${rollback_id}"
+          echo "rolled back; invalidation ${rollback_id} completed"
+
+      - name: Summary
+        if: ${{ always() && !inputs.dry_run }}
+        run: |
+          {
+            echo "### Web app deploy"
+            echo ""
+            echo "| field | value |"
+            echo "|---|---|"
+            echo "| build | \`${BUILD_SHA}\` |"
+            echo "| ref | \`${{ github.ref_name }}\` |"
+            echo "| target | \`s3://${BUCKET}/${PREFIX}\` |"
+            echo "| url | ${BASE_URL} |"
+            echo "| invalidation | \`${{ steps.invalidate.outputs.invalidation || 'n/a' }}\` |"
+            echo "| verify | ${{ steps.verify.outcome || 'did not run' }} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/superpowers/plans/2026-07-30-webapp-s3-deploy-pipeline.md
+++ b/docs/superpowers/plans/2026-07-30-webapp-s3-deploy-pipeline.md
@@ -129,9 +129,10 @@ async function main(): Promise<void> {
     format: 'esm',
     platform: 'browser',
     target: 'es2022',
-    // Deliberately unminified: this matches the bundle shape already validated
-    // on real hardware. Flipping this on is a one-line change later.
-    minify: false,
+    // Minified, matching the bundle that has been validated on real hardware
+    // (the previous hand-built deploy was minified: 177 KB / 22 lines).
+    // Unminified would be the deviation here, not the safe default.
+    minify: true,
     define: { __BUILD_SHA__: JSON.stringify(sha) },
     logLevel: 'info',
   });
@@ -206,16 +207,25 @@ git checkout app/index.html
 
 Expected: fails with `Error: index.html does not reference ./dist/main.js` and `exit=1`. The `git checkout` restores the file — confirm with `git status --short app/index.html` printing nothing.
 
-Then confirm the stamp assertion fires, by building with the `define` disabled:
+Then confirm the stamp assertion fires, by substituting the wrong value. The
+copy must live inside the tree or Node cannot resolve `esbuild`:
 
 ```bash
-node -e "
-const s = require('fs').readFileSync('dist/scripts/build-site.js','utf8');
-require('fs').writeFileSync('/tmp/no-define.js', s.replace('define:', 'defineDISABLED:'));
-" && BUILD_SHA=abc1234 node /tmp/no-define.js; echo "exit=$?"
+sed 's|JSON.stringify(sha)|JSON.stringify("wrong")|' dist/scripts/build-site.js > dist/scripts/bad-define.mjs
+BUILD_SHA=abc1234 node dist/scripts/bad-define.mjs 2>&1 | grep -i Error
+rm -f dist/scripts/bad-define.mjs
 ```
 
-Expected: fails with `bundle does not contain BUILD_SHA "abc1234" — esbuild define did not apply` and `exit=1`. (Removing the key makes esbuild ignore it, so `__BUILD_SHA__` is never substituted — exactly the silent failure this assertion exists to catch.) Clean up with `rm /tmp/no-define.js`.
+Expected: `Error: bundle does not contain BUILD_SHA "abc1234" — esbuild define did not apply`.
+
+(Do **not** try this by renaming the `define:` key — esbuild's JS API rejects
+unknown options outright, so it would fail for the wrong reason.)
+
+Finally, rebuild cleanly so `site/` is not left holding a bad bundle:
+
+```bash
+BUILD_SHA=abc1234 npm run build:site | tail -1
+```
 
 - [ ] **Step 8: Confirm the existing suite still passes**
 

--- a/docs/superpowers/plans/2026-07-30-webapp-s3-deploy-pipeline.md
+++ b/docs/superpowers/plans/2026-07-30-webapp-s3-deploy-pipeline.md
@@ -276,8 +276,19 @@ prove CloudFront is serving this build rather than merely serving something."
 - Create: `webapp/test/healthcheck.test.ts`
 
 **Interfaces:**
-- Consumes: `BUILD_SHA` semantics from Task 1 — the SHA string is present verbatim in the served bundle.
+- Consumes: the build marker from Task 1 — `nfar-build:<sha>`, emitted as an esbuild banner.
 - Produces: `checkOnce(baseUrl: string, expectedSha: string, fetchImpl?: typeof fetch): Promise<CheckResult>`, `healthcheck(baseUrl: string, expectedSha: string, opts?: HealthcheckOptions): Promise<CheckResult>`, `interface CheckResult { ok: boolean; failures: string[] }`, and a CLI: `node dist/scripts/healthcheck.js <baseUrl> <expectedSha>` exiting 0 on healthy, 1 otherwise.
+
+> **Implementation note (deviation from the code listed below).** The listed
+> version searches the served bundle for the bare `expectedSha`. That was
+> implemented, and Step 5's end-to-end check caught it passing a *stale* deploy:
+> the bundle contains hex constants such as `"C82000000000"`, so the 7-character
+> needle `0000000` matched by coincidence. As shipped, the check instead matches
+> the prefixed sentinel `nfar-build:<sha>` emitted by esbuild's `banner` option,
+> with the format defined once in `scripts/build-marker.ts` and imported by both
+> `build-site.ts` and `healthcheck.ts`. A regression test covers the
+> hex-constant collision. Read the shipped files, not the listings below, when
+> touching this logic.
 
 - [ ] **Step 1: Write the failing test**
 

--- a/docs/superpowers/specs/2026-07-30-webapp-s3-deploy-design.md
+++ b/docs/superpowers/specs/2026-07-30-webapp-s3-deploy-design.md
@@ -110,9 +110,11 @@ site/
 
 - `bundle: true`, `format: 'esm'`, `platform: 'browser'`
 - `define: { __BUILD_SHA__: JSON.stringify(process.env.BUILD_SHA ?? 'dev') }`
-- **No minification.** The current bundle is unminified and is what has been
-  validated on real hardware; keeping the output shape unchanged removes a
-  variable from the first automated deploys. It is a one-line toggle later.
+- **Minified** (`minify: true`), matching the hand-built bundle already deployed
+  and validated on real hardware — that one is minified (176,813 B across 22
+  lines). An unminified build would be the deviation: it comes out at 296,772 B,
+  68% larger. With minification on, the reproducible build lands within 21 bytes
+  of the deployed artifact, the delta being exactly the added SHA stamp.
 - Output directory `webapp/site/` is gitignored.
 
 `index.html` is copied verbatim, unmodified. It already references
@@ -375,7 +377,6 @@ fixes only where they live.
 
 - Content-hashed asset filenames and long-lived immutable caching.
 - Staging or preview environments.
-- Bundle minification.
 - Any change to NFAR format, transports, or app behaviour.
 - Creating or reconfiguring the S3 bucket, CloudFront distribution, ACM
   certificate, or DNS — all already exist.

--- a/docs/superpowers/specs/2026-07-30-webapp-s3-deploy-design.md
+++ b/docs/superpowers/specs/2026-07-30-webapp-s3-deploy-design.md
@@ -206,7 +206,18 @@ rather than just the origin:
 
 1. `GET /app/` → 200 and `content-type` starts with `text/html`
 2. `GET /app/dist/main.js` → 200 and `content-type` contains `javascript`
-3. the body of `main.js` **contains `<expectedSha>`**
+3. the body of `main.js` **contains the build marker `nfar-build:<expectedSha>`**
+
+Check 3 matches a **prefixed sentinel, not the bare SHA**. Searching for the raw
+SHA was tried first and is unsafe: the bundle is full of hex string constants
+(CRC tables, APDU literals such as `"C82000000000"`), so a 7-hex-character
+needle can match by coincidence — `0000000` genuinely occurs in an unrelated
+constant, and the healthcheck passed a stale deploy as a result. The marker is
+emitted by esbuild's `banner` option, which is written verbatim and survives
+both minification and tree-shaking, so it is present regardless of whether any
+application code references `BUILD_SHA`. Its format lives in one place,
+`scripts/build-marker.ts`, imported by both the writer and the reader so the two
+cannot drift.
 
 Requests send `Cache-Control: no-cache`. Each check retries with exponential
 backoff for up to ~60 s to absorb residual edge propagation, then fails.
@@ -216,8 +227,11 @@ misconfigured content type; only check 3 distinguishes "the deploy worked" from
 "an older version is still being served".
 
 Unit tests cover the script against a local `http.createServer` stub: a passing
-case, a wrong-SHA case, and a non-200 case. A healthcheck that mis-fires
-triggers a needless rollback, so its own logic is worth testing.
+case, a wrong-marker case, a non-200 case, the backoff schedule, and a
+regression case asserting that a SHA appearing only inside an unrelated hex
+constant does **not** satisfy the check. A healthcheck that mis-fires either
+triggers a needless rollback or — worse, as the bare-SHA search did — waves a
+stale deploy through, so its own logic is worth testing.
 
 ## Rollback
 

--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 app/dist/
+site/

--- a/webapp/app/ui/about-panel.ts
+++ b/webapp/app/ui/about-panel.ts
@@ -1,9 +1,9 @@
 /** About tab: description, supported tags (web-accurate), version, licenses, privacy. */
-import { APP_VERSION } from '../version.js';
+import { APP_VERSION, BUILD_SHA } from '../version.js';
 
 const SECTIONS: Array<{ h: string; body: string[] }> = [
   { h: 'NFC Archiver', body: [
-    `Web version ${APP_VERSION}`,
+    `Web version ${APP_VERSION} (${BUILD_SHA})`,
     'A distributed data archive system using NFC tags. Store files across multiple tags and restore them later — fully in your browser.',
   ] },
   { h: 'Supported tags', body: [

--- a/webapp/app/version.ts
+++ b/webapp/app/version.ts
@@ -1,2 +1,12 @@
 /** Web app version, shown in the About tab. Bump on release. */
 export const APP_VERSION = '0.1.0';
+
+/**
+ * Commit SHA substituted at build time by scripts/build-site.ts via esbuild
+ * `define`. Falls back to 'dev' when nothing substituted it — under
+ * `npm run app` or `node --test`. `typeof` on an identifier that does not exist
+ * at runtime is safe (it does not throw), which is what makes the fallback work
+ * without polluting the global scope with a declaration.
+ */
+declare const __BUILD_SHA__: string | undefined;
+export const BUILD_SHA: string = typeof __BUILD_SHA__ === 'undefined' ? 'dev' : __BUILD_SHA__;

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
+    "build:site": "tsc && node dist/scripts/build-site.js",
     "test": "tsc && node --test 'dist/test/**/*.test.js'",
     "fixtures": "tsc && node dist/test/write_ts_fixtures.js",
     "app": "esbuild app/main.ts --bundle --format=esm --outdir=app/dist --servedir=app --serve=localhost:8000"

--- a/webapp/scripts/build-marker.ts
+++ b/webapp/scripts/build-marker.ts
@@ -1,0 +1,14 @@
+/**
+ * The single definition of the build sentinel, shared by the writer
+ * (build-site.ts) and the reader (healthcheck.ts) so the two cannot drift.
+ *
+ * Why a prefixed sentinel rather than searching the bundle for the bare SHA:
+ * the bundle is full of hex string constants (CRC tables, APDU literals such as
+ * "C82000000000"), so a 7-hex-character needle can match by pure coincidence. A
+ * SHA of 0000000 really does appear in an unrelated constant. A false match
+ * means the healthcheck passes a stale deploy — the exact failure it exists to
+ * catch — so the needle must be something that cannot occur by accident.
+ */
+export function buildMarker(sha: string): string {
+  return `nfar-build:${sha}`;
+}

--- a/webapp/scripts/build-site.ts
+++ b/webapp/scripts/build-site.ts
@@ -1,0 +1,63 @@
+/**
+ * Production build: bundles app/main.ts and stages a deployable site/ tree.
+ * Run via `npm run build:site`, which compiles this file to
+ * dist/scripts/build-site.js first.
+ *
+ * The commit SHA from BUILD_SHA is stamped into the bundle so that a deploy can
+ * be verified end to end — see scripts/healthcheck.ts. The script asserts its
+ * own output before exiting, so a bundle that lost its stamp or its entry-point
+ * reference can never reach S3.
+ */
+import { build } from 'esbuild';
+import { copyFile, mkdir, readFile, rm } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// This file runs as dist/scripts/build-site.js, so webapp/ is two levels up.
+const webappRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const outDir = join(webappRoot, 'site');
+
+async function main(): Promise<void> {
+  const sha = process.env.BUILD_SHA ?? 'dev';
+
+  await rm(outDir, { recursive: true, force: true });
+  await mkdir(join(outDir, 'dist'), { recursive: true });
+
+  await build({
+    entryPoints: [join(webappRoot, 'app', 'main.ts')],
+    outfile: join(outDir, 'dist', 'main.js'),
+    bundle: true,
+    format: 'esm',
+    platform: 'browser',
+    target: 'es2022',
+    // Minified, matching the bundle that has been validated on real hardware
+    // (the previous hand-built deploy was minified: 177 KB / 22 lines).
+    // Unminified would be the deviation here, not the safe default.
+    minify: true,
+    define: { __BUILD_SHA__: JSON.stringify(sha) },
+    logLevel: 'info',
+  });
+
+  // index.html is copied verbatim. It references ./dist/main.js relatively, so
+  // the site/ tree is self-contained and position-independent — which is what
+  // makes it safe to copy to a prefix and to restore from a snapshot.
+  await copyFile(join(webappRoot, 'app', 'index.html'), join(outDir, 'index.html'));
+
+  const bundle = await readFile(join(outDir, 'dist', 'main.js'), 'utf8');
+  const html = await readFile(join(outDir, 'index.html'), 'utf8');
+  if (bundle.length === 0) throw new Error('bundle is empty');
+  if (html.length === 0) throw new Error('index.html is empty');
+  if (!bundle.includes(sha)) {
+    throw new Error(`bundle does not contain BUILD_SHA "${sha}" — esbuild define did not apply`);
+  }
+  if (!html.includes('./dist/main.js')) {
+    throw new Error('index.html does not reference ./dist/main.js');
+  }
+
+  console.log(`site/ built and verified — BUILD_SHA=${sha}, bundle ${bundle.length} B`);
+}
+
+main().catch((e: unknown) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/webapp/scripts/build-site.ts
+++ b/webapp/scripts/build-site.ts
@@ -12,6 +12,7 @@ import { build } from 'esbuild';
 import { copyFile, mkdir, readFile, rm } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { buildMarker } from './build-marker.js';
 
 // This file runs as dist/scripts/build-site.js, so webapp/ is two levels up.
 const webappRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
@@ -19,6 +20,7 @@ const outDir = join(webappRoot, 'site');
 
 async function main(): Promise<void> {
   const sha = process.env.BUILD_SHA ?? 'dev';
+  const marker = buildMarker(sha);
 
   await rm(outDir, { recursive: true, force: true });
   await mkdir(join(outDir, 'dist'), { recursive: true });
@@ -35,6 +37,10 @@ async function main(): Promise<void> {
     // Unminified would be the deviation here, not the safe default.
     minify: true,
     define: { __BUILD_SHA__: JSON.stringify(sha) },
+    // The sentinel the healthcheck greps for. A banner is emitted verbatim and
+    // is immune to minification and tree-shaking, so it is present whether or
+    // not any application code happens to reference BUILD_SHA.
+    banner: { js: `/* ${marker} */` },
     logLevel: 'info',
   });
 
@@ -47,6 +53,9 @@ async function main(): Promise<void> {
   const html = await readFile(join(outDir, 'index.html'), 'utf8');
   if (bundle.length === 0) throw new Error('bundle is empty');
   if (html.length === 0) throw new Error('index.html is empty');
+  if (!bundle.includes(marker)) {
+    throw new Error(`bundle does not contain the build marker "${marker}" — the esbuild banner did not apply`);
+  }
   if (!bundle.includes(sha)) {
     throw new Error(`bundle does not contain BUILD_SHA "${sha}" — esbuild define did not apply`);
   }
@@ -54,7 +63,7 @@ async function main(): Promise<void> {
     throw new Error('index.html does not reference ./dist/main.js');
   }
 
-  console.log(`site/ built and verified — BUILD_SHA=${sha}, bundle ${bundle.length} B`);
+  console.log(`site/ built and verified — ${marker}, bundle ${bundle.length} B`);
 }
 
 main().catch((e: unknown) => {

--- a/webapp/scripts/healthcheck.ts
+++ b/webapp/scripts/healthcheck.ts
@@ -1,0 +1,117 @@
+/**
+ * Post-deploy verification. Fetches the live site through its PUBLIC url — so
+ * DNS, CloudFront and S3 are all exercised, not just the origin — and asserts
+ * it is serving the bundle this run built.
+ *
+ *   node dist/scripts/healthcheck.js https://nfcarchiver.com/app/ <sha>
+ *
+ * A 200 only proves S3 holds something. The SHA match is the load-bearing
+ * check: it proves the bundle is THIS build and that no edge is still serving
+ * the previous one. That matters doubly with an S3 static-website origin, which
+ * answers a missing key with the bucket's error document rather than nothing —
+ * so both the content-type check and the SHA check guard against HTML being
+ * served where JavaScript belongs.
+ */
+import { pathToFileURL } from 'node:url';
+import { buildMarker } from './build-marker.js';
+
+export interface CheckResult {
+  ok: boolean;
+  failures: string[];
+}
+
+export interface HealthcheckOptions {
+  attempts?: number;
+  firstDelayMs?: number;
+  fetchImpl?: typeof fetch;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const NO_CACHE: Record<string, string> = { 'cache-control': 'no-cache', pragma: 'no-cache' };
+
+/** One full pass. Collects every failure rather than stopping at the first, so
+ *  a failing deploy reports everything wrong with it in one log. */
+export async function checkOnce(
+  baseUrl: string,
+  expectedSha: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<CheckResult> {
+  const failures: string[] = [];
+  const base = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+  const bundleUrl = new URL('dist/main.js', base).toString();
+
+  const html = await fetchImpl(base, { headers: NO_CACHE, redirect: 'follow' });
+  if (html.status !== 200) failures.push(`GET ${base} -> ${html.status} (want 200)`);
+  const htmlType = html.headers.get('content-type') ?? '';
+  if (!htmlType.includes('text/html')) {
+    failures.push(`GET ${base} content-type "${htmlType}" (want text/html)`);
+  }
+
+  const js = await fetchImpl(bundleUrl, { headers: NO_CACHE, redirect: 'follow' });
+  if (js.status !== 200) failures.push(`GET ${bundleUrl} -> ${js.status} (want 200)`);
+  const jsType = js.headers.get('content-type') ?? '';
+  if (!jsType.includes('javascript')) {
+    failures.push(`GET ${bundleUrl} content-type "${jsType}" (want javascript)`);
+  }
+  if (js.status === 200) {
+    const body = await js.text();
+    // Match the prefixed sentinel, never the bare SHA — see build-marker.ts for
+    // why a 7-hex-character needle can match an unrelated constant.
+    const marker = buildMarker(expectedSha);
+    if (!body.includes(marker)) {
+      failures.push(`served bundle does not carry the build marker ${marker} — an older version is still live`);
+    }
+  }
+
+  return { ok: failures.length === 0, failures };
+}
+
+/** Retry with exponential backoff to absorb residual CloudFront propagation.
+ *  Defaults total ~62s across 6 attempts. */
+export async function healthcheck(
+  baseUrl: string,
+  expectedSha: string,
+  opts: HealthcheckOptions = {},
+): Promise<CheckResult> {
+  const attempts = opts.attempts ?? 6;
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  let delay = opts.firstDelayMs ?? 2000;
+  let last: CheckResult = { ok: false, failures: ['no attempt was made'] };
+
+  for (let i = 1; i <= attempts; i++) {
+    try {
+      last = await checkOnce(baseUrl, expectedSha, fetchImpl);
+    } catch (e: unknown) {
+      last = { ok: false, failures: [`request failed: ${String(e)}`] };
+    }
+    if (last.ok) return last;
+    if (i < attempts) {
+      console.error(`attempt ${i}/${attempts} failed:`);
+      for (const f of last.failures) console.error(`  - ${f}`);
+      console.error(`retrying in ${delay}ms`);
+      await sleep(delay);
+      delay *= 2;
+    }
+  }
+  return last;
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedDirectly) {
+  const [baseUrl, expectedSha] = process.argv.slice(2);
+  if (!baseUrl || !expectedSha) {
+    console.error('usage: node dist/scripts/healthcheck.js <baseUrl> <expectedSha>');
+    process.exit(2);
+  }
+  const result = await healthcheck(baseUrl, expectedSha);
+  if (result.ok) {
+    console.log(`healthy: ${baseUrl} is serving build ${expectedSha}`);
+    process.exit(0);
+  }
+  console.error('UNHEALTHY:');
+  for (const f of result.failures) console.error(`  - ${f}`);
+  process.exit(1);
+}

--- a/webapp/test/healthcheck.test.ts
+++ b/webapp/test/healthcheck.test.ts
@@ -1,0 +1,91 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer, type Server } from 'node:http';
+import { checkOnce, healthcheck } from '../scripts/healthcheck.js';
+import { buildMarker } from '../scripts/build-marker.js';
+
+const SHA = 'abc1234';
+const HTML = '<!doctype html><html><body>ok</body></html>';
+/** What build-site.ts emits as its esbuild banner. */
+const stamped = (sha: string) => `/* ${buildMarker(sha)} */\nconsole.log("app");`;
+
+/** Serve a fake deployed site; `bundle` and `jsStatus` are the knobs under test. */
+async function serve(opts: { bundle: string; jsStatus?: number }): Promise<{ base: string; close: () => Promise<void> }> {
+  const server: Server = createServer((req, res) => {
+    if (req.url === '/app/dist/main.js') {
+      const status = opts.jsStatus ?? 200;
+      res.writeHead(status, { 'content-type': 'text/javascript; charset=utf-8' });
+      res.end(status === 200 ? opts.bundle : 'not found');
+      return;
+    }
+    if (req.url === '/app/' || req.url === '/app/index.html') {
+      res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+      res.end(HTML);
+      return;
+    }
+    res.writeHead(404, { 'content-type': 'text/plain' });
+    res.end('nope');
+  });
+  await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+  const port = (server.address() as { port: number }).port;
+  return {
+    base: `http://127.0.0.1:${port}/app/`,
+    close: () => new Promise<void>((r) => server.close(() => r())),
+  };
+}
+
+test('healthy deploy: 200s, right content types, bundle carries the build marker', async () => {
+  const s = await serve({ bundle: stamped(SHA) });
+  try {
+    const r = await checkOnce(s.base, SHA);
+    assert.deepEqual(r.failures, []);
+    assert.equal(r.ok, true);
+  } finally { await s.close(); }
+});
+
+test('stale edge: bundle carrying a different build marker fails', async () => {
+  const s = await serve({ bundle: stamped('0000000') });
+  try {
+    const r = await checkOnce(s.base, SHA);
+    assert.equal(r.ok, false);
+    assert.ok(r.failures.some((f) => f.includes(SHA)), `expected a marker failure, got ${JSON.stringify(r.failures)}`);
+  } finally { await s.close(); }
+});
+
+test('a bare SHA occurring inside an unrelated constant is NOT a match', async () => {
+  // Regression: the real bundle contains hex literals such as "C82000000000",
+  // so searching for a bare 7-hex-character SHA matched by coincidence and
+  // passed a stale deploy. Only the prefixed marker may satisfy the check.
+  const s = await serve({ bundle: `/* ${buildMarker('0000000')} */\nl.from("C82000000000","hex");` });
+  try {
+    const r = await checkOnce(s.base, '0000000');
+    assert.equal(r.ok, true, 'the correctly-stamped bundle must pass');
+
+    const stale = await checkOnce(s.base, '2000000'); // appears inside C82000000000
+    assert.equal(stale.ok, false, 'a SHA present only inside an unrelated constant must NOT pass');
+    assert.ok(stale.failures.some((f) => f.includes('build marker')));
+  } finally { await s.close(); }
+});
+
+test('missing bundle: a non-200 on main.js fails', async () => {
+  const s = await serve({ bundle: '', jsStatus: 404 });
+  try {
+    const r = await checkOnce(s.base, SHA);
+    assert.equal(r.ok, false);
+    assert.ok(r.failures.some((f) => f.includes('404')), `expected a 404 failure, got ${JSON.stringify(r.failures)}`);
+  } finally { await s.close(); }
+});
+
+test('healthcheck retries a failing check and reports the last result', async () => {
+  const s = await serve({ bundle: stamped('0000000') });
+  const slept: number[] = [];
+  try {
+    const r = await healthcheck(s.base, SHA, {
+      attempts: 3,
+      firstDelayMs: 10,
+      sleep: async (ms) => { slept.push(ms); },
+    });
+    assert.equal(r.ok, false);
+    assert.deepEqual(slept, [10, 20], 'should back off between attempts, not after the last');
+  } finally { await s.close(); }
+});

--- a/webapp/tsconfig.json
+++ b/webapp/tsconfig.json
@@ -10,5 +10,5 @@
     "rootDir": ".",
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts", "app/**/*.ts", "test/**/*.ts"]
+  "include": ["src/**/*.ts", "app/**/*.ts", "test/**/*.ts", "scripts/**/*.ts"]
 }


### PR DESCRIPTION
Follow-up to #43, which merged at head `b5085e9` — the spec and plan only. These four implementation commits landed on the branch after that point and so were not included. `b5085e9` is already an ancestor of master, so this PR shows exactly the missing work.

## Commits

| | |
|---|---|
| `9a9ce0a` | `build:site` production build + commit-SHA stamp |
| `c2946cb` | post-deploy healthcheck |
| `07fd5a1` | webapp job in `ci.yml` |
| `d2c5693` | the deploy workflow |

## What this adds

- **`webapp/scripts/build-site.ts`** — the first reproducible production build. Bundles `app/main.ts` into a self-contained `site/` tree and asserts its own output before exiting: non-empty files, the build marker present, `BUILD_SHA` substituted, and `index.html` still referencing `./dist/main.js`. Both assertions were verified to fire.
- **`webapp/scripts/healthcheck.ts`** + 5 tests — fetches the live site through its public URL and requires the served bundle to carry this build's marker.
- **`webapp/scripts/build-marker.ts`** — the sentinel format, in one place, imported by both writer and reader.
- **`ci.yml`** gains a `webapp` job, so the Node suite gates PRs for the first time.
- **`.github/workflows/deploy-webapp.yml`** — `workflow_dispatch` only, OIDC credentials, prefix-bound sync and invalidation, snapshot-based auto-rollback.

## Two bugs the verification steps caught

**1. The healthcheck passed a stale deploy.** Searching the served bundle for the bare commit SHA shipped with green unit tests, then the end-to-end check with a deliberately wrong SHA (`0000000`) returned *healthy*. The bundle contains `"C82000000000"`, a Chameleon APDU constant — a 7-hex-character needle collides with hex literals, of which a minified NFC bundle has many. A false pass defeats the entire purpose of the check, so the needle is now the prefixed sentinel `nfar-build:<sha>`, emitted via esbuild's `banner` (verbatim, immune to minification and tree-shaking). A regression test pins the collision.

**2. Minification.** The spec and plan claimed the deployed bundle was unminified and that matching it preserved what had been hardware-validated. It is minified — 176,813 B across 22 lines with mangled identifiers — so unminified was the deviation, and came out 68% larger. With `minify: true` the reproducible build lands 21 bytes from the deployed artifact, the delta being exactly the added stamp. Corrected in code and in both documents.

## Beyond the plan

- A **pre-flight configuration check** in the deploy job, rejecting empty variables and an `S3_PREFIX` missing its trailing slash, so a misconfiguration reports itself instead of becoming an `s3:///` path inside a sync command.
- The healthcheck artifact ships the whole `dist/scripts/` directory, since `healthcheck.js` imports `./build-marker.js` — uploading the single file would have failed at runtime mid-deploy. Verified by running the artifact layout standalone outside the repo with no `node_modules`.

## Testing

159 tests pass, 0 fail. Build verified end to end: `site/ built and verified — nfar-build:07fd5a1, bundle 176859 B`, healthcheck exits 0 on a correct stamp and 1 on a stale one.

Not yet run against real AWS — that is the dry run, next.

Remaining from the plan: Task 5 (README/CLAUDE.md, delete the hand-made `webapp/s3-upload/`) and the rollback drill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)