### PR TITLE
fix: NDEF terminator reserve and honest "not NDEF" reporting

### DIFF
--- a/lib/core/constants/nfar_format.dart
+++ b/lib/core/constants/nfar_format.dart
@@ -144,7 +144,16 @@ enum NfcTagType {
     // NFAR format overhead
     const nfarOverhead = NfarHeaderSize.total; // 32 bytes (28 header + 4 CRC)
 
-    final payload = ndefCapacity - ndefRecordOverhead - nfarOverhead;
+    // The NFC Forum Type-2 spec terminates the TLV area with a 0xFE byte, which
+    // shares the NDEF data area with the message. Android's ndef.maxSize does
+    // NOT reserve it, so filling the reported capacity exactly leaves no room
+    // and the terminator is silently dropped — producing a non-conformant tag
+    // one byte over-full. Reserving it here also makes this match the web app's
+    // chunkPayloadForCapacity(), so cards written by either app are identical.
+    const terminatorTlv = 1;
+
+    final payload =
+        ndefCapacity - ndefRecordOverhead - nfarOverhead - terminatorTlv;
     return payload > 0 ? payload : 0;
   }
 

--- a/lib/features/nfc/data/nfc_repository.dart
+++ b/lib/features/nfc/data/nfc_repository.dart
@@ -5,6 +5,7 @@ import 'package:nfc_manager/nfc_manager.dart';
 import '../../../core/constants/nfar_format.dart';
 import '../../../core/models/chunk.dart';
 import '../../../core/models/nfc_tag_info.dart';
+import '../domain/ndef_availability.dart';
 import '../domain/ndef_formatter.dart';
 
 /// Repository for NFC operations.
