### PR TITLE
fix(webapp): invalidate the NDEF TLV before rewriting an NTAG chunk

### DIFF
--- a/webapp/src/transport/ntag-transport.ts
+++ b/webapp/src/transport/ntag-transport.ts
@@ -128,14 +128,26 @@ export class NtagTransport implements Transport {
     const padded = new Uint8Array(Math.ceil(tlv.length / 4) * 4);
     padded.set(tlv);
     const pageCount = padded.length / 4;
-    for (let p = 0; p < pageCount; p++) {
-      // NTAG WRITE returns a 4-bit ACK/NAK with no CRC, so checkResponseCrc is
-      // intentionally omitted here (unlike the READ/GET_VERSION transceives above).
-      await this.device.transceive14a(
-        new Uint8Array([0xa2, NDEF_START_PAGE + p, ...padded.subarray(p * 4, p * 4 + 4)]),
+    // NTAG WRITE returns a 4-bit ACK/NAK with no CRC, so checkResponseCrc is
+    // intentionally omitted here (unlike the READ/GET_VERSION transceives above).
+    const writePage = (p: number, four: Uint8Array): Promise<Uint8Array> =>
+      this.device.transceive14a(
+        new Uint8Array([0xa2, NDEF_START_PAGE + p, ...four]),
         { autoSelect: true, appendCrc: true },
       );
+
+    // Invalidate, body, then header — never header first. If the card leaves the
+    // field partway through, it is left announcing an EMPTY NDEF message rather
+    // than a full-length record over bytes that were never written: Android
+    // rejects the latter outright as "not NDEF", which reads to the user as a
+    // dead card. Page 4 is rewritten last because it carries the TLV length (and,
+    // for a short-form TLV, the first record bytes too), so it is the single
+    // write that makes the record readable.
+    await writePage(0, new Uint8Array([0x03, 0x00, 0x00, 0x00]));
+    for (let p = 1; p < pageCount; p++) {
+      await writePage(p, padded.subarray(p * 4, p * 4 + 4));
     }
+    await writePage(0, padded.subarray(0, 4));
     // Read-back verify.
     const readBack = await this.readMemory(NDEF_START_PAGE, padded.length);
     if (!bytesEqual(readBack, padded)) throw new WriteVerifyError('NTAG read-back does not match written pages');

--- a/webapp/test/fake-chameleon.ts
+++ b/webapp/test/fake-chameleon.ts
@@ -25,6 +25,7 @@ export class FakeChameleon implements ChameleonDevice {
   private field: string | null = null;
   private corruptNext = false;
   private truncateNext: number | null = null;
+  private failWriteIn: number | null = null;
   private readonly cards = new Map<string, Card>();
 
   defineCard(uid: Uint8Array, opts?: { keyA?: Uint8Array; sak?: number }): void {
@@ -65,8 +66,16 @@ export class FakeChameleon implements ChameleonDevice {
   truncateNextRead(keepBytes = 4): void {
     this.truncateNext = keepBytes;
   }
+  /** Simulate the card leaving the field partway through a multi-page write:
+   *  the next `afterWrites` page writes succeed, the one after that throws. */
+  failWriteAfter(afterWrites: number): void {
+    this.failWriteIn = afterWrites;
+  }
   blockOf(uid: Uint8Array, block: number): Uint8Array {
     return this.cards.get(hex(uid))!.image.slice(block * 16, block * 16 + 16);
+  }
+  pageOf(uid: Uint8Array, page: number): Uint8Array {
+    return this.cards.get(hex(uid))!.ntag!.pages.slice(page * 4, page * 4 + 4);
   }
 
   isConnected(): boolean {
@@ -106,6 +115,13 @@ export class FakeChameleon implements ChameleonDevice {
       return full;
     }
     if (cmd === 0xa2) { // WRITE one page
+      if (this.failWriteIn !== null) {
+        if (this.failWriteIn === 0) {
+          this.failWriteIn = null;
+          throw new CardAuthError('Card left the field mid-write');
+        }
+        this.failWriteIn -= 1;
+      }
       const page = data[1]!;
       ntag.pages.set(data.subarray(2, 6), page * 4);
       return new Uint8Array([0x0a]); // ACK

--- a/webapp/test/ntag-transport.test.ts
+++ b/webapp/test/ntag-transport.test.ts
@@ -97,6 +97,35 @@ test('a full-size chunk stays within the CC-declared NDEF area so Android can re
   assert.deepEqual(await t.readChunk(), full);
 });
 
+test('an interrupted write leaves an empty NDEF TLV, never a stale length over new bytes', async () => {
+  const device = new FakeChameleon();
+  const t = new NtagTransport(device, { pollMs: 1, defaultTimeoutMs: 500 });
+  await t.connect();
+  const uid = new Uint8Array([0x04, 7, 7, 7, 7, 7, 7]);
+  device.placeNtag(uid, NtagType.NTAG215);
+  await t.awaitTag();
+
+  // A card that already holds a complete, valid chunk.
+  await t.writeChunk(chunkBytes(200));
+  device.placeNtag(uid, NtagType.NTAG215);
+  await t.awaitTag();
+  assert.equal(await t.peekIsNfar(), true);
+
+  // Now the card leaves the field a few pages into overwriting it.
+  device.placeNtag(uid, NtagType.NTAG215);
+  await t.awaitTag();
+  device.failWriteAfter(3);
+  await assert.rejects(() => t.writeChunk(chunkBytes(200)));
+
+  // The TLV header must declare a ZERO-length NDEF message. Writing the real
+  // header first would leave a card announcing a full-length record over bytes
+  // that were never finished — which is what Android rejects outright as "not
+  // NDEF", with no way for the user to tell a half-written card from a dead one.
+  const header = device.pageOf(uid, 4);
+  assert.equal(header[0], 0x03, 'NDEF TLV tag must survive');
+  assert.equal(header[1], 0x00, 'TLV length must read as empty, not the new chunk length');
+});
+
 test('a chunk larger than the tag capacity is rejected', async () => {
   const device = new FakeChameleon();
   const t = new NtagTransport(device, { pollMs: 1, defaultTimeoutMs: 500 });


### PR DESCRIPTION
Third of three fixes from the NTAG interop investigation (two card dumps compared, webapp/Chameleon-written vs Android-written). This is the webapp half; the two Flutter fixes follow in a separate PR.

## The bug

`writeChunk` wrote page 4 — the TLV header — **before** any body page. Between that write and the last one, the card announces the new chunk's full length over bytes that were never written.

If the card leaves the field in that window, it is left declaring a valid-length NDEF record over stale content. Android's NDEF detection can't parse an `NdefMessage` out of it, so the `Ndef` tech is never attached to the tag and `Ndef.from(tag)` returns null — which the Flutter app reports as `"Tag does not support NDEF. Please use a pre-formatted NDEF tag."` That reads as a dead card, not a retryable one.

The read-back verify at the end of `writeChunk` catches the failure, but only *after* the header is already committed on the tag, so it cannot prevent this state.

## The fix

Invalidate, body, header:

1. write page 4 as an empty NDEF TLV (`03 00 …`)
2. write the body pages
3. write the real header last

An interrupted write now leaves a well-formed **empty** NDEF tag, which reads as blank and can simply be rewritten. Page 4 goes last because it carries the TLV length and — for a short-form TLV, which is what NTAG213-sized chunks use — the first record bytes too, so it is the single write that makes the record readable. That is why "body first, header last" alone would not have been enough: the TLV header is not page-aligned at every chunk size.

Costs one extra page write per chunk, out of roughly 120.

## Tests

New test in `ntag-transport.test.ts` writes a valid chunk, then interrupts an overwrite three pages in via a new `FakeChameleon.failWriteAfter()` hook, and asserts the TLV length byte reads `0x00`. Before the fix it reads `0xFF` — the long-form length marker, written before the body existed.

223 tests pass (`rm -rf dist && npm test`).

## Note on scope

This removes a structural failure mode. It is **not** confirmed to be the cause of the original one-off incident — that card was never retested, and the leading hypothesis for it remains a transient NDEF-detection failure at tap, addressed by the error-framing fix in the Flutter PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)