@@ -78,7 +79,7 @@ class NfcRepository {
 
           final ndef = Ndef.from(tag);
           if (ndef == null) {
-            onError('Tag does not support NDEF');
+            onError(messageFor(_ndefUnavailableReason(tag)));
             return;
           }
 
@@ -138,7 +139,7 @@ class NfcRepository {
           final ndef = Ndef.from(tag);
 
           if (ndef == null) {
-            onError('Tag does not support NDEF. Please use a pre-formatted NDEF tag.');
+            onError(messageFor(_ndefUnavailableReason(tag)));
             return;
           }
 
@@ -290,6 +291,18 @@ class NfcRepository {
     NfcManager.instance.stopSession(
       alertMessage: message,
       errorMessage: null,
+    );
+  }
+
+  /// Why this tag came back without the `Ndef` technology.
+  ///
+  /// The techs the platform *did* attach are the evidence: an `NfcA` or
+  /// `MifareUltralight` tag whose NDEF detection failed is a good tag that was
+  /// tapped badly, not one the user needs to replace.
+  NdefUnavailableReason _ndefUnavailableReason(NfcTag tag) {
+    return classifyNdefUnavailable(
+      hasNfcA: tag.data['nfca'] != null,
+      hasMifareUltralight: tag.data['mifareultralight'] != null,
     );
   }
 

--- a/lib/features/nfc/domain/ndef_availability.dart
+++ b/lib/features/nfc/domain/ndef_availability.dart
@@ -1,0 +1,45 @@
+/// Explains why a discovered tag exposed no NDEF technology.
+///
+/// On Android the `Ndef` tech is attached to a tag only if the platform's NFC
+/// service completed NDEF detection during discovery: read the capability
+/// container, walk the TLVs, and parse the `NdefMessage`. Detecting a full
+/// NTAG215 takes ~31 READ commands, so a brief or badly-coupled tap aborts the
+/// walk on a perfectly good tag. The tag then surfaces with only `NfcA` /
+/// `MifareUltralight`, `Ndef.from(tag)` returns null, and the two conditions
+/// are indistinguishable at that call site — which is why both used to be
+/// reported as "use a pre-formatted NDEF tag", a permanent-sounding message for
+/// what is usually a retry.
+library;
+
+enum NdefUnavailableReason {
+  /// The tag exposes NFC-A technology, so it is a real tag the reader talked
+  /// to — NDEF detection simply did not finish. Retrying the tap usually works.
+  detectionFailed,
+
+  /// No NFC-A technology at all: nothing we can write an NDEF message to.
+  notNdefFormatted,
+}
+
+/// Classify a tag that came back without the `Ndef` technology.
+NdefUnavailableReason classifyNdefUnavailable({
+  required bool hasNfcA,
+  required bool hasMifareUltralight,
+}) {
+  return hasNfcA || hasMifareUltralight
+      ? NdefUnavailableReason.detectionFailed
+      : NdefUnavailableReason.notNdefFormatted;
+}
+
+/// User-facing text for [reason].
+///
+/// English-only for now: errors reach the UI as plain strings through
+/// `NfcSessionError.message`, so localizing them needs a typed error code and a
+/// UI-side mapping across the whole NFC error surface, not just these two.
+String messageFor(NdefUnavailableReason reason) {
+  switch (reason) {
+    case NdefUnavailableReason.detectionFailed:
+      return "Couldn't read the tag — hold it still against the phone and try again.";
+    case NdefUnavailableReason.notNdefFormatted:
+      return 'Tag does not support NDEF. Please use a pre-formatted NDEF tag.';
+  }
+}

--- a/lib/features/nfc/domain/ndef_formatter.dart
+++ b/lib/features/nfc/domain/ndef_formatter.dart
@@ -100,43 +100,6 @@ class NdefFormatter {
     return 1 + 1 + lengthBytes + typeSize + payloadSize;
   }
 
-  /// Calculate the maximum payload size that will fit in a given NDEF capacity.
-  ///
-  /// This accounts for all NDEF overhead:
-  /// - NDEF record header (flags, type length, payload length)
-  /// - MIME type string
-  /// - NFAR header and CRC
-  int maxPayloadForNdefCapacity(int ndefCapacity) {
-    // NDEF record overhead:
-    // - 1 byte: flags/type name format
-    // - 1 byte: type length
-    // - 1 byte: ID length (usually 0, but we account for structure)
-    // - N bytes: type (MIME type string = 33 bytes for our type)
-    const mimeTypeLength = 33; // "application/vnd.nfcarchiver.chunk"
-    const ndefHeaderBase = 3; // flags + type length + payload length (short)
-    const ndefHeaderLong = 6; // flags + type length + 4-byte payload length
-
-    // NFAR overhead per chunk
-    const nfarOverhead = NfarHeaderSize.total; // 28 bytes header + 4 CRC = 32
-
-    // Try short record format first (payload < 256)
-    // Available = ndefCapacity - ndefHeader - mimeType - nfarOverhead
-    final shortFormatPayload = ndefCapacity - ndefHeaderBase - mimeTypeLength - nfarOverhead;
-
-    if (shortFormatPayload > 0 && shortFormatPayload < 256) {
-      // Verify: total NDEF size should fit
-      final totalSize = ndefHeaderBase + mimeTypeLength + nfarOverhead + shortFormatPayload;
-      if (totalSize <= ndefCapacity) {
-        return shortFormatPayload;
-      }
-    }
-
-    // Use long record format (payload >= 256)
-    final longFormatPayload = ndefCapacity - ndefHeaderLong - mimeTypeLength - nfarOverhead;
-
-    // Ensure we have positive payload space
-    return longFormatPayload > 0 ? longFormatPayload : 0;
-  }
 
   /// Create an empty NDEF message (for erasing tags).
   NdefMessage createEmpty() {

--- a/test/ndef_availability_test.dart
+++ b/test/ndef_availability_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nfc_archiver/features/nfc/domain/ndef_availability.dart';
+
+void main() {
+  group('classifyNdefUnavailable', () {
+    test('a tag exposing NfcA is a failed detection, not an unusable tag', () {
+      // Android attaches the Ndef tech only if it completed NDEF detection at
+      // discovery — reading the CC, walking the TLVs and parsing the message.
+      // A brief or badly-coupled tap aborts that walk on a perfectly good tag,
+      // which surfaces as no Ndef tech but NfcA still present.
+      expect(
+        classifyNdefUnavailable(hasNfcA: true, hasMifareUltralight: false),
+        NdefUnavailableReason.detectionFailed,
+      );
+    });
+
+    test('a tag exposing only MifareUltralight is also a failed detection', () {
+      expect(
+        classifyNdefUnavailable(hasNfcA: false, hasMifareUltralight: true),
+        NdefUnavailableReason.detectionFailed,
+      );
+    });
+
+    test('a tag exposing no NFC-A technology is genuinely not NDEF', () {
+      expect(
+        classifyNdefUnavailable(hasNfcA: false, hasMifareUltralight: false),
+        NdefUnavailableReason.notNdefFormatted,
+      );
+    });
+
+    test('the failed-detection message invites a retry', () {
+      final message =
+          messageFor(NdefUnavailableReason.detectionFailed);
+      expect(message.toLowerCase(), contains('again'));
+      // It must not tell the user to go find a different tag: the tag is fine.
+      expect(message.toLowerCase(), isNot(contains('pre-formatted')));
+    });
+
+    test('the not-formatted message points at the tag, not a retry', () {
+      final message =
+          messageFor(NdefUnavailableReason.notNdefFormatted);
+      expect(message.toLowerCase(), contains('ndef'));
+      expect(message, isNot(equals(messageFor(NdefUnavailableReason.detectionFailed))));
+    });
+  });
+}

--- a/test/ndef_capacity_test.dart
+++ b/test/ndef_capacity_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nfc_archiver/core/constants/nfar_format.dart';
+
+/// NDEF record overhead for one NFAR chunk, as written to a Type-2 tag:
+/// 1 flags + 1 type length + 4 payload length (long form) + 33 MIME type.
+const _ndefRecordOverhead = 6 + 33;
+
+/// The NFC Forum Type-2 spec terminates the TLV area with a 0xFE byte. It has
+/// to live inside the same NDEF data area as the message, so the writer must
+/// reserve it.
+const _terminatorTlv = 1;
+
+void main() {
+  group('maxPayloadForCapacity', () {
+    test('leaves room for the 0xFE terminator TLV', () {
+      // Android reports 492 for an NTAG215: the CC-declared 496 B data area
+      // minus the 4-byte TLV header. Fitting a message of exactly 492 B leaves
+      // nothing for the terminator, which is the bug this guards.
+      for (final capacity in [144, 240, 492, 872, 1024]) {
+        final payload = NfcTagType.maxPayloadForCapacity(capacity);
+        final message = _ndefRecordOverhead + NfarHeaderSize.total + payload;
+        expect(
+          message + _terminatorTlv,
+          lessThanOrEqualTo(capacity),
+          reason: 'capacity $capacity: message $message + terminator overruns',
+        );
+      }
+    });
+
+    test('matches the web app so both writers chunk identically', () {
+      // The web app's chunkPayloadForCapacity() measures the whole wrapped TLV
+      // including the terminator, and yields 420 for an NTAG215. A card written
+      // by either app must be interchangeable with one written by the other.
+      expect(NfcTagType.maxPayloadForCapacity(492), 420);
+    });
+
+    test('is maximal — one more byte would not fit', () {
+      const capacity = 492;
+      final payload = NfcTagType.maxPayloadForCapacity(capacity);
+      final oneMore =
+          _ndefRecordOverhead + NfarHeaderSize.total + payload + 1 + _terminatorTlv;
+      expect(oneMore, greaterThan(capacity),
+          reason: 'payload is smaller than it needs to be');
+    });
+
+    test('never returns a negative payload for a tiny capacity', () {
+      expect(NfcTagType.maxPayloadForCapacity(10), 0);
+      expect(NfcTagType.maxPayloadForCapacity(0), 0);
+    });
+  });
+}


### PR DESCRIPTION
The Flutter half of the NTAG interop investigation (two card dumps compared, webapp/Chameleon-written vs Android-written). The webapp half is #48. The two are independent — neither needs the other to land first.

## Fix 1 — reserve the terminator byte

`NfcTagType.maxPayloadForCapacity` filled the reported NDEF capacity exactly, leaving no room for the `0xFE` terminator TLV that shares the same data area.

On an NTAG215 Android reports `ndef.maxSize` = 492 (the CC-declared 496 B area minus the 4-byte TLV header) and does **not** reserve the terminator. So `492 − 39 − 32` = 421, the wrapped TLV needs 497 B in a 496 B area, and the terminator is silently dropped. The card dump confirmed it: page 128 read `00 00 00 00` where `0xFE` should have been.

Reserving the byte gives 420 — exactly what the web app's `chunkPayloadForCapacity()` produces. Both apps now write identical geometry, so their cards are interchangeable within one archive, which they previously were not.

**Backward compatibility:** existing archives are unaffected. `assembleChunks` sums each chunk's own payload length and concatenates (`chunker_service.dart:208-220`); nothing compares chunk size against the writer's capacity math. Cards written with 421-byte chunks restore exactly as before, and the NFAR header is unchanged, so there is no format version bump and nothing to migrate. The one user-visible effect: re-archiving the same file can need one additional tag in a boundary case (on NTAG215, 8 tags held 8×421 = 3368 B and now hold 8×420 = 3360 B).

Also deletes `NdefFormatter.maxPayloadForNdefCapacity`. It has zero callers repo-wide and duplicates the function fixed here, so leaving it would preserve the off-by-one in a form no test covers.

## Fix 2 — stop reporting a mis-tapped tag as unusable

Both `"Tag does not support NDEF"` sites fired on `Ndef.from(tag) == null`, which conflates two different situations. Android attaches the `Ndef` tech only if it completed NDEF detection at discovery — and detecting a full NTAG215 takes ~31 READ commands, so a brief or badly-coupled tap aborts the walk on a perfectly good tag. The user was then told to *"use a pre-formatted NDEF tag"*: a permanent-sounding instruction for what is usually a retry.

`classifyNdefUnavailable()` uses the evidence the platform does give us. If `NfcA` or `MifareUltralight` is attached, the reader talked to a real tag and only detection failed → the message now invites a retry. With no NFC-A technology at all, the original message stands.

This is also the leading hypothesis for the original incident, which was never reproduced — the card was not retested, so this fix makes the failure legible rather than provably eliminating it.

## Tests

Two new files, both written before the fixes and watched to fail:
- `test/ndef_capacity_test.dart` (4 tests) — terminator fits across five capacities, the NTAG215 value matches the web app's 420, the result is still *maximal*, and tiny capacities never go negative. Failed with `145 > 144` and `421 ≠ 420`.
- `test/ndef_availability_test.dart` (5 tests) — the classification and the two messages.

29 tests pass; `flutter analyze` adds no new issues (the three infos in touched files pre-exist on master).

## Deliberately not in this PR

- **Localizing these strings.** The memory note called for moving them into the ARB files, but errors reach the UI as plain `String` through `NfcSessionError.message`, and there are ~8 hardcoded English strings on that path, not 2. Doing it properly means a typed error code plus UI-side mapping across the whole NFC error surface — its own piece of work, and half-localizing this path would be worse than not starting.
- **Release bookkeeping.** Fix 1 changes chunk geometry, so whenever this ships it wants a `pubspec.yaml` version bump and changelog files in all 7 locale directories per CLAUDE.md. Left for the release, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)