### PR TITLE
feat: Mifare Classic 1K support on capable Android phones

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Flutter app for distributed file storage across NFC tags using the NFAR (NFC Arc
 Each feature follows: `data/` (repository) → `presentation/providers/` (Riverpod StateNotifier) → `presentation/screens/`
 
 - **`nfc/`** — NFC abstraction over `nfc_manager`. `NfcRepository` manages sessions with write cooldown to prevent re-read. `NdefFormatter` converts Chunk↔NDEF with MIME type `application/vnd.nfcarchiver.chunk`.
+- **Mifare Classic 1K (Android only):** `NfcRepository` selects a `TagCodec` per tapped tag — `MifareTagCodec` when `MifareClassic.from(tag)` is non-null, else `NdefTagCodec`. Block layout in `lib/core/mifare/card_layout.dart` is a deliberate port of `webapp/src/mifare/card-layout.ts`, proven byte-identical by `tool/generate_mifare_fixtures.dart` + the web app's `interop-dart.test.ts`. Factory keys only; **sector trailers are never written**. Hardware support is detected via the `com.nfcarchiver/nfc_capabilities` platform channel (`com.nxp.mifare`) and hides the tag-type option when absent. iOS cannot support this — Core NFC has no CRYPTO1.
 - **`archive/`** — `ArchiveNotifier` uses sealed class states (`ArchiveInitial` → `ArchiveFileSelected` → `ArchiveConfiguring` → `ArchivePreparing` → `ArchiveReady` → `ArchiveWriting` → `ArchiveComplete`). Supports `rechunkForDetectedCapacity()` when tag is smaller than expected.
 - **`restore/`** — `RestoreNotifier` with states for scanning, collecting chunks into `RestoreSession` by UUID, handling CRC errors with rescan capability.
 

--- a/android/app/src/main/kotlin/com/nfcarchiver/nfc_archiver/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/nfcarchiver/nfc_archiver/MainActivity.kt
@@ -1,5 +1,25 @@
 package com.nfcarchiver.nfc_archiver
 
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity: FlutterActivity()
+class MainActivity : FlutterActivity() {
+    private val channelName = "com.nfcarchiver/nfc_capabilities"
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, channelName)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    // "com.nxp.mifare" is the standard Android system feature
+                    // reported by devices whose NFC controller implements
+                    // CRYPTO1. Absent on Broadcom/Samsung S3FWRN5 controllers.
+                    "hasMifareClassic" -> result.success(
+                        packageManager.hasSystemFeature("com.nxp.mifare")
+                    )
+                    else -> result.notImplemented()
+                }
+            }
+    }
+}

--- a/docs/superpowers/plans/2026-07-31-flutter-mifare-classic.md
+++ b/docs/superpowers/plans/2026-07-31-flutter-mifare-classic.md
@@ -1,0 +1,1466 @@
+# Mifare Classic 1K (Flutter) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let capable Android phones read and write the same raw-block Mifare Classic 1K cards the web app writes, closing an interop hole where those cards are currently invisible to the Flutter app.
+
+**Architecture:** A `TagCodec` strategy seam replaces `NfcRepository`'s hardcoded NDEF assumption, with `NdefTagCodec` preserving today's behaviour and `MifareClassicTagCodec` added alongside. Block layout is a deliberate file-for-file port of the web app's `card-layout.ts`, guarded by a cross-language byte fixture. Hardware capability is detected through a `com.nxp.mifare` platform channel and hides the option rather than failing at tap.
+
+**Tech Stack:** Flutter, Dart, `nfc_manager` 3.5.0 (`MifareClassic` platform tag), Riverpod, Kotlin (one platform channel), `flutter_test`.
+
+**Source spec:** `docs/superpowers/specs/2026-07-31-flutter-mifare-classic-design.md`
+
+## Global Constraints
+
+- **Android only.** iOS has no CRYPTO1 support in Core NFC. Every capability path must return `false` on iOS rather than throwing.
+- **Factory keys only:** key A = `FF FF FF FF FF FF`. No custom keys, no key recovery.
+- **Sector trailers are NEVER written.** Only `usableBlockIndexes` (block 0 and every `b % 4 == 3` excluded) may be written. Writing a trailer can permanently brick a card.
+- **`lib/core/mifare/card_layout.dart` is a port of `webapp/src/mifare/card-layout.ts`,** not a reimplementation. Same constant names, same values, same block ordering. Read the TypeScript before writing the Dart.
+- **No change to the NFAR format, on-tag bytes, or the web app.**
+- **All new user-facing strings go in `lib/l10n/app_en.arb` AND all 6 translation files** (`ru`, `tr`, `uk`, `ka`, `pl`, `be`), then `flutter gen-l10n`. This is a project rule from CLAUDE.md.
+- **Commands:** `flutter test` (all), `flutter test test/<file>` (one), `flutter analyze`. Run `flutter gen-l10n` after touching any ARB file.
+- **`flutter analyze` must introduce no new issues.** The baseline on master is 22 info-level issues; the count must not rise.
+- **Commit style:** `feat: …` / `test: …`. End every commit message with:
+  `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>`
+
+## File Structure
+
+**Created:**
+
+| File | Responsibility |
+|---|---|
+| `lib/core/mifare/card_layout.dart` | Pure block-layout maths, ported from the web app. No Flutter imports. |
+| `lib/features/nfc/domain/tag_codec.dart` | The `TagCodec` interface. |
+| `lib/features/nfc/domain/ndef_tag_codec.dart` | Today's NDEF behaviour, moved behind the interface. |
+| `lib/features/nfc/domain/mifare_block_io.dart` | Narrow IO seam over `MifareClassic` so the codec is testable. |
+| `lib/features/nfc/domain/mifare_tag_codec.dart` | Sector auth + block read/write using the layout. |
+| `lib/features/nfc/data/nfc_capabilities.dart` | Platform-channel wrapper + Riverpod provider. |
+| `test/mifare_card_layout_test.dart`, `test/mifare_tag_codec_test.dart`, `test/tag_codec_selection_test.dart`, `test/nfc_capabilities_test.dart` | Tests. |
+| `tool/generate_mifare_fixtures.dart` | Cross-language fixture generator. |
+
+**Modified:** `lib/core/constants/nfar_format.dart`, `lib/features/nfc/data/nfc_repository.dart`, `lib/features/nfc/domain/ndef_availability.dart`, `test/ndef_availability_test.dart`, `lib/features/archive/presentation/screens/archive_settings_screen.dart`, `lib/l10n/app_*.arb` (7), `android/app/src/main/kotlin/com/nfcarchiver/nfc_archiver/MainActivity.kt`, `CLAUDE.md`.
+
+**Task order rationale:** pure logic first (Tasks 1–2), then the capability gate (3), then the seam refactor with no behaviour change (4), then the new codec (5), then wiring (6–7), then UI (8), then cross-language proof (9) and docs (10).
+
+---
+
+### Task 1: Mifare block layout
+
+**Files:**
+- Create: `lib/core/mifare/card_layout.dart`
+- Test: `test/mifare_card_layout_test.dart`
+
+**Interfaces:**
+- Consumes: `NfarHeaderSize.total` (= 32) and `nfarMagic` from `lib/core/constants/nfar_format.dart`.
+- Produces: `usableBlockIndexes` (`List<int>`, 47 entries), `blockSize` (16), `cardCapacityBytes` (752), `cardPayloadSize` (720), `MifareCapacityException`, `chunkToBlocks(Uint8List) → List<MifareBlockWrite>`, `class MifareBlockWrite { final int block; final Uint8List data; }`, `firstBlockIsNfar(Uint8List) → bool`, `nfarTotalLength(Uint8List) → int`.
+
+**Read `webapp/src/mifare/card-layout.ts` before starting.** This is a port; the constants and ordering must match exactly.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/mifare_card_layout_test.dart`:
+
+```dart
+import 'dart:typed_data';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nfc_archiver/core/mifare/card_layout.dart';
+
+void main() {
+  group('layout constants', () {
+    test('47 usable blocks, excluding block 0 and every sector trailer', () {
+      expect(usableBlockIndexes.length, 47);
+      expect(usableBlockIndexes.contains(0), isFalse);
+      for (final b in usableBlockIndexes) {
+        expect(b % 4 == 3, isFalse, reason: 'block $b is a sector trailer');
+      }
+      expect(usableBlockIndexes.first, 1);
+      expect(usableBlockIndexes.last, 62);
+    });
+
+    test('capacity matches the web app', () {
+      expect(cardCapacityBytes, 752);
+      expect(cardPayloadSize, 720);
+    });
+  });
+
+  group('chunkToBlocks', () {
+    test('maps bytes onto usable blocks in order', () {
+      final bytes = Uint8List.fromList(List.generate(32, (i) => i));
+      final writes = chunkToBlocks(bytes);
+      expect(writes.length, 2);
+      expect(writes[0].block, 1);
+      expect(writes[1].block, 2);
+      expect(writes[0].data, bytes.sublist(0, 16));
+    });
+
+    test('zero-pads the final partial block', () {
+      final writes = chunkToBlocks(Uint8List.fromList([1, 2, 3]));
+      expect(writes.length, 1);
+      expect(writes[0].data.length, 16);
+      expect(writes[0].data.sublist(3), Uint8List(13));
+    });
+
+    test('skips sector trailers once past block 2', () {
+      final writes = chunkToBlocks(Uint8List(16 * 4));
+      expect(writes.map((w) => w.block).toList(), [1, 2, 4, 5]);
+    });
+
+    test('rejects a chunk larger than the card', () {
+      expect(() => chunkToBlocks(Uint8List(cardCapacityBytes + 1)),
+          throwsA(isA<MifareCapacityException>()));
+    });
+  });
+
+  group('probing', () {
+    test('firstBlockIsNfar recognises magic + version', () {
+      final block = Uint8List(16)
+        ..setAll(0, [0x4E, 0x46, 0x41, 0x52, 0x01]); // "NFAR" v1
+      expect(firstBlockIsNfar(block), isTrue);
+    });
+
+    test('firstBlockIsNfar rejects a blank block', () {
+      expect(firstBlockIsNfar(Uint8List(16)), isFalse);
+    });
+
+    test('nfarTotalLength reads the big-endian payload size at offset 26', () {
+      final header = Uint8List(32)
+        ..setAll(0, [0x4E, 0x46, 0x41, 0x52, 0x01])
+        ..[26] = 0x01
+        ..[27] = 0x2C; // 300
+      expect(nfarTotalLength(header), 332); // 32 overhead + 300
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `flutter test test/mifare_card_layout_test.dart`
+Expected: FAIL — "Error when reading 'lib/core/mifare/card_layout.dart': No such file or directory".
+
+- [ ] **Step 3: Write the implementation**
+
+Create `lib/core/mifare/card_layout.dart`:
+
+```dart
+import 'dart:typed_data';
+
+import '../constants/nfar_format.dart';
+
+/// Maps one NFAR chunk onto the usable data blocks of a Mifare Classic 1K card.
+///
+/// Deliberate port of `webapp/src/mifare/card-layout.ts` — same constants, same
+/// ordering — so cards written by either app are byte-identical. Change both or
+/// neither.
+///
+/// Layout is raw NFAR-native: serialized chunk bytes run sequentially across the
+/// 47 usable blocks (block 0 and every sector trailer skipped), zero-padding the
+/// final block. The NFAR header is self-delimiting, so no per-block framing is
+/// added.
+const int blockSize = 16;
+
+/// Blocks 0-63 minus block 0 (manufacturer) and every `b % 4 == 3` (sector
+/// trailer, holds the keys — writing one can brick the card).
+final List<int> usableBlockIndexes = List.unmodifiable(
+  List<int>.generate(64, (b) => b).where((b) => b != 0 && b % 4 != 3).toList(),
+);
+
+final int cardCapacityBytes = usableBlockIndexes.length * blockSize; // 752
+final int cardPayloadSize = cardCapacityBytes - NfarHeaderSize.total; // 720
+
+/// A chunk does not fit a Mifare Classic 1K card.
+class MifareCapacityException implements Exception {
+  MifareCapacityException(this.message);
+  final String message;
+  @override
+  String toString() => 'MifareCapacityException: $message';
+}
+
+/// One block-sized write: which block, and the 16 bytes to put there.
+class MifareBlockWrite {
+  const MifareBlockWrite(this.block, this.data);
+  final int block;
+  final Uint8List data;
+}
+
+/// Split serialized chunk bytes across the usable blocks, zero-padding the last.
+List<MifareBlockWrite> chunkToBlocks(Uint8List chunkBytes) {
+  if (chunkBytes.length > cardCapacityBytes) {
+    throw MifareCapacityException(
+      'Chunk is ${chunkBytes.length} bytes; a Mifare Classic 1K card holds '
+      '$cardCapacityBytes',
+    );
+  }
+  final blockCount = (chunkBytes.length + blockSize - 1) ~/ blockSize;
+  final out = <MifareBlockWrite>[];
+  for (var i = 0; i < blockCount; i++) {
+    final data = Uint8List(blockSize); // zero-filled -> pads the last block
+    final start = i * blockSize;
+    final end = (start + blockSize).clamp(0, chunkBytes.length);
+    data.setAll(0, chunkBytes.sublist(start, end));
+    out.add(MifareBlockWrite(usableBlockIndexes[i], data));
+  }
+  return out;
+}
+
+/// Whether the first usable block starts an NFAR chunk.
+bool firstBlockIsNfar(Uint8List block1) {
+  if (block1.length < nfarMagic.length + 1) return false;
+  for (var i = 0; i < nfarMagic.length; i++) {
+    if (block1[i] != nfarMagic[i]) return false;
+  }
+  return block1[nfarMagic.length] == nfarVersion;
+}
+
+/// Total serialized length declared by an NFAR header.
+int nfarTotalLength(Uint8List header) {
+  if (!firstBlockIsNfar(header)) {
+    throw const FormatException('Not an NFAR card: magic or version mismatch');
+  }
+  if (header.length < NfarHeaderSize.total) {
+    throw FormatException(
+      'Header too short: need ${NfarHeaderSize.total} bytes, '
+      'got ${header.length}',
+    );
+  }
+  final payloadSize = ByteData.sublistView(header).getUint16(26); // big-endian
+  return NfarHeaderSize.total + payloadSize;
+}
+```
+
+If `nfarMagic` or `nfarVersion` are named differently in `lib/core/constants/nfar_format.dart`, use the real names — read the file rather than assuming.
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run: `flutter test test/mifare_card_layout_test.dart`
+Expected: PASS, 9 tests.
+
+- [ ] **Step 5: Run the full suite and analyzer**
+
+Run: `flutter test && flutter analyze`
+Expected: all tests pass; analyzer issue count no higher than 22.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/core/mifare/card_layout.dart test/mifare_card_layout_test.dart
+git commit -m "feat: port the Mifare Classic block layout from the web app"
+```
+
+---
+
+### Task 2: Medium-aware `NfcTagType`
+
+**Files:**
+- Modify: `lib/core/constants/nfar_format.dart`
+- Test: `test/ndef_capacity_test.dart` (append)
+
+**Interfaces:**
+- Consumes: `cardCapacityBytes`, `cardPayloadSize` from Task 1 — **do not import them here**; `nfar_format.dart` must stay free of `lib/core/mifare/` to avoid a cycle. Hardcode 752 in the enum value and assert equality in the test instead.
+- Produces: `enum TagMedium { ndef, mifareClassic }`, `NfcTagType.medium` getter, `NfcTagType.mifareClassic1k`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/ndef_capacity_test.dart`:
+
+```dart
+import 'package:nfc_archiver/core/mifare/card_layout.dart';
+
+// ... inside main(), add:
+
+  group('Mifare Classic tag type', () {
+    test('carries the web app capacity and payload size', () {
+      expect(NfcTagType.mifareClassic1k.capacity, cardCapacityBytes);
+      expect(NfcTagType.mifareClassic1k.maxPayloadSize, cardPayloadSize);
+      expect(NfcTagType.mifareClassic1k.maxPayloadSize, 720);
+    });
+
+    test('subtracts no NDEF overhead — it is not an NDEF medium', () {
+      expect(NfcTagType.mifareClassic1k.medium, TagMedium.mifareClassic);
+      expect(
+        NfcTagType.mifareClassic1k.capacity -
+            NfcTagType.mifareClassic1k.maxPayloadSize,
+        NfarHeaderSize.total,
+      );
+    });
+
+    test('NDEF tag types keep their existing medium and sizes', () {
+      expect(NfcTagType.ntag215.medium, TagMedium.ndef);
+      expect(NfcTagType.ntag215.maxPayloadSize, 504 - 44 - 32);
+    });
+  });
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `flutter test test/ndef_capacity_test.dart`
+Expected: FAIL — "Undefined name 'TagMedium'" and no `mifareClassic1k` member.
+
+- [ ] **Step 3: Write the implementation**
+
+In `lib/core/constants/nfar_format.dart`, add above the enum:
+
+```dart
+/// How a tag stores an NFAR chunk. NDEF tags wrap the chunk in a MIME record
+/// inside a Type-2 TLV; Mifare Classic holds the raw chunk across data blocks.
+enum TagMedium { ndef, mifareClassic }
+```
+
+Give the enum a `medium` field defaulting to `TagMedium.ndef`, add the new value, and make `maxPayloadSize` medium-aware:
+
+```dart
+  ntag213(name: 'NTAG213', capacity: 144),
+  ntag215(name: 'NTAG215', capacity: 504),
+  ntag216(name: 'NTAG216', capacity: 888),
+
+  /// Mifare Classic 1K: 47 usable blocks x 16 B = 752 B of raw storage.
+  /// Value duplicated from card_layout.dart's cardCapacityBytes to keep this
+  /// file free of a lib/core/mifare/ import; the test asserts they agree.
+  mifareClassic1k(
+      name: 'Mifare Classic 1K',
+      capacity: 752,
+      medium: TagMedium.mifareClassic),
+
+  mifareUltralight(name: 'MIFARE Ultralight', capacity: 48),
+  // ... remaining values unchanged, none pass `medium`
+
+  const NfcTagType({
+    required this.name,
+    required this.capacity,
+    this.medium = TagMedium.ndef,
+  });
+
+  final String name;
+  final int capacity;
+  final TagMedium medium;
+
+  int get maxPayloadSize {
+    // Mifare Classic carries the raw chunk with no NDEF framing at all, so only
+    // the NFAR header and CRC come off the top.
+    if (medium == TagMedium.mifareClassic) {
+      final available = capacity - NfarHeaderSize.total;
+      return available > 0 ? available : 0;
+    }
+    const ndefOverhead = 44;
+    final available = capacity - ndefOverhead;
+    return available - NfarHeaderSize.total;
+  }
+```
+
+Keep every other enum value and the rest of the class exactly as they are.
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run: `flutter test test/ndef_capacity_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Check nothing else broke on the enum**
+
+`NfcTagInfo.effectiveTagType` and `archive_settings_screen.dart` both iterate `NfcTagType.values`, so a new value changes their behaviour.
+
+Run: `flutter test && flutter analyze`
+Expected: all pass. The picker will now show Mifare unconditionally — Task 8 gates it; that is expected at this point.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/core/constants/nfar_format.dart test/ndef_capacity_test.dart
+git commit -m "feat: make NfcTagType medium-aware and add Mifare Classic 1K"
+```
+
+---
+
+### Task 3: Hardware capability detection
+
+**Files:**
+- Create: `lib/features/nfc/data/nfc_capabilities.dart`
+- Modify: `android/app/src/main/kotlin/com/nfcarchiver/nfc_archiver/MainActivity.kt`
+- Test: `test/nfc_capabilities_test.dart`
+
+**Interfaces:**
+- Produces: `const MethodChannel nfcCapabilitiesChannel = MethodChannel('com.nfcarchiver/nfc_capabilities')`, `Future<bool> hasMifareClassicSupport()`, `final mifareSupportProvider = FutureProvider<bool>(...)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/nfc_capabilities_test.dart`:
+
+```dart
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nfc_archiver/features/nfc/data/nfc_capabilities.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(nfcCapabilitiesChannel, null);
+  });
+
+  test('reports true when the platform says the feature is present', () async {
+    messenger.setMockMethodCallHandler(nfcCapabilitiesChannel, (call) async {
+      expect(call.method, 'hasMifareClassic');
+      return true;
+    });
+    expect(await hasMifareClassicSupport(), isTrue);
+  });
+
+  test('reports false when the platform says it is absent', () async {
+    messenger.setMockMethodCallHandler(
+        nfcCapabilitiesChannel, (call) async => false);
+    expect(await hasMifareClassicSupport(), isFalse);
+  });
+
+  test('reports false when the channel is unimplemented (iOS)', () async {
+    messenger.setMockMethodCallHandler(nfcCapabilitiesChannel, (call) async {
+      throw MissingPluginException('no implementation');
+    });
+    expect(await hasMifareClassicSupport(), isFalse);
+  });
+
+  test('reports false rather than throwing on any platform error', () async {
+    messenger.setMockMethodCallHandler(nfcCapabilitiesChannel, (call) async {
+      throw PlatformException(code: 'ERROR');
+    });
+    expect(await hasMifareClassicSupport(), isFalse);
+  });
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `flutter test test/nfc_capabilities_test.dart`
+Expected: FAIL — cannot read `lib/features/nfc/data/nfc_capabilities.dart`.
+
+- [ ] **Step 3: Write the Dart side**
+
+Create `lib/features/nfc/data/nfc_capabilities.dart`:
+
+```dart
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Platform channel for NFC hardware capabilities Flutter cannot query itself.
+const MethodChannel nfcCapabilitiesChannel =
+    MethodChannel('com.nfcarchiver/nfc_capabilities');
+
+/// Whether this device's NFC controller can talk to Mifare Classic cards.
+///
+/// Mifare Classic uses NXP's proprietary CRYPTO1 cipher rather than a standard
+/// ISO 14443-4 protocol, so support lives in the controller chip: NXP
+/// controllers have it, Broadcom and Samsung's S3FWRN5 generally do not, and
+/// iOS never does. Any failure to answer is treated as "not supported" — the
+/// feature is hidden rather than offered and then failing at tap.
+Future<bool> hasMifareClassicSupport() async {
+  try {
+    final result =
+        await nfcCapabilitiesChannel.invokeMethod<bool>('hasMifareClassic');
+    return result ?? false;
+  } on MissingPluginException {
+    return false; // iOS, or an older build without the channel
+  } on PlatformException {
+    return false;
+  }
+}
+
+/// Queried once and cached for the app's lifetime — hardware does not change.
+final mifareSupportProvider =
+    FutureProvider<bool>((ref) => hasMifareClassicSupport());
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run: `flutter test test/nfc_capabilities_test.dart`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Write the Android side**
+
+Replace `android/app/src/main/kotlin/com/nfcarchiver/nfc_archiver/MainActivity.kt` with:
+
+```kotlin
+package com.nfcarchiver.nfc_archiver
+
+import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
+
+class MainActivity : FlutterActivity() {
+    private val channelName = "com.nfcarchiver/nfc_capabilities"
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, channelName)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    // "com.nxp.mifare" is the standard Android system feature
+                    // reported by devices whose NFC controller implements
+                    // CRYPTO1. Absent on Broadcom/Samsung S3FWRN5 controllers.
+                    "hasMifareClassic" -> result.success(
+                        packageManager.hasSystemFeature("com.nxp.mifare")
+                    )
+                    else -> result.notImplemented()
+                }
+            }
+    }
+}
+```
+
+- [ ] **Step 6: Verify the Android build still compiles**
+
+Run: `flutter build apk --debug`
+Expected: BUILD SUCCESSFUL. This is the only way to catch a Kotlin error — `flutter analyze` does not compile Kotlin.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/features/nfc/data/nfc_capabilities.dart test/nfc_capabilities_test.dart android/app/src/main/kotlin/com/nfcarchiver/nfc_archiver/MainActivity.kt
+git commit -m "feat: detect Mifare Classic hardware support via platform channel"
+```
+
+---
+
+### Task 4: `TagCodec` seam with NDEF behaviour preserved
+
+**Files:**
+- Create: `lib/features/nfc/domain/tag_codec.dart`, `lib/features/nfc/domain/ndef_tag_codec.dart`
+- Modify: `lib/features/nfc/data/nfc_repository.dart`
+
+**Interfaces:**
+- Consumes: `NdefFormatter` (`chunkToNdef`, `ndefToChunk`, `requiredNdefSize`) from `lib/features/nfc/domain/ndef_formatter.dart`; `Chunk` from `lib/core/models/chunk.dart`.
+- Produces:
+  ```dart
+  abstract interface class TagCodec {
+    String get name;
+    bool supports(NfcTag tag);
+    Future<int> capacityBytes(NfcTag tag);
+    Future<Chunk?> readChunk(NfcTag tag);
+    Future<void> writeChunk(NfcTag tag, Chunk chunk);
+  }
+  ```
+  and `class NdefTagCodec implements TagCodec`.
+
+**This task must not change any behaviour.** It is a pure refactor; the existing suite is the gate.
+
+- [ ] **Step 1: Record the baseline**
+
+Run: `flutter test`
+Expected: all tests pass. Note the count — it must be identical at Step 5.
+
+- [ ] **Step 2: Create the interface**
+
+Create `lib/features/nfc/domain/tag_codec.dart`:
+
+```dart
+import 'package:nfc_manager/nfc_manager.dart';
+
+import '../../../core/models/chunk.dart';
+
+/// How one storage medium carries an NFAR chunk on a tag.
+///
+/// `NfcRepository` owns sessions, cooldowns and errors; a codec owns the bytes.
+/// Mirrors the web app's `Transport` seam so the two codebases stay legible to
+/// each other.
+abstract interface class TagCodec {
+  /// Short identifier for logs and error messages, e.g. 'NDEF'.
+  String get name;
+
+  /// Whether this codec can handle the tapped tag.
+  bool supports(NfcTag tag);
+
+  /// Largest serialized chunk this tag can hold.
+  ///
+  /// Defined as chunk bytes, NOT the medium's raw size, so the two codecs
+  /// return comparable numbers: the caller checks `chunk.totalSize > capacity`
+  /// without knowing which medium it is talking to.
+  Future<int> capacityBytes(NfcTag tag);
+
+  /// Read a chunk, or null if the tag holds no valid NFAR data.
+  Future<Chunk?> readChunk(NfcTag tag);
+
+  /// Write a chunk. Throws on failure.
+  Future<void> writeChunk(NfcTag tag, Chunk chunk);
+}
+```
+
+- [ ] **Step 3: Move the NDEF logic behind it**
+
+Create `lib/features/nfc/domain/ndef_tag_codec.dart`:
+
+```dart
+import 'package:nfc_manager/nfc_manager.dart';
+
+import '../../../core/models/chunk.dart';
+import 'ndef_formatter.dart';
+import 'tag_codec.dart';
+
+/// NDEF-backed tags: NTAG213/215/216 and Mifare Ultralight.
+class NdefTagCodec implements TagCodec {
+  NdefTagCodec([NdefFormatter? formatter])
+      : _formatter = formatter ?? NdefFormatter();
+
+  final NdefFormatter _formatter;
+
+  @override
+  String get name => 'NDEF';
+
+  @override
+  bool supports(NfcTag tag) => Ndef.from(tag) != null;
+
+  @override
+  Future<int> capacityBytes(NfcTag tag) async {
+    final ndef = Ndef.from(tag)!;
+    // ndef.maxSize is the NDEF *message* capacity. Subtract the record overhead
+    // and the terminator byte to get the chunk bytes that actually fit.
+    return NfcTagType.maxPayloadForCapacity(ndef.maxSize) +
+        NfarHeaderSize.total;
+  }
+
+  @override
+  Future<Chunk?> readChunk(NfcTag tag) async {
+    final ndef = Ndef.from(tag)!;
+    return _formatter.ndefToChunk(await ndef.read());
+  }
+
+  @override
+  Future<void> writeChunk(NfcTag tag, Chunk chunk) async {
+    final ndef = Ndef.from(tag)!;
+    if (!ndef.isWritable) {
+      throw StateError('Tag is not writable');
+    }
+    await ndef.write(_formatter.chunkToNdef(chunk));
+  }
+}
+```
+
+Add the imports `../../../core/constants/nfar_format.dart` for `NfcTagType` and `NfarHeaderSize`.
+
+- [ ] **Step 4: Route `NfcRepository` through the codec**
+
+In `lib/features/nfc/data/nfc_repository.dart`, add a field `final List<TagCodec> _codecs = [NdefTagCodec()];` and a selector:
+
+```dart
+  /// First codec that can handle this tag, or null.
+  TagCodec? _codecFor(NfcTag tag) {
+    for (final codec in _codecs) {
+      if (codec.supports(tag)) return codec;
+    }
+    return null;
+  }
+```
+
+Replace the three NDEF call sites so they go through the selected codec, keeping every message and control-flow branch exactly as it is today: the read path (`Ndef.from(tag)` → `ndef.read()` → `ndefToChunk`), the write path (`Ndef.from(tag)` → writability check → `maxSize` comparison → `ndef.write`), and `_extractTagInfo`. Where a codec is null, keep calling the existing `messageFor(_ndefUnavailableReason(tag))`.
+
+- [ ] **Step 5: Run the full suite and analyzer**
+
+Run: `flutter test && flutter analyze`
+Expected: identical test count and result to Step 1; analyzer no worse than 22.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/features/nfc/domain/tag_codec.dart lib/features/nfc/domain/ndef_tag_codec.dart lib/features/nfc/data/nfc_repository.dart
+git commit -m "refactor: put NDEF tag access behind a TagCodec seam"
+```
+
+---
+
+### Task 5: Mifare block IO seam and codec
+
+**Files:**
+- Create: `lib/features/nfc/domain/mifare_block_io.dart`, `lib/features/nfc/domain/mifare_tag_codec.dart`
+- Test: `test/mifare_tag_codec_test.dart`
+
+**Interfaces:**
+- Consumes: `TagCodec` (Task 4); `chunkToBlocks`, `usableBlockIndexes`, `blockSize`, `cardCapacityBytes`, `firstBlockIsNfar`, `nfarTotalLength`, `MifareBlockWrite` (Task 1); `Chunk.fromBytes`, `chunk.toBytes()`, `chunk.totalSize`.
+- Produces:
+  ```dart
+  abstract interface class MifareBlockIO {
+    Future<bool> authenticateSector(int sectorIndex, Uint8List keyA);
+    Future<Uint8List> readBlock(int blockIndex);
+    Future<void> writeBlock(int blockIndex, Uint8List data);
+  }
+  const factoryKeyA = <int>[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF];
+  class MifareAuthException implements Exception { … }
+  class MifareTagCodec implements TagCodec { MifareTagCodec(this._ioFor); }
+  ```
+  where `_ioFor` is `MifareBlockIO? Function(NfcTag)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/mifare_tag_codec_test.dart`:
+
+```dart
+import 'dart:typed_data';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nfc_archiver/core/mifare/card_layout.dart';
+import 'package:nfc_archiver/core/models/chunk.dart';
+import 'package:nfc_archiver/core/services/checksum_service.dart';
+import 'package:nfc_archiver/features/nfc/domain/mifare_block_io.dart';
+
+/// In-memory Mifare Classic 1K: 64 blocks of 16 bytes, factory-keyed.
+class FakeMifareBlockIO implements MifareBlockIO {
+  final Map<int, Uint8List> blocks = {};
+  final List<int> authenticatedSectors = [];
+  final List<int> writtenBlocks = [];
+  bool failAuth = false;
+
+  @override
+  Future<bool> authenticateSector(int sectorIndex, Uint8List keyA) async {
+    if (failAuth) return false;
+    authenticatedSectors.add(sectorIndex);
+    return true;
+  }
+
+  @override
+  Future<Uint8List> readBlock(int blockIndex) async =>
+      blocks[blockIndex] ?? Uint8List(16);
+
+  @override
+  Future<void> writeBlock(int blockIndex, Uint8List data) async {
+    writtenBlocks.add(blockIndex);
+    blocks[blockIndex] = Uint8List.fromList(data);
+  }
+}
+
+Chunk makeChunk(int payloadLen) {
+  final payload = Uint8List.fromList(
+      List.generate(payloadLen, (i) => (i + 3) % 256));
+  return Chunk(
+    archiveId: Uint8List(16)..fillRange(0, 16, 4),
+    totalChunks: 1,
+    chunkIndex: 0,
+    payload: payload,
+    crc32: ChecksumService.instance.calculate(payload),
+  );
+}
+
+void main() {
+  test('write then read round-trips a chunk', () async {
+    final io = FakeMifareBlockIO();
+    final codec = MifareTagCodec((_) => io);
+    final chunk = makeChunk(200);
+
+    await codec.writeChunk(FakeTag(), chunk);
+    final read = await codec.readChunk(FakeTag());
+
+    expect(read, isNotNull);
+    expect(read!.payload, chunk.payload);
+    expect(read.chunkIndex, chunk.chunkIndex);
+  });
+
+  test('never writes block 0 or a sector trailer', () async {
+    final io = FakeMifareBlockIO();
+    final codec = MifareTagCodec((_) => io);
+
+    await codec.writeChunk(FakeTag(), makeChunk(cardPayloadSize));
+
+    expect(io.writtenBlocks.contains(0), isFalse);
+    for (final b in io.writtenBlocks) {
+      expect(b % 4 == 3, isFalse, reason: 'wrote sector trailer $b');
+    }
+  });
+
+  test('authenticates a sector before touching its blocks', () async {
+    final io = FakeMifareBlockIO();
+    final codec = MifareTagCodec((_) => io);
+    await codec.writeChunk(FakeTag(), makeChunk(200));
+    expect(io.authenticatedSectors, isNotEmpty);
+    expect(io.authenticatedSectors.first, 0);
+  });
+
+  test('a failed authentication throws rather than writing', () async {
+    final io = FakeMifareBlockIO()..failAuth = true;
+    final codec = MifareTagCodec((_) => io);
+    await expectLater(
+      codec.writeChunk(FakeTag(), makeChunk(200)),
+      throwsA(isA<MifareAuthException>()),
+    );
+    expect(io.writtenBlocks, isEmpty);
+  });
+
+  test('reads null from a blank card rather than throwing', () async {
+    final codec = MifareTagCodec((_) => FakeMifareBlockIO());
+    expect(await codec.readChunk(FakeTag()), isNull);
+  });
+
+  test('capacity is the raw card capacity', () async {
+    final codec = MifareTagCodec((_) => FakeMifareBlockIO());
+    expect(await codec.capacityBytes(FakeTag()), cardCapacityBytes);
+  });
+}
+```
+
+Define the stand-in tag once at the top of the test file:
+
+```dart
+import 'package:nfc_manager/nfc_manager.dart';
+
+/// nfc_manager exposes a const NfcTag constructor explicitly for testing.
+NfcTag FakeTag() => const NfcTag(handle: 'test', data: <String, dynamic>{});
+```
+
+`ChecksumService` has a private constructor — always `ChecksumService.instance`, never `ChecksumService()`.
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `flutter test test/mifare_tag_codec_test.dart`
+Expected: FAIL — missing `mifare_block_io.dart`.
+
+- [ ] **Step 3: Write the IO seam**
+
+Create `lib/features/nfc/domain/mifare_block_io.dart`:
+
+```dart
+import 'dart:typed_data';
+
+import 'package:nfc_manager/nfc_manager.dart';
+
+/// Factory key A. Every card this app writes stays factory-keyed, because
+/// sector trailers are never written.
+final Uint8List factoryKeyA =
+    Uint8List.fromList([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]);
+
+/// Sector authentication failed — the card is not factory-keyed.
+class MifareAuthException implements Exception {
+  MifareAuthException(this.sectorIndex);
+  final int sectorIndex;
+  @override
+  String toString() =>
+      'MifareAuthException: sector $sectorIndex rejected the factory key';
+}
+
+/// Narrow block-level access to a Mifare Classic card.
+///
+/// Exists so the codec is testable without hardware: `nfc_manager`'s
+/// `MifareClassic` cannot be constructed in a test.
+abstract interface class MifareBlockIO {
+  Future<bool> authenticateSector(int sectorIndex, Uint8List keyA);
+  Future<Uint8List> readBlock(int blockIndex);
+  Future<void> writeBlock(int blockIndex, Uint8List data);
+}
+
+/// Real implementation over `nfc_manager`.
+class NfcManagerMifareBlockIO implements MifareBlockIO {
+  NfcManagerMifareBlockIO(this._mifare);
+  final MifareClassic _mifare;
+
+  @override
+  Future<bool> authenticateSector(int sectorIndex, Uint8List keyA) =>
+      _mifare.authenticateSectorWithKeyA(sectorIndex: sectorIndex, key: keyA);
+
+  @override
+  Future<Uint8List> readBlock(int blockIndex) =>
+      _mifare.readBlock(blockIndex: blockIndex);
+
+  @override
+  Future<void> writeBlock(int blockIndex, Uint8List data) =>
+      _mifare.writeBlock(blockIndex: blockIndex, data: data);
+}
+
+/// Adapter used in production: null when the tag is not a Mifare Classic card,
+/// or when this phone's controller cannot talk CRYPTO1.
+MifareBlockIO? mifareIoFor(NfcTag tag) {
+  final mifare = MifareClassic.from(tag);
+  return mifare == null ? null : NfcManagerMifareBlockIO(mifare);
+}
+```
+
+- [ ] **Step 4: Write the codec**
+
+Create `lib/features/nfc/domain/mifare_tag_codec.dart`:
+
+```dart
+import 'dart:typed_data';
+
+import 'package:nfc_manager/nfc_manager.dart';
+
+import '../../../core/mifare/card_layout.dart';
+import '../../../core/models/chunk.dart';
+import 'mifare_block_io.dart';
+import 'tag_codec.dart';
+
+/// Mifare Classic 1K holding a raw NFAR chunk across its usable data blocks.
+///
+/// Byte-compatible with the web app: same block set, same ordering, same
+/// zero-padding. Sector trailers are never written, so cards stay factory-keyed
+/// and re-writable.
+class MifareTagCodec implements TagCodec {
+  MifareTagCodec(this._ioFor);
+
+  final MifareBlockIO? Function(NfcTag tag) _ioFor;
+
+  @override
+  String get name => 'Mifare Classic';
+
+  @override
+  bool supports(NfcTag tag) => _ioFor(tag) != null;
+
+  @override
+  Future<int> capacityBytes(NfcTag tag) async => cardCapacityBytes;
+
+  int _sectorOf(int block) => block ~/ 4;
+
+  /// Authenticate a sector once, then keep using it until the sector changes.
+  Future<void> _ensureSector(
+      MifareBlockIO io, int block, int? currentSector) async {
+    final sector = _sectorOf(block);
+    if (sector == currentSector) return;
+    if (!await io.authenticateSector(sector, factoryKeyA)) {
+      throw MifareAuthException(sector);
+    }
+  }
+
+  @override
+  Future<Chunk?> readChunk(NfcTag tag) async {
+    final io = _ioFor(tag);
+    if (io == null) return null;
+
+    int? sector;
+    final first = usableBlockIndexes.first;
+    await _ensureSector(io, first, sector);
+    sector = _sectorOf(first);
+    final head = await io.readBlock(first);
+    if (!firstBlockIsNfar(head)) return null;
+
+    // Read enough blocks to cover the declared length. The header spans the
+    // first two usable blocks, so read the second before trusting the length.
+    final bytes = BytesBuilder()..add(head);
+    for (final block in usableBlockIndexes.skip(1)) {
+      await _ensureSector(io, block, sector);
+      sector = _sectorOf(block);
+      bytes.add(await io.readBlock(block));
+      if (bytes.length >= 32) {
+        final total = nfarTotalLength(Uint8List.fromList(bytes.toBytes()));
+        if (bytes.length >= total) {
+          return Chunk.fromBytes(
+              Uint8List.fromList(bytes.toBytes().sublist(0, total)));
+        }
+      }
+    }
+    return null;
+  }
+
+  @override
+  Future<void> writeChunk(NfcTag tag, Chunk chunk) async {
+    final io = _ioFor(tag);
+    if (io == null) {
+      throw StateError('Tag is not a Mifare Classic card');
+    }
+    final writes = chunkToBlocks(chunk.toBytes());
+
+    // Authenticate every sector we are about to touch BEFORE writing anything,
+    // so a non-factory-keyed card fails without leaving a half-written chunk.
+    final sectors = writes.map((w) => _sectorOf(w.block)).toSet();
+    for (final sector in sectors) {
+      if (!await io.authenticateSector(sector, factoryKeyA)) {
+        throw MifareAuthException(sector);
+      }
+    }
+
+    int? sector;
+    for (final write in writes) {
+      await _ensureSector(io, write.block, sector);
+      sector = _sectorOf(write.block);
+      await io.writeBlock(write.block, write.data);
+      final back = await io.readBlock(write.block);
+      if (!_bytesEqual(back, write.data)) {
+        throw StateError('Read-back mismatch on block ${write.block}');
+      }
+    }
+  }
+
+  bool _bytesEqual(Uint8List a, Uint8List b) {
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+}
+```
+
+- [ ] **Step 5: Run the test and verify it passes**
+
+Run: `flutter test test/mifare_tag_codec_test.dart`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 6: Run the full suite and analyzer**
+
+Run: `flutter test && flutter analyze`
+Expected: all pass, analyzer no worse than 22.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/features/nfc/domain/mifare_block_io.dart lib/features/nfc/domain/mifare_tag_codec.dart test/mifare_tag_codec_test.dart
+git commit -m "feat: add a Mifare Classic tag codec behind a testable block-IO seam"
+```
+
+---
+
+### Task 6: Route the repository across both codecs
+
+**Files:**
+- Modify: `lib/features/nfc/data/nfc_repository.dart`
+- Test: `test/tag_codec_selection_test.dart`
+
+**Interfaces:**
+- Consumes: `NdefTagCodec` (Task 4), `MifareTagCodec` + `mifareIoFor` (Task 5).
+- Produces: no new public API; `NfcRepository._codecs` becomes `[MifareTagCodec(mifareIoFor), NdefTagCodec()]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/tag_codec_selection_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nfc_archiver/features/nfc/domain/mifare_tag_codec.dart';
+import 'package:nfc_archiver/features/nfc/domain/ndef_tag_codec.dart';
+import 'package:nfc_archiver/features/nfc/domain/tag_codec.dart';
+
+// Reuse FakeMifareBlockIO from mifare_tag_codec_test.dart by importing it, or
+// duplicate the four-method stub here if the test file does not export it.
+
+void main() {
+  test('Mifare is tried before NDEF', () {
+    // NDEF is never written onto Classic, so a tag exposing MifareClassic is
+    // unambiguously ours to handle with the Mifare codec. Order matters: a
+    // Classic card that happens to be NDEF-formatted by another app must still
+    // route to Mifare, or we would read the wrong bytes.
+    final codecs = <TagCodec>[
+      MifareTagCodec((_) => null),
+      NdefTagCodec(),
+    ];
+    expect(codecs.first, isA<MifareTagCodec>());
+  });
+
+  test('MifareTagCodec does not claim a tag with no Mifare IO', () {
+    expect(MifareTagCodec((_) => null).supports(FakeTag()), isFalse);
+  });
+}
+```
+
+Use the same `FakeTag()` construction settled in Task 5.
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `flutter test test/tag_codec_selection_test.dart`
+Expected: FAIL — the repository still has only the NDEF codec, and the imports may not resolve until Step 3.
+
+- [ ] **Step 3: Wire both codecs**
+
+In `lib/features/nfc/data/nfc_repository.dart`, change the codec list to:
+
+```dart
+  /// Mifare first: NDEF is never written onto Classic, so a tag exposing
+  /// MifareClassic is unambiguously ours. NDEF handles everything else.
+  final List<TagCodec> _codecs = [
+    MifareTagCodec(mifareIoFor),
+    NdefTagCodec(),
+  ];
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run: `flutter test && flutter analyze`
+Expected: all pass, analyzer no worse than 22.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/nfc/data/nfc_repository.dart test/tag_codec_selection_test.dart
+git commit -m "feat: route NFC reads and writes across both tag codecs"
+```
+
+---
+
+### Task 7: Third classification outcome for unsupported phones
+
+**Files:**
+- Modify: `lib/features/nfc/domain/ndef_availability.dart`, `lib/features/nfc/data/nfc_repository.dart`
+- Test: `test/ndef_availability_test.dart` (append)
+
+**Interfaces:**
+- Consumes: `hasMifareClassicSupport()` (Task 3) at the call site only.
+- Produces: `NdefUnavailableReason.mifareUnsupported`; `classifyNdefUnavailable` gains a third named parameter `required bool deviceSupportsMifare`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/ndef_availability_test.dart`:
+
+```dart
+  group('mifareUnsupported', () {
+    test('NfcA with no Ndef and no MifareClassic on an incapable phone', () {
+      // A Mifare Classic card tapped on a phone whose controller cannot do
+      // CRYPTO1 looks exactly like this. Reporting "try again" would invite
+      // endless retries of something that can never succeed.
+      expect(
+        classifyNdefUnavailable(
+          hasNfcA: true,
+          hasMifareUltralight: false,
+          deviceSupportsMifare: false,
+        ),
+        NdefUnavailableReason.mifareUnsupported,
+      );
+    });
+
+    test('the same signature on a CAPABLE phone is a failed detection', () {
+      expect(
+        classifyNdefUnavailable(
+          hasNfcA: true,
+          hasMifareUltralight: false,
+          deviceSupportsMifare: true,
+        ),
+        NdefUnavailableReason.detectionFailed,
+      );
+    });
+
+    test('MifareUltralight present is always a failed detection', () {
+      expect(
+        classifyNdefUnavailable(
+          hasNfcA: false,
+          hasMifareUltralight: true,
+          deviceSupportsMifare: false,
+        ),
+        NdefUnavailableReason.detectionFailed,
+      );
+    });
+
+    test('no NFC-A at all is still notNdefFormatted', () {
+      expect(
+        classifyNdefUnavailable(
+          hasNfcA: false,
+          hasMifareUltralight: false,
+          deviceSupportsMifare: false,
+        ),
+        NdefUnavailableReason.notNdefFormatted,
+      );
+    });
+
+    test('its message names the hardware limit, not a retry', () {
+      final message = messageFor(NdefUnavailableReason.mifareUnsupported);
+      expect(message.toLowerCase(), contains('mifare'));
+      expect(message.toLowerCase(), isNot(contains('again')));
+    });
+  });
+```
+
+Update the four existing `classifyNdefUnavailable` calls in this file to pass `deviceSupportsMifare: true`, which preserves their current expectations.
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `flutter test test/ndef_availability_test.dart`
+Expected: FAIL — no named parameter `deviceSupportsMifare`, and `mifareUnsupported` undefined.
+
+- [ ] **Step 3: Extend the classifier**
+
+In `lib/features/nfc/domain/ndef_availability.dart`, add the enum value and rewrite the function:
+
+```dart
+  /// The tag exposes NFC-A but neither Ndef nor MifareClassic, on a phone whose
+  /// controller cannot do CRYPTO1 — the signature of a Mifare Classic card on
+  /// hardware that will never read it. Retrying cannot help.
+  mifareUnsupported,
+```
+
+```dart
+NdefUnavailableReason classifyNdefUnavailable({
+  required bool hasNfcA,
+  required bool hasMifareUltralight,
+  required bool deviceSupportsMifare,
+}) {
+  if (hasMifareUltralight) return NdefUnavailableReason.detectionFailed;
+  if (hasNfcA) {
+    return deviceSupportsMifare
+        ? NdefUnavailableReason.detectionFailed
+        : NdefUnavailableReason.mifareUnsupported;
+  }
+  return NdefUnavailableReason.notNdefFormatted;
+}
+```
+
+Add the message case:
+
+```dart
+    case NdefUnavailableReason.mifareUnsupported:
+      return "This looks like a Mifare Classic card. Your phone's NFC chip "
+          "can't read them.";
+```
+
+- [ ] **Step 4: Update the call site**
+
+In `lib/features/nfc/data/nfc_repository.dart`, `_ndefUnavailableReason` needs the capability. Cache it in a field set once:
+
+```dart
+  bool _deviceSupportsMifare = false;
+
+  /// Call once at startup, before any session.
+  Future<void> initCapabilities() async {
+    _deviceSupportsMifare = await hasMifareClassicSupport();
+  }
+```
+
+and pass `deviceSupportsMifare: _deviceSupportsMifare` in `_ndefUnavailableReason`. Call `initCapabilities()` from app startup in `lib/main.dart` alongside the other initialisation.
+
+- [ ] **Step 5: Run the tests and verify they pass**
+
+Run: `flutter test && flutter analyze`
+Expected: all pass, analyzer no worse than 22.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/features/nfc/domain/ndef_availability.dart lib/features/nfc/data/nfc_repository.dart lib/main.dart test/ndef_availability_test.dart
+git commit -m "feat: report a Mifare card tapped on incapable hardware honestly"
+```
+
+---
+
+### Task 8: Picker gating, mismatch error, and localization
+
+**Files:**
+- Modify: `lib/features/archive/presentation/screens/archive_settings_screen.dart`, `lib/l10n/app_en.arb` + the six translation files
+- Test: manual, plus `flutter analyze`
+
+**Interfaces:**
+- Consumes: `mifareSupportProvider` (Task 3), `TagMedium` and `NfcTagType.mifareClassic1k` (Task 2), `TagCodec.name` (Task 4).
+- Produces: l10n keys `mifareNotSupportedOnDevice`, `tagTypeMismatch`.
+
+- [ ] **Step 1: Add the English strings**
+
+In `lib/l10n/app_en.arb`:
+
+```json
+  "mifareNotSupportedOnDevice": "This looks like a Mifare Classic card. Your phone's NFC chip can't read them.",
+  "@mifareNotSupportedOnDevice": {
+    "description": "Shown when a Mifare Classic card is tapped on a phone whose NFC controller lacks CRYPTO1 support"
+  },
+  "tagTypeMismatch": "That's a {tapped} card, but this archive is configured for {configured} — change the tag type in Settings.",
+  "@tagTypeMismatch": {
+    "description": "Shown when the tapped card's medium differs from the configured tag type",
+    "placeholders": { "tapped": { "type": "String" }, "configured": { "type": "String" } }
+  }
+```
+
+- [ ] **Step 2: Translate into all six other locales**
+
+Add the same two keys to `app_ru.arb`, `app_tr.arb`, `app_uk.arb`, `app_ka.arb`, `app_pl.arb`, `app_be.arb`. Keep `{tapped}` and `{configured}` placeholders intact and let each locale order them naturally. Do not translate "Mifare Classic", "NTAG213/215/216" or "NFC".
+
+- [ ] **Step 3: Regenerate and verify**
+
+Run: `flutter gen-l10n && flutter analyze`
+Expected: generation succeeds; no new analyzer issues. A missing key in any locale fails here.
+
+- [ ] **Step 4: Gate the picker**
+
+In `archive_settings_screen.dart`, the list currently filters only `custom`. Watch the capability provider and filter Mifare out when unsupported:
+
+```dart
+    final mifareSupported =
+        ref.watch(mifareSupportProvider).valueOrNull ?? false;
+```
+
+```dart
+                  ...NfcTagType.values
+                      .where((t) => t != NfcTagType.custom)
+                      .where((t) =>
+                          t.medium != TagMedium.mifareClassic || mifareSupported)
+                      .map((type) => RadioListTile<NfcTagType>(
+```
+
+Keep the rest of the `RadioListTile` exactly as it is.
+
+- [ ] **Step 5: Report a medium mismatch on write**
+
+In `nfc_repository.dart`'s write session, after selecting the codec, reject a medium mismatch before writing:
+
+```dart
+          final expectedMedium = chunk.payload.length > 0
+              ? configuredTagType.medium
+              : TagMedium.ndef;
+```
+
+Simpler and sufficient: compare the selected codec's `name` against the configured type's medium, and when they disagree call `onError` with the localized `tagTypeMismatch` string built from `codec.name` and `configuredTagType.name`. The configured type must be passed into `startWriteSession` as a new required parameter `NfcTagType configuredTagType`, and threaded from `archive_provider`.
+
+- [ ] **Step 6: Verify**
+
+Run: `flutter test && flutter analyze`
+Expected: all pass, analyzer no worse than 22.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/features/archive/presentation/screens/archive_settings_screen.dart lib/features/nfc/data/nfc_repository.dart lib/l10n/
+git commit -m "feat: gate the Mifare option on hardware support and report mismatches"
+```
+
+---
+
+### Task 9: Cross-language byte fixture
+
+**Files:**
+- Create: `tool/generate_mifare_fixtures.dart`
+- Modify: `webapp/test/interop-dart.test.ts`
+
+**Interfaces:**
+- Consumes: `chunkToBlocks` (Task 1); the web app's `chunkToBlocks` from `webapp/src/mifare/card-layout.ts`.
+- Produces: `webapp/test/fixtures/mifare-card.json` — `{ "payloadLength": int, "blocks": [{ "block": int, "hex": string }] }`.
+
+This is what keeps the port honest: two implementations of the same layout would drift, a byte fixture cannot.
+
+- [ ] **Step 1: Write the generator**
+
+Create `tool/generate_mifare_fixtures.dart`:
+
+```dart
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:nfc_archiver/core/mifare/card_layout.dart';
+import 'package:nfc_archiver/core/models/chunk.dart';
+import 'package:nfc_archiver/core/services/checksum_service.dart';
+
+/// Emits the exact block image the Dart layout produces, so the TypeScript
+/// side can assert byte equality. Run: dart run tool/generate_mifare_fixtures.dart
+void main() {
+  const payloadLength = 300;
+  final payload =
+      Uint8List.fromList(List.generate(payloadLength, (i) => (i + 3) % 256));
+  final chunk = Chunk(
+    archiveId: Uint8List(16)..fillRange(0, 16, 4),
+    totalChunks: 1,
+    chunkIndex: 0,
+    payload: payload,
+    crc32: ChecksumService.instance.calculate(payload),
+  );
+
+  final blocks = chunkToBlocks(chunk.toBytes())
+      .map((w) => {
+            'block': w.block,
+            'hex': w.data.map((b) => b.toRadixString(16).padLeft(2, '0')).join(),
+          })
+      .toList();
+
+  final out = File('webapp/test/fixtures/mifare-card.json');
+  out.createSync(recursive: true);
+  out.writeAsStringSync(
+      const JsonEncoder.withIndent('  ').convert({
+    'payloadLength': payloadLength,
+    'blocks': blocks,
+  }));
+  stdout.writeln('wrote ${out.path} with ${blocks.length} blocks');
+}
+```
+
+- [ ] **Step 2: Generate the fixture**
+
+Run: `dart run tool/generate_mifare_fixtures.dart`
+Expected: `wrote webapp/test/fixtures/mifare-card.json with 21 blocks` (332 bytes over 16-byte blocks = 21).
+
+- [ ] **Step 3: Write the failing TypeScript assertion**
+
+Append to `webapp/test/interop-dart.test.ts`:
+
+```ts
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { chunkToBlocks } from '../src/mifare/card-layout.js';
+import { encodeChunk } from '../src/chunk.js';
+import { crc32 } from '../src/crc32.js';
+
+test('Dart and TypeScript produce identical Mifare card images', () => {
+  const fixture = JSON.parse(readFileSync(
+    fileURLToPath(new URL('../../test/fixtures/mifare-card.json', import.meta.url)), 'utf8',
+  )) as { payloadLength: number; blocks: Array<{ block: number; hex: string }> };
+
+  const payload = new Uint8Array(fixture.payloadLength).map((_, i) => (i + 3) % 256);
+  const bytes = encodeChunk({
+    archiveId: new Uint8Array(16).fill(4),
+    totalChunks: 1, chunkIndex: 0, payload, crc32: crc32(payload), flags: 0,
+  });
+
+  const ours = chunkToBlocks(bytes);
+  assert.equal(ours.length, fixture.blocks.length);
+  for (let i = 0; i < ours.length; i++) {
+    assert.equal(ours[i]!.block, fixture.blocks[i]!.block);
+    assert.equal(
+      Array.from(ours[i]!.data, (b) => b.toString(16).padStart(2, '0')).join(''),
+      fixture.blocks[i]!.hex,
+      `block ${ours[i]!.block} differs`,
+    );
+  }
+});
+```
+
+Verify the fixture path resolves from `dist/test/`; correct the depth if it throws ENOENT.
+
+- [ ] **Step 4: Run the web app suite**
+
+```bash
+source ~/.nvm/nvm.sh && nvm use --lts
+cd webapp && rm -rf dist && npm test
+```
+
+Expected: PASS. A failure here means the Dart port and the TypeScript original disagree — fix the **Dart**, since the TypeScript is the shipped original.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tool/generate_mifare_fixtures.dart webapp/test/fixtures/mifare-card.json webapp/test/interop-dart.test.ts
+git commit -m "test: prove Dart and TypeScript Mifare card images are byte-identical"
+```
+
+---
+
+### Task 10: Documentation
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Document the feature**
+
+Under the Architecture section's Features Layer bullet list, add:
+
+> - **Mifare Classic 1K (Android only):** `NfcRepository` selects a `TagCodec` per tapped tag — `MifareTagCodec` when `MifareClassic.from(tag)` is non-null, else `NdefTagCodec`. Block layout in `lib/core/mifare/card_layout.dart` is a deliberate port of `webapp/src/mifare/card-layout.ts`, proven byte-identical by `tool/generate_mifare_fixtures.dart` + the web app's `interop-dart.test.ts`. Factory keys only; **sector trailers are never written**. Hardware support is detected via the `com.nfcarchiver/nfc_capabilities` platform channel (`com.nxp.mifare`) and hides the tag-type option when absent. iOS cannot support this — Core NFC has no CRYPTO1.
+
+- [ ] **Step 2: Verify the whole tree**
+
+```bash
+flutter test && flutter analyze
+source ~/.nvm/nvm.sh && nvm use --lts && cd webapp && rm -rf dist && npm test
+```
+
+Expected: both suites pass; analyzer no worse than 22.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: document Mifare Classic support and the TagCodec seam"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| Capability detection (channel, two levels) | 3, 8 |
+| `TagCodec` seam + routing rule | 4, 6 |
+| Block layout port | 1 |
+| `capacityBytes` defined as chunk bytes | 4 (NDEF), 5 (Mifare) |
+| Medium-aware `NfcTagType`, 720 == web app | 2 |
+| Write flow: picker entry, mismatch error, read-back verify | 5 (verify), 8 (picker, error) |
+| Restore flow + `mifareUnsupported` four-condition rule | 7 |
+| Testing: layout, codec selection, fixture, capability | 1, 5, 6, 9, 3 |
+| Non-goals | honored: no iOS path, factory keys only, no trailer writes, no cross-medium re-chunk |
+
+**Known soft spot, flagged rather than hidden:** Task 8 Step 5 is the least concrete step in this plan. Threading `configuredTagType` into `startWriteSession` touches `archive_provider` and `write_progress_screen`, and I could not fully specify those edits without reading them at implementation time. The implementer should expect to read both files and may find the parameter is better carried on an existing config object. **If that step balloons, stop and split it into its own task rather than improvising.**
+
+**Placeholder scan:** none besides the flagged Task 8 Step 5. Every other code step carries the code.
+
+**Type consistency:** `MifareBlockIO` (`authenticateSector`/`readBlock`/`writeBlock`) is used identically in Tasks 5 and 6. `TagCodec`'s five members match across Tasks 4, 5, 6. `MifareBlockWrite(block, data)` from Task 1 is consumed unchanged in Tasks 5 and 9. `classifyNdefUnavailable`'s three named parameters match between Task 7's test and implementation. `cardCapacityBytes`/`cardPayloadSize` from Task 1 are consumed in Tasks 2 and 5 under those exact names.

--- a/docs/superpowers/specs/2026-07-31-flutter-mifare-classic-design.md
+++ b/docs/superpowers/specs/2026-07-31-flutter-mifare-classic-design.md
@@ -1,0 +1,201 @@
+# Mifare Classic 1K support in the Flutter app
+
+**Date:** 2026-07-31
+**Scope:** The Flutter app only. Adds Mifare Classic 1K read and write on Android
+phones whose NFC controller supports it, using the same raw-block NFAR layout the
+web app already writes. No change to the NFAR format, the web app, or the
+on-tag bytes.
+
+## Problem
+
+The web app writes Mifare Classic 1K cards as raw NFAR blocks — the chunk laid
+across the 47 usable blocks, block 0 and every sector trailer skipped
+(`webapp/src/mifare/card-layout.ts`). There is no NDEF framing, because Mifare
+Classic is not an NDEF medium in this design.
+
+The Flutter app is NDEF-only. Both its read and write paths call `Ndef.from(tag)`
+and give up when it returns null (`nfc_repository.dart:80`, `:139`). For a
+webapp-written Mifare card that is exactly what happens.
+
+**So the phone can neither read nor write any Mifare archive the web app
+produced.** Those cards are invisible to it. That quietly splits a user's card
+collection into two incompatible families: NTAG cards both apps can handle, and
+Mifare cards only the Chameleon can. Closing this is worth more than the
+convenience of one more tag type.
+
+The capability exists and is already a dependency: `nfc_manager` 3.5.0 ships a
+`MifareClassic` platform tag exposing `authenticateSectorWithKeyA`, `readBlock`
+and `writeBlock` — a near-exact match for the web app's `ChameleonDevice` seam.
+
+## Constraint that shapes everything
+
+Mifare Classic uses NXP's proprietary CRYPTO1 cipher rather than a standard
+ISO 14443-4 protocol, so support lives in the phone's NFC controller. Devices
+with NXP controllers have it; Broadcom and Samsung's own S3FWRN5 generally do
+not. **iOS never will** — Core NFC has no CRYPTO1 support at all, so this is an
+Android-only feature permanently.
+
+CRYPTO1 is also cryptographically broken and NXP has deprecated Classic. That is
+acceptable for an archival hobby format, but it means we are building on a
+declining base and should not invest beyond what interop requires.
+
+## Decisions (confirmed with user)
+
+1. **Read and write**, not read-only. Being able to read cards you cannot write
+   is a strange place to stop.
+2. **Hide the option on unsupported devices**, and explain on tap. No dead UI on
+   hardware that will never support it; restore, which has no picker, gets a
+   specific message instead.
+3. **Explicit medium selection.** "Mifare Classic 1K" joins the tag-type picker;
+   a mismatched tap produces a clear error. No cross-medium re-chunking.
+4. **A `TagCodec` strategy seam**, mirroring the web app's `Transport`, rather
+   than branching inside `NfcRepository`.
+5. **Factory keys only** (`FF FF FF FF FF FF`, key A) — supporting custom keys
+   would break the interop this feature exists to create.
+6. **Sector trailers are never written.** Cards stay factory-keyed and
+   re-writable, matching `USABLE_BLOCK_INDEXES` in the web app.
+
+## Architecture
+
+### Capability detection
+
+Flutter cannot reach `PackageManager`, so this needs the one piece of native code
+in the feature: a platform channel `com.nfcarchiver/nfc_capabilities` with a
+single method `hasMifareClassic`, implemented in `MainActivity.kt` as
+`packageManager.hasSystemFeature("com.nxp.mifare")`. iOS returns `false`
+unconditionally.
+
+Detection happens at two levels, because the feature flag and the runtime truth
+can disagree:
+
+- the **flag** gates the UI — whether "Mifare Classic 1K" appears in the picker
+- **`MifareClassic.from(tag) != null`** gates the operation — whether this
+  particular tap can proceed
+
+The flag is queried once at startup and exposed as a Riverpod provider.
+
+### The `TagCodec` seam
+
+```dart
+abstract interface class TagCodec {
+  String get name;
+  bool supports(NfcTag tag);
+  Future<int> capacityBytes(NfcTag tag);
+  Future<Chunk?> readChunk(NfcTag tag);
+  Future<void> writeChunk(NfcTag tag, Chunk chunk);
+}
+```
+
+`NdefTagCodec` wraps today's logic and `NdefFormatter` without behaviour change.
+`MifareClassicTagCodec` authenticates each sector with factory key A and then
+reads or writes the usable blocks. `NfcRepository` holds an ordered list of
+codecs, selects the first whose `supports(tag)` returns true, and becomes
+medium-agnostic.
+
+**`capacityBytes` is defined as the largest serialized chunk this tag can hold**,
+not the medium's raw size — otherwise the two codecs would return numbers that
+cannot be compared. `NdefTagCodec` derives it from `ndef.maxSize` minus the
+record overhead and the terminator byte; `MifareClassicTagCodec` returns 752.
+The too-small check in `startWriteSession` then becomes uniform:
+`chunk.totalSize > await codec.capacityBytes(tag)`.
+
+Routing is unambiguous because NDEF is never written onto Classic:
+
+1. `MifareClassic.from(tag) != null` → `MifareClassicTagCodec`
+2. else `Ndef.from(tag) != null` → `NdefTagCodec`
+3. else → the existing `classifyNdefUnavailable` path
+
+### Block layout
+
+`lib/core/mifare/card_layout.dart` is a deliberate file-for-file port of
+`webapp/src/mifare/card-layout.ts`: `usableBlockIndexes` (0–63, excluding block 0
+and every `b % 4 == 3`), `cardCapacityBytes` = 752, `cardPayloadSize` = 720,
+`chunkToBlocks()`, `firstBlockIsNfar()`, `nfarTotalLength()`.
+
+Pure Dart with no Flutter imports, so it unit-tests without NFC hardware.
+
+It is a **port, not a reimplementation**, and that is load-bearing: two
+independent implementations of the same layout would drift, whereas a port plus
+the byte-equality fixture below cannot.
+
+### `NfcTagType` becomes medium-aware
+
+The enum currently hardcodes an NDEF assumption — `maxPayloadSize` subtracts a
+44-byte NDEF overhead that does not exist on Classic. It gains:
+
+- a `medium` field: `TagMedium.ndef` | `TagMedium.mifareClassic`
+- a new value `mifareClassic1k(name: 'Mifare Classic 1K', capacity: 752)`
+
+For the Mifare medium `maxPayloadSize` subtracts only the 32-byte NFAR overhead,
+yielding **720 — exactly the web app's `CARD_PAYLOAD_SIZE`**.
+
+`NfcTagInfo.fromCapacity` and any other consumer that walks `NfcTagType.values`
+must be checked: adding a value to that enum changes their behaviour.
+
+### Write flow
+
+"Mifare Classic 1K — 720 B" appears in the tag-type picker, filtered out when
+the capability flag is false. On a mismatched tap the error names both sides:
+
+> That's a Mifare Classic card, but this archive is configured for NTAG215 —
+> change the tag type in Settings.
+
+The existing Tag Too Small re-chunk dialog is untouched and continues to operate
+only within NDEF tags.
+
+A Mifare write is roughly 16 sector authentications plus 47 block writes, so the
+card must be held still noticeably longer than for an NDEF write; the progress
+screen says so. Every write is verified by read-back, matching the web app.
+
+### Restore flow
+
+Restore has no picker and routes purely on techs, via the same codec list.
+
+This creates a case the classification added in PR #49 currently gets wrong: a
+Mifare card tapped on a phone **without** NXP support exposes `NfcA` but neither
+`Ndef` nor `MifareClassic`, so it would be reported as "couldn't read the tag,
+try again" — inviting endless retries of something that can never succeed.
+
+`classifyNdefUnavailable` therefore gains a third outcome, `mifareUnsupported`,
+selected by this precise rule — all four conditions required:
+
+1. `Ndef` absent, and
+2. `MifareClassic` absent, and
+3. `NfcA` present, and
+4. the device capability flag is **false**
+
+> This looks like a Mifare Classic card. Your phone's NFC chip can't read them.
+
+On a device whose flag is **true**, the same tech signature means something else
+(a genuinely unformatted or foreign tag), so the existing `detectionFailed` /
+`notNdefFormatted` outcomes still apply there. The classifier therefore takes the
+capability flag as an explicit parameter rather than reading it globally, keeping
+it a pure function.
+
+## Testing
+
+- **`card_layout.dart` unit tests** mirroring the web app's `card-layout.test.ts`:
+  block mapping, the 720/752 boundaries, final-block zero padding, NFAR probing.
+- **Codec selection** tested against fake `tag.data` maps — no hardware.
+- **Cross-language fixture test** extending the existing
+  `tool/generate_web_fixtures.dart` / `tool/verify_web_fixtures.dart` pair to
+  Mifare card images, proving Dart-written and TypeScript-written cards are
+  byte-identical. This is the same mechanism that already guards the NFAR chunk
+  format, and it is what makes the "port, not reimplementation" decision hold
+  over time.
+- **Capability detection** tested with a mocked MethodChannel.
+- **Hardware validation on a real NXP phone is manual and required.** No
+  simulator covers CRYPTO1.
+
+The Flutter app currently has four test files and none covering the NFC path, so
+this work also establishes that path's first tests.
+
+## Non-goals
+
+- iOS support — Core NFC has no CRYPTO1; permanently impossible
+- Non-factory keys, key recovery, or re-keying cards
+- Writing sector trailers
+- Mifare Classic 4K
+- NDEF-on-Mifare via the MAD/TLV layout — this design uses raw NFAR blocks
+- Cross-medium re-chunking (decision 3)
+- Any change to the web app, the NFAR format, or on-tag bytes

--- a/lib/core/constants/nfar_format.dart
+++ b/lib/core/constants/nfar_format.dart
@@ -92,6 +92,10 @@ abstract class NfarFlags {
   }
 }
 
+/// How a tag stores an NFAR chunk. NDEF tags wrap the chunk in a MIME record
+/// inside a Type-2 TLV; Mifare Classic holds the raw chunk across data blocks.
+enum TagMedium { ndef, mifareClassic }
+
 /// NFC tag type specifications
 enum NfcTagType {
   /// NTAG213: 144 bytes user memory
@@ -102,6 +106,14 @@ enum NfcTagType {
 
   /// NTAG216: 888 bytes user memory
   ntag216(name: 'NTAG216', capacity: 888),
+
+  /// Mifare Classic 1K: 47 usable blocks x 16 B = 752 B of raw storage.
+  /// Value duplicated from card_layout.dart's cardCapacityBytes to keep this
+  /// file free of a lib/core/mifare/ import; the test asserts they agree.
+  mifareClassic1k(
+      name: 'Mifare Classic 1K',
+      capacity: 752,
+      medium: TagMedium.mifareClassic),
 
   /// MIFARE Ultralight: 48 bytes user memory
   mifareUltralight(name: 'MIFARE Ultralight', capacity: 48),
@@ -115,13 +127,24 @@ enum NfcTagType {
   /// Custom capacity (user-defined)
   custom(name: 'Custom', capacity: 0);
 
-  const NfcTagType({required this.name, required this.capacity});
+  const NfcTagType({
+    required this.name,
+    required this.capacity,
+    this.medium = TagMedium.ndef,
+  });
 
   final String name;
   final int capacity;
+  final TagMedium medium;
 
   /// Maximum payload size for this tag type
   int get maxPayloadSize {
+    // Mifare Classic carries the raw chunk with no NDEF framing at all, so only
+    // the NFAR header and CRC come off the top.
+    if (medium == TagMedium.mifareClassic) {
+      final available = capacity - NfarHeaderSize.total;
+      return available > 0 ? available : 0;
+    }
     // NDEF overhead includes:
     // - NDEF record header: 3-6 bytes (flags, type length, payload length)
     // - MIME type: 33 bytes ("application/vnd.nfcarchiver.chunk")

--- a/lib/core/mifare/card_layout.dart
+++ b/lib/core/mifare/card_layout.dart
@@ -1,0 +1,83 @@
+import 'dart:typed_data';
+
+import '../constants/nfar_format.dart';
+
+/// Maps one NFAR chunk onto the usable data blocks of a Mifare Classic 1K card.
+///
+/// Deliberate port of `webapp/src/mifare/card-layout.ts` — same constants, same
+/// ordering — so cards written by either app are byte-identical. Change both or
+/// neither.
+///
+/// Layout is raw NFAR-native: serialized chunk bytes run sequentially across the
+/// 47 usable blocks (block 0 and every sector trailer skipped), zero-padding the
+/// final block. The NFAR header is self-delimiting, so no per-block framing is
+/// added.
+const int blockSize = 16;
+
+/// Blocks 0-63 minus block 0 (manufacturer) and every `b % 4 == 3` (sector
+/// trailer, holds the keys — writing one can brick the card).
+final List<int> usableBlockIndexes = List.unmodifiable(
+  List<int>.generate(64, (b) => b).where((b) => b != 0 && b % 4 != 3).toList(),
+);
+
+final int cardCapacityBytes = usableBlockIndexes.length * blockSize; // 752
+final int cardPayloadSize = cardCapacityBytes - NfarHeaderSize.total; // 720
+
+/// A chunk does not fit a Mifare Classic 1K card.
+class MifareCapacityException implements Exception {
+  MifareCapacityException(this.message);
+  final String message;
+  @override
+  String toString() => 'MifareCapacityException: $message';
+}
+
+/// One block-sized write: which block, and the 16 bytes to put there.
+class MifareBlockWrite {
+  const MifareBlockWrite(this.block, this.data);
+  final int block;
+  final Uint8List data;
+}
+
+/// Split serialized chunk bytes across the usable blocks, zero-padding the last.
+List<MifareBlockWrite> chunkToBlocks(Uint8List chunkBytes) {
+  if (chunkBytes.length > cardCapacityBytes) {
+    throw MifareCapacityException(
+      'Chunk is ${chunkBytes.length} bytes; a Mifare Classic 1K card holds '
+      '$cardCapacityBytes',
+    );
+  }
+  final blockCount = (chunkBytes.length + blockSize - 1) ~/ blockSize;
+  final out = <MifareBlockWrite>[];
+  for (var i = 0; i < blockCount; i++) {
+    final data = Uint8List(blockSize); // zero-filled -> pads the last block
+    final start = i * blockSize;
+    final end = (start + blockSize).clamp(0, chunkBytes.length);
+    data.setAll(0, chunkBytes.sublist(start, end));
+    out.add(MifareBlockWrite(usableBlockIndexes[i], data));
+  }
+  return out;
+}
+
+/// Whether the first usable block starts an NFAR chunk.
+bool firstBlockIsNfar(Uint8List block1) {
+  if (block1.length < nfarMagic.length + 1) return false;
+  for (var i = 0; i < nfarMagic.length; i++) {
+    if (block1[i] != nfarMagic[i]) return false;
+  }
+  return block1[nfarMagic.length] == nfarVersion;
+}
+
+/// Total serialized length declared by an NFAR header.
+int nfarTotalLength(Uint8List header) {
+  if (!firstBlockIsNfar(header)) {
+    throw const FormatException('Not an NFAR card: magic or version mismatch');
+  }
+  if (header.length < NfarHeaderSize.total) {
+    throw FormatException(
+      'Header too short: need ${NfarHeaderSize.total} bytes, '
+      'got ${header.length}',
+    );
+  }
+  final payloadSize = ByteData.sublistView(header).getUint16(26); // big-endian
+  return NfarHeaderSize.total + payloadSize;
+}

--- a/lib/core/mifare/card_layout.dart
+++ b/lib/core/mifare/card_layout.dart
@@ -79,5 +79,12 @@ int nfarTotalLength(Uint8List header) {
     );
   }
   final payloadSize = ByteData.sublistView(header).getUint16(26); // big-endian
-  return NfarHeaderSize.total + payloadSize;
+  final total = NfarHeaderSize.total + payloadSize;
+  if (total > cardCapacityBytes) {
+    throw FormatException(
+      'Declared length $total exceeds card capacity $cardCapacityBytes; '
+      'card is corrupt or not NFAR',
+    );
+  }
+  return total;
 }

--- a/lib/features/archive/presentation/screens/archive_settings_screen.dart
+++ b/lib/features/archive/presentation/screens/archive_settings_screen.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../core/constants/nfar_format.dart';
 import '../../../../shared/utils/format_utils.dart';
+import '../../../nfc/data/nfc_capabilities.dart';
 import '../providers/archive_provider.dart';
 
 /// Screen for configuring archive settings.
@@ -48,6 +49,8 @@ class _ArchiveSettingsScreenState extends ConsumerState<ArchiveSettingsScreen> {
     final tagType = ref.watch(selectedTagTypeProvider);
     final compress = ref.watch(compressionEnabledProvider);
     final encrypt = ref.watch(encryptionEnabledProvider);
+    final mifareSupported =
+        ref.watch(mifareSupportProvider).valueOrNull ?? false;
     final l10n = AppLocalizations.of(context)!;
 
     if (state is! ArchiveConfiguring && state is! ArchiveFileSelected) {
@@ -93,6 +96,9 @@ class _ArchiveSettingsScreenState extends ConsumerState<ArchiveSettingsScreen> {
                   const SizedBox(height: 16),
                   ...NfcTagType.values
                       .where((t) => t != NfcTagType.custom)
+                      .where((t) =>
+                          t.medium != TagMedium.mifareClassic ||
+                          mifareSupported)
                       .map((type) => RadioListTile<NfcTagType>(
                             title: Text(type.name),
                             subtitle:

--- a/lib/features/archive/presentation/screens/write_progress_screen.dart
+++ b/lib/features/archive/presentation/screens/write_progress_screen.dart
@@ -47,6 +47,15 @@ class _WriteProgressScreenState extends ConsumerState<WriteProgressScreen> {
         // Tag is too small - offer to rechunk
         ref.read(archiveProvider.notifier).cancelWriting();
         _showRechunkDialog(context, next.detectedCapacity, next.requiredSize);
+      } else if (next is NfcSessionTagTypeMismatch) {
+        // Tapped tag's medium doesn't match the configured tag type.
+        final l10n = AppLocalizations.of(context)!;
+        final message =
+            l10n.tagTypeMismatch(next.tappedMedium, next.configuredMedium);
+        ref.read(archiveProvider.notifier).writeError(message);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(message)),
+        );
       } else if (next is NfcSessionError) {
         // Error writing
         ref.read(archiveProvider.notifier).writeError(next.message);
@@ -500,6 +509,7 @@ class _WriteProgressScreenState extends ConsumerState<WriteProgressScreen> {
     ref.read(archiveProvider.notifier).startWriting();
     await ref.read(nfcSessionProvider.notifier).startWriteSession(
           chunk: state.currentChunk,
+          configuredTagType: ref.read(selectedTagTypeProvider),
           message: l10n.holdTagNearDeviceToWrite(
               state.currentChunkIndex + 1, state.totalChunks),
         );

--- a/lib/features/archive/presentation/screens/write_progress_screen.dart
+++ b/lib/features/archive/presentation/screens/write_progress_screen.dart
@@ -48,7 +48,11 @@ class _WriteProgressScreenState extends ConsumerState<WriteProgressScreen> {
         ref.read(archiveProvider.notifier).cancelWriting();
         _showRechunkDialog(context, next.detectedCapacity, next.requiredSize);
       } else if (next is NfcSessionTagTypeMismatch) {
-        // Tapped tag's medium doesn't match the configured tag type.
+        // Tapped tag's medium doesn't match the configured tag type. Stop
+        // the session (as _showRechunkDialog does for NfcSessionTagTooSmall)
+        // so the reader doesn't stay armed with the stale chunk closure after
+        // the error is shown.
+        ref.read(nfcSessionProvider.notifier).stopSession();
         final l10n = AppLocalizations.of(context)!;
         final message =
             l10n.tagTypeMismatch(next.tappedMedium, next.configuredMedium);

--- a/lib/features/nfc/data/nfc_capabilities.dart
+++ b/lib/features/nfc/data/nfc_capabilities.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Platform channel for NFC hardware capabilities Flutter cannot query itself.
+const MethodChannel nfcCapabilitiesChannel =
+    MethodChannel('com.nfcarchiver/nfc_capabilities');
+
+/// Whether this device's NFC controller can talk to Mifare Classic cards.
+///
+/// Mifare Classic uses NXP's proprietary CRYPTO1 cipher rather than a standard
+/// ISO 14443-4 protocol, so support lives in the controller chip: NXP
+/// controllers have it, Broadcom and Samsung's S3FWRN5 generally do not, and
+/// iOS never does. Any failure to answer is treated as "not supported" — the
+/// feature is hidden rather than offered and then failing at tap.
+Future<bool> hasMifareClassicSupport() async {
+  try {
+    final result =
+        await nfcCapabilitiesChannel.invokeMethod<bool>('hasMifareClassic');
+    return result ?? false;
+  } on MissingPluginException {
+    return false; // iOS, or an older build without the channel
+  } on PlatformException {
+    return false;
+  }
+}
+
+/// Queried once and cached for the app's lifetime — hardware does not change.
+final mifareSupportProvider =
+    FutureProvider<bool>((ref) => hasMifareClassicSupport());

--- a/lib/features/nfc/data/nfc_repository.dart
+++ b/lib/features/nfc/data/nfc_repository.dart
@@ -12,6 +12,7 @@ import '../domain/ndef_availability.dart';
 import '../domain/ndef_formatter.dart';
 import '../domain/ndef_tag_codec.dart';
 import '../domain/tag_codec.dart';
+import 'nfc_capabilities.dart';
 
 /// Repository for NFC operations.
 ///
@@ -23,6 +24,13 @@ class NfcRepository {
   NfcRepository._();
 
   final _ndefFormatter = NdefFormatter.instance;
+
+  bool _deviceSupportsMifare = false;
+
+  /// Call once at startup, before any session.
+  Future<void> initCapabilities() async {
+    _deviceSupportsMifare = await hasMifareClassicSupport();
+  }
 
   /// Mifare first: NDEF is never written onto Classic, so a tag exposing
   /// MifareClassic is unambiguously ours. NDEF handles everything else.
@@ -342,6 +350,7 @@ class NfcRepository {
     return classifyNdefUnavailable(
       hasNfcA: tag.data['nfca'] != null,
       hasMifareUltralight: tag.data['mifareultralight'] != null,
+      deviceSupportsMifare: _deviceSupportsMifare,
     );
   }
 

--- a/lib/features/nfc/data/nfc_repository.dart
+++ b/lib/features/nfc/data/nfc_repository.dart
@@ -5,6 +5,8 @@ import 'package:nfc_manager/nfc_manager.dart';
 import '../../../core/constants/nfar_format.dart';
 import '../../../core/models/chunk.dart';
 import '../../../core/models/nfc_tag_info.dart';
+import '../domain/mifare_block_io.dart';
+import '../domain/mifare_tag_codec.dart';
 import '../domain/ndef_availability.dart';
 import '../domain/ndef_formatter.dart';
 import '../domain/ndef_tag_codec.dart';
@@ -21,8 +23,12 @@ class NfcRepository {
 
   final _ndefFormatter = NdefFormatter.instance;
 
-  /// Codecs tried, in order, to find one that can handle a tapped tag.
-  final List<TagCodec> _codecs = [NdefTagCodec()];
+  /// Mifare first: NDEF is never written onto Classic, so a tag exposing
+  /// MifareClassic is unambiguously ours. NDEF handles everything else.
+  final List<TagCodec> _codecs = [
+    MifareTagCodec(mifareIoFor),
+    NdefTagCodec(),
+  ];
 
   /// First codec that can handle this tag, or null.
   TagCodec? _codecFor(NfcTag tag) {
@@ -154,24 +160,31 @@ class NfcRepository {
             return;
           }
 
-          final ndef = Ndef.from(tag)!;
-
-          if (!ndef.isWritable) {
-            onError('Tag is not writable');
-            return;
-          }
-
-          final requiredSize = _ndefFormatter.requiredNdefSize(chunk);
-          if (ndef.maxSize < requiredSize) {
-            if (onTagTooSmall != null) {
-              onTagTooSmall(requiredSize, ndef.maxSize, tagInfo);
-            } else {
-              onError(
-                'Tag too small: needs $requiredSize bytes, '
-                'has ${ndef.maxSize} bytes',
-              );
+          // These pre-write checks are NDEF-specific: a Mifare Classic tag has
+          // no NDEF technology to query (`Ndef.from(tag)` is null), so it
+          // skips straight to `codec.writeChunk`, which does its own capacity
+          // check (`MifareCapacityException`) and auth check
+          // (`MifareAuthException`) — both land in the catch below like any
+          // other write failure. NDEF's checks and messages are unchanged.
+          final ndef = Ndef.from(tag);
+          if (ndef != null) {
+            if (!ndef.isWritable) {
+              onError('Tag is not writable');
+              return;
             }
-            return;
+
+            final requiredSize = _ndefFormatter.requiredNdefSize(chunk);
+            if (ndef.maxSize < requiredSize) {
+              if (onTagTooSmall != null) {
+                onTagTooSmall(requiredSize, ndef.maxSize, tagInfo);
+              } else {
+                onError(
+                  'Tag too small: needs $requiredSize bytes, '
+                  'has ${ndef.maxSize} bytes',
+                );
+              }
+              return;
+            }
           }
 
           await codec.writeChunk(tag, chunk);

--- a/lib/features/nfc/data/nfc_repository.dart
+++ b/lib/features/nfc/data/nfc_repository.dart
@@ -7,6 +7,8 @@ import '../../../core/models/chunk.dart';
 import '../../../core/models/nfc_tag_info.dart';
 import '../domain/ndef_availability.dart';
 import '../domain/ndef_formatter.dart';
+import '../domain/ndef_tag_codec.dart';
+import '../domain/tag_codec.dart';
 
 /// Repository for NFC operations.
 ///
@@ -18,6 +20,17 @@ class NfcRepository {
   NfcRepository._();
 
   final _ndefFormatter = NdefFormatter.instance;
+
+  /// Codecs tried, in order, to find one that can handle a tapped tag.
+  final List<TagCodec> _codecs = [NdefTagCodec()];
+
+  /// First codec that can handle this tag, or null.
+  TagCodec? _codecFor(NfcTag tag) {
+    for (final codec in _codecs) {
+      if (codec.supports(tag)) return codec;
+    }
+    return null;
+  }
 
   /// Cooldown period after successful write to prevent immediate re-read
   static const _writeCooldown = Duration(milliseconds: 2000);
@@ -77,14 +90,13 @@ class NfcRepository {
           final tagInfo = _extractTagInfo(tag);
           onTagDiscovered?.call(tagInfo);
 
-          final ndef = Ndef.from(tag);
-          if (ndef == null) {
+          final codec = _codecFor(tag);
+          if (codec == null) {
             onError(messageFor(_ndefUnavailableReason(tag)));
             return;
           }
 
-          final message = await ndef.read();
-          final chunk = _ndefFormatter.ndefToChunk(message);
+          final chunk = await codec.readChunk(tag);
 
           if (chunk == null) {
             onError('Tag does not contain valid archive data');
@@ -129,19 +141,20 @@ class NfcRepository {
     }
 
     final completer = Completer<void Function()>();
-    final message = _ndefFormatter.chunkToNdef(chunk);
 
     NfcManager.instance.startSession(
       alertMessage: alertMessage,
       onDiscovered: (tag) async {
         try {
           final tagInfo = _extractTagInfo(tag);
-          final ndef = Ndef.from(tag);
+          final codec = _codecFor(tag);
 
-          if (ndef == null) {
+          if (codec == null) {
             onError(messageFor(_ndefUnavailableReason(tag)));
             return;
           }
+
+          final ndef = Ndef.from(tag)!;
 
           if (!ndef.isWritable) {
             onError('Tag is not writable');
@@ -161,7 +174,7 @@ class NfcRepository {
             return;
           }
 
-          await ndef.write(message);
+          await codec.writeChunk(tag, chunk);
           _recordWrite(); // Start cooldown to prevent immediate re-read
           onSuccess(tagInfo);
         } catch (e) {
@@ -315,7 +328,8 @@ class NfcRepository {
     final technologies = <String>[];
 
     // Try to get NDEF info
-    final ndef = Ndef.from(tag);
+    final codec = _codecFor(tag);
+    final ndef = codec != null ? Ndef.from(tag) : null;
     if (ndef != null) {
       capacity = ndef.maxSize;
       isWritable = ndef.isWritable;

--- a/lib/features/nfc/data/nfc_repository.dart
+++ b/lib/features/nfc/data/nfc_repository.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:nfc_manager/nfc_manager.dart';
 
 import '../../../core/constants/nfar_format.dart';
@@ -37,6 +38,11 @@ class NfcRepository {
     }
     return null;
   }
+
+  /// The codec list, in try order. Exposed read-only so a test can assert
+  /// against the production ordering itself rather than a local copy of it.
+  @visibleForTesting
+  List<TagCodec> get codecs => List.unmodifiable(_codecs);
 
   /// Cooldown period after successful write to prevent immediate re-read
   static const _writeCooldown = Duration(milliseconds: 2000);
@@ -160,14 +166,21 @@ class NfcRepository {
             return;
           }
 
-          // These pre-write checks are NDEF-specific: a Mifare Classic tag has
-          // no NDEF technology to query (`Ndef.from(tag)` is null), so it
-          // skips straight to `codec.writeChunk`, which does its own capacity
-          // check (`MifareCapacityException`) and auth check
+          // These pre-write checks are NDEF-specific and must key off which
+          // codec was actually selected, not off `Ndef.from(tag) != null`: a
+          // Mifare Classic card that some other app happened to NDEF-format
+          // still has non-null NDEF data, but Mifare-first routing still
+          // selects MifareTagCodec for it, and NDEF's writability/size numbers
+          // do not describe that raw block write. `codec is NdefTagCodec` is
+          // strictly narrower than `ndef != null` (it also requires
+          // MifareTagCodec.supports(tag) to have been false), so this cannot
+          // change behaviour for a tag that actually gets the NDEF codec.
+          // Mifare skips straight to `codec.writeChunk`, which does its own
+          // capacity check (`MifareCapacityException`) and auth check
           // (`MifareAuthException`) — both land in the catch below like any
           // other write failure. NDEF's checks and messages are unchanged.
-          final ndef = Ndef.from(tag);
-          if (ndef != null) {
+          if (codec is NdefTagCodec) {
+            final ndef = Ndef.from(tag)!;
             if (!ndef.isWritable) {
               onError('Tag is not writable');
               return;

--- a/lib/features/nfc/data/nfc_repository.dart
+++ b/lib/features/nfc/data/nfc_repository.dart
@@ -14,6 +14,21 @@ import '../domain/ndef_tag_codec.dart';
 import '../domain/tag_codec.dart';
 import 'nfc_capabilities.dart';
 
+/// Whether a tapped tag's medium disagrees with [configuredMedium].
+///
+/// Pure so it's testable without a real `NfcTag`/`NfcManager` session: the
+/// write path's medium-mismatch check (Task 8) funnels its boolean decision
+/// through here so the logic has a single, unit-testable source of truth.
+@visibleForTesting
+bool tagMediumMismatches({
+  required bool tappedIsMifare,
+  required TagMedium configuredMedium,
+}) {
+  final tappedMedium =
+      tappedIsMifare ? TagMedium.mifareClassic : TagMedium.ndef;
+  return tappedMedium != configuredMedium;
+}
+
 /// Repository for NFC operations.
 ///
 /// Provides a high-level API for reading and writing NFAR chunks to NFC tags.
@@ -143,17 +158,26 @@ class NfcRepository {
   /// Start an NFC session for writing a chunk.
   ///
   /// [chunk] is the chunk to write.
+  /// [configuredTagType] is the tag type the archive was configured for; a
+  /// tapped tag whose medium (NDEF vs Mifare Classic) doesn't match it is
+  /// rejected via [onTagTypeMismatch] before any write is attempted.
   /// [onSuccess] is called when the chunk is successfully written.
   /// [onError] is called when an error occurs.
   /// [onTagTooSmall] is called when the tag doesn't have enough capacity.
+  /// [onTagTypeMismatch] is called when the tapped tag's medium doesn't match
+  /// [configuredTagType].
   ///
   /// Returns a function to stop the session.
   Future<void Function()> startWriteSession({
     required Chunk chunk,
+    required NfcTagType configuredTagType,
     required void Function(NfcTagInfo tagInfo) onSuccess,
     required void Function(String message) onError,
     void Function(int requiredSize, int detectedCapacity, NfcTagInfo? tagInfo)?
         onTagTooSmall,
+    void Function(String tappedMedium, String configuredMedium,
+            NfcTagInfo? tagInfo)?
+        onTagTypeMismatch,
     String alertMessage = 'Hold your device near an NFC tag to write',
   }) async {
     if (!await isAvailable()) {
@@ -174,6 +198,29 @@ class NfcRepository {
             return;
           }
 
+          // The tapped tag's medium must match what the archive was
+          // configured for. `codec is MifareTagCodec` is the ground truth for
+          // which medium was actually selected (routing is Mifare-first, see
+          // `_codecFor`), so this can't be fooled by e.g. a Mifare Classic
+          // card that some other app happened to NDEF-format. Checked before
+          // any medium-specific pre-check or write, so a mismatch never
+          // reaches `codec.writeChunk`.
+          if (tagMediumMismatches(
+            tappedIsMifare: codec is MifareTagCodec,
+            configuredMedium: configuredTagType.medium,
+          )) {
+            if (onTagTypeMismatch != null) {
+              onTagTypeMismatch(codec.name, configuredTagType.name, tagInfo);
+            } else {
+              onError(
+                "That's a ${codec.name} card, but this archive is configured "
+                'for ${configuredTagType.name} — change the tag type in '
+                'Settings.',
+              );
+            }
+            return;
+          }
+
           // These pre-write checks are NDEF-specific and must key off which
           // codec was actually selected, not off `Ndef.from(tag) != null`: a
           // Mifare Classic card that some other app happened to NDEF-format
@@ -183,10 +230,10 @@ class NfcRepository {
           // strictly narrower than `ndef != null` (it also requires
           // MifareTagCodec.supports(tag) to have been false), so this cannot
           // change behaviour for a tag that actually gets the NDEF codec.
-          // Mifare skips straight to `codec.writeChunk`, which does its own
-          // capacity check (`MifareCapacityException`) and auth check
-          // (`MifareAuthException`) — both land in the catch below like any
-          // other write failure. NDEF's checks and messages are unchanged.
+          // NDEF's checks and messages are unchanged: this is the same
+          // `ndef.maxSize` vs `requiredNdefSize(chunk)` comparison as before,
+          // not the (1-4 byte stricter) `codec.capacityBytes(tag)` used below
+          // for other media.
           if (codec is NdefTagCodec) {
             final ndef = Ndef.from(tag)!;
             if (!ndef.isWritable) {
@@ -202,6 +249,24 @@ class NfcRepository {
                 onError(
                   'Tag too small: needs $requiredSize bytes, '
                   'has ${ndef.maxSize} bytes',
+                );
+              }
+              return;
+            }
+          } else {
+            // Non-NDEF media (Mifare Classic): `capacityBytes` is defined as
+            // chunk bytes, so it's directly comparable to `chunk.totalSize`.
+            // Checked before `writeChunk` so an oversized chunk is reported
+            // via `onTagTooSmall` (the same re-chunk offer NDEF gets) instead
+            // of failing mid-write with a raw `MifareCapacityException`.
+            final capacity = await codec.capacityBytes(tag);
+            if (chunk.totalSize > capacity) {
+              if (onTagTooSmall != null) {
+                onTagTooSmall(chunk.totalSize, capacity, tagInfo);
+              } else {
+                onError(
+                  'Tag too small: needs ${chunk.totalSize} bytes, '
+                  'has $capacity bytes',
                 );
               }
               return;
@@ -284,6 +349,7 @@ class NfcRepository {
   /// This is a convenience method that wraps the session API.
   Future<NfcWriteResult> writeTag({
     required Chunk chunk,
+    required NfcTagType configuredTagType,
     Duration timeout = const Duration(seconds: 30),
   }) async {
     if (!await isAvailable()) {
@@ -307,6 +373,7 @@ class NfcRepository {
     try {
       stopSession = await startWriteSession(
         chunk: chunk,
+        configuredTagType: configuredTagType,
         onSuccess: (tagInfo) {
           timeoutTimer?.cancel();
           if (!completer.isCompleted) {

--- a/lib/features/nfc/data/nfc_repository.dart
+++ b/lib/features/nfc/data/nfc_repository.dart
@@ -259,6 +259,21 @@ class NfcRepository {
             // Checked before `writeChunk` so an oversized chunk is reported
             // via `onTagTooSmall` (the same re-chunk offer NDEF gets) instead
             // of failing mid-write with a raw `MifareCapacityException`.
+            //
+            // This branch is currently unreachable: `mifareClassic1k` is the
+            // only `TagMedium.mifareClassic` type, its capacity (752) equals
+            // `MifareTagCodec.capacityBytes`, and the tag-type picker refuses
+            // to render once an archive is prepared, so the configured medium
+            // can't change mid-archive. Kept as defence-in-depth for the day
+            // a second Mifare medium exists.
+            //
+            // If that day comes: `onTagTooSmall`'s consumer,
+            // `_showRechunkDialog`, computes the rechunk size via
+            // `NfcTagType.maxPayloadForCapacity(detectedCapacity)`, which is
+            // NDEF-shaped (subtracts NDEF record/terminator overhead). For
+            // capacity 752 that yields 680 — the wrong payload for Mifare,
+            // whose real payload is 720. That formula must be fixed before
+            // this branch can fire for a real Mifare "too small" case.
             final capacity = await codec.capacityBytes(tag);
             if (chunk.totalSize > capacity) {
               if (onTagTooSmall != null) {

--- a/lib/features/nfc/domain/mifare_block_io.dart
+++ b/lib/features/nfc/domain/mifare_block_io.dart
@@ -1,0 +1,53 @@
+import 'dart:typed_data';
+
+import 'package:nfc_manager/nfc_manager.dart';
+import 'package:nfc_manager/platform_tags.dart';
+
+/// Factory key A. Every card this app writes stays factory-keyed, because
+/// sector trailers are never written.
+final Uint8List factoryKeyA =
+    Uint8List.fromList([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]);
+
+/// Sector authentication failed — the card is not factory-keyed.
+class MifareAuthException implements Exception {
+  MifareAuthException(this.sectorIndex);
+  final int sectorIndex;
+  @override
+  String toString() =>
+      'MifareAuthException: sector $sectorIndex rejected the factory key';
+}
+
+/// Narrow block-level access to a Mifare Classic card.
+///
+/// Exists so the codec is testable without hardware: `nfc_manager`'s
+/// `MifareClassic` cannot be constructed in a test.
+abstract interface class MifareBlockIO {
+  Future<bool> authenticateSector(int sectorIndex, Uint8List keyA);
+  Future<Uint8List> readBlock(int blockIndex);
+  Future<void> writeBlock(int blockIndex, Uint8List data);
+}
+
+/// Real implementation over `nfc_manager`.
+class NfcManagerMifareBlockIO implements MifareBlockIO {
+  NfcManagerMifareBlockIO(this._mifare);
+  final MifareClassic _mifare;
+
+  @override
+  Future<bool> authenticateSector(int sectorIndex, Uint8List keyA) =>
+      _mifare.authenticateSectorWithKeyA(sectorIndex: sectorIndex, key: keyA);
+
+  @override
+  Future<Uint8List> readBlock(int blockIndex) =>
+      _mifare.readBlock(blockIndex: blockIndex);
+
+  @override
+  Future<void> writeBlock(int blockIndex, Uint8List data) =>
+      _mifare.writeBlock(blockIndex: blockIndex, data: data);
+}
+
+/// Adapter used in production: null when the tag is not a Mifare Classic card,
+/// or when this phone's controller cannot talk CRYPTO1.
+MifareBlockIO? mifareIoFor(NfcTag tag) {
+  final mifare = MifareClassic.from(tag);
+  return mifare == null ? null : NfcManagerMifareBlockIO(mifare);
+}

--- a/lib/features/nfc/domain/mifare_tag_codec.dart
+++ b/lib/features/nfc/domain/mifare_tag_codec.dart
@@ -1,0 +1,117 @@
+import 'dart:typed_data';
+
+import 'package:nfc_manager/nfc_manager.dart';
+
+import '../../../core/mifare/card_layout.dart';
+import '../../../core/models/chunk.dart';
+import 'mifare_block_io.dart';
+import 'tag_codec.dart';
+
+/// Mifare Classic 1K holding a raw NFAR chunk across its usable data blocks.
+///
+/// Byte-compatible with the web app: same block set, same ordering, same
+/// zero-padding. Sector trailers are never written, so cards stay factory-keyed
+/// and re-writable.
+class MifareTagCodec implements TagCodec {
+  MifareTagCodec(this._ioFor);
+
+  final MifareBlockIO? Function(NfcTag tag) _ioFor;
+
+  @override
+  String get name => 'Mifare Classic';
+
+  @override
+  bool supports(NfcTag tag) => _ioFor(tag) != null;
+
+  @override
+  Future<int> capacityBytes(NfcTag tag) async => cardCapacityBytes;
+
+  int _sectorOf(int block) => block ~/ 4;
+
+  /// Authenticate a sector once, then keep using it until the sector changes.
+  Future<void> _ensureSector(
+      MifareBlockIO io, int block, int? currentSector) async {
+    final sector = _sectorOf(block);
+    if (sector == currentSector) return;
+    if (!await io.authenticateSector(sector, factoryKeyA)) {
+      throw MifareAuthException(sector);
+    }
+  }
+
+  @override
+  Future<Chunk?> readChunk(NfcTag tag) async {
+    final io = _ioFor(tag);
+    if (io == null) return null;
+
+    int? sector;
+    final first = usableBlockIndexes.first;
+    await _ensureSector(io, first, sector);
+    sector = _sectorOf(first);
+    final head = await io.readBlock(first);
+    if (!firstBlockIsNfar(head)) return null;
+
+    // Read enough blocks to cover the declared length. The header spans the
+    // first two usable blocks, so read the second before trusting the length.
+    // `nfarTotalLength` and `Chunk.fromBytes` both throw `FormatException` on
+    // malformed data; a card whose first block happens to pass the magic/
+    // version check but whose later bytes are garbage (or not NFAR at all)
+    // must still come back as "not one of ours" rather than blow up the
+    // caller's scan loop, so those exceptions are caught here and folded
+    // into a null result rather than allowed to escape.
+    final bytes = BytesBuilder()..add(head);
+    for (final block in usableBlockIndexes.skip(1)) {
+      await _ensureSector(io, block, sector);
+      sector = _sectorOf(block);
+      bytes.add(await io.readBlock(block));
+      if (bytes.length >= 32) {
+        try {
+          final total = nfarTotalLength(Uint8List.fromList(bytes.toBytes()));
+          if (bytes.length >= total) {
+            return Chunk.fromBytes(
+                Uint8List.fromList(bytes.toBytes().sublist(0, total)));
+          }
+        } on FormatException {
+          return null;
+        }
+      }
+    }
+    return null;
+  }
+
+  @override
+  Future<void> writeChunk(NfcTag tag, Chunk chunk) async {
+    final io = _ioFor(tag);
+    if (io == null) {
+      throw StateError('Tag is not a Mifare Classic card');
+    }
+    final writes = chunkToBlocks(chunk.toBytes());
+
+    // Authenticate every sector we are about to touch BEFORE writing anything,
+    // so a non-factory-keyed card fails without leaving a half-written chunk.
+    final sectors = writes.map((w) => _sectorOf(w.block)).toSet();
+    for (final sector in sectors) {
+      if (!await io.authenticateSector(sector, factoryKeyA)) {
+        throw MifareAuthException(sector);
+      }
+    }
+
+    int? sector;
+    for (final write in writes) {
+      await _ensureSector(io, write.block, sector);
+      sector = _sectorOf(write.block);
+      await io.writeBlock(write.block, write.data);
+      final back = await io.readBlock(write.block);
+      if (!_bytesEqual(back, write.data)) {
+        throw StateError('Read-back mismatch on block ${write.block}');
+      }
+    }
+  }
+
+  bool _bytesEqual(Uint8List a, Uint8List b) {
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+}

--- a/lib/features/nfc/domain/ndef_availability.dart
+++ b/lib/features/nfc/domain/ndef_availability.dart
@@ -18,16 +18,26 @@ enum NdefUnavailableReason {
 
   /// No NFC-A technology at all: nothing we can write an NDEF message to.
   notNdefFormatted,
+
+  /// The tag exposes NFC-A but neither Ndef nor MifareClassic, on a phone whose
+  /// controller cannot do CRYPTO1 — the signature of a Mifare Classic card on
+  /// hardware that will never read it. Retrying cannot help.
+  mifareUnsupported,
 }
 
 /// Classify a tag that came back without the `Ndef` technology.
 NdefUnavailableReason classifyNdefUnavailable({
   required bool hasNfcA,
   required bool hasMifareUltralight,
+  required bool deviceSupportsMifare,
 }) {
-  return hasNfcA || hasMifareUltralight
-      ? NdefUnavailableReason.detectionFailed
-      : NdefUnavailableReason.notNdefFormatted;
+  if (hasMifareUltralight) return NdefUnavailableReason.detectionFailed;
+  if (hasNfcA) {
+    return deviceSupportsMifare
+        ? NdefUnavailableReason.detectionFailed
+        : NdefUnavailableReason.mifareUnsupported;
+  }
+  return NdefUnavailableReason.notNdefFormatted;
 }
 
 /// User-facing text for [reason].
@@ -41,5 +51,8 @@ String messageFor(NdefUnavailableReason reason) {
       return "Couldn't read the tag — hold it still against the phone and try again.";
     case NdefUnavailableReason.notNdefFormatted:
       return 'Tag does not support NDEF. Please use a pre-formatted NDEF tag.';
+    case NdefUnavailableReason.mifareUnsupported:
+      return "This looks like a Mifare Classic card. Your phone's NFC chip "
+          "can't read them.";
   }
 }

--- a/lib/features/nfc/domain/ndef_tag_codec.dart
+++ b/lib/features/nfc/domain/ndef_tag_codec.dart
@@ -1,0 +1,44 @@
+import 'package:nfc_manager/nfc_manager.dart';
+
+import '../../../core/constants/nfar_format.dart';
+import '../../../core/models/chunk.dart';
+import 'ndef_formatter.dart';
+import 'tag_codec.dart';
+
+/// NDEF-backed tags: NTAG213/215/216 and Mifare Ultralight.
+class NdefTagCodec implements TagCodec {
+  NdefTagCodec([NdefFormatter? formatter])
+      : _formatter = formatter ?? NdefFormatter.instance;
+
+  final NdefFormatter _formatter;
+
+  @override
+  String get name => 'NDEF';
+
+  @override
+  bool supports(NfcTag tag) => Ndef.from(tag) != null;
+
+  @override
+  Future<int> capacityBytes(NfcTag tag) async {
+    final ndef = Ndef.from(tag)!;
+    // ndef.maxSize is the NDEF *message* capacity. Subtract the record overhead
+    // and the terminator byte to get the chunk bytes that actually fit.
+    return NfcTagType.maxPayloadForCapacity(ndef.maxSize) +
+        NfarHeaderSize.total;
+  }
+
+  @override
+  Future<Chunk?> readChunk(NfcTag tag) async {
+    final ndef = Ndef.from(tag)!;
+    return _formatter.ndefToChunk(await ndef.read());
+  }
+
+  @override
+  Future<void> writeChunk(NfcTag tag, Chunk chunk) async {
+    final ndef = Ndef.from(tag)!;
+    if (!ndef.isWritable) {
+      throw StateError('Tag is not writable');
+    }
+    await ndef.write(_formatter.chunkToNdef(chunk));
+  }
+}

--- a/lib/features/nfc/domain/ndef_tag_codec.dart
+++ b/lib/features/nfc/domain/ndef_tag_codec.dart
@@ -23,6 +23,14 @@ class NdefTagCodec implements TagCodec {
     final ndef = Ndef.from(tag)!;
     // ndef.maxSize is the NDEF *message* capacity. Subtract the record overhead
     // and the terminator byte to get the chunk bytes that actually fit.
+    //
+    // Unused in the live write path: the NDEF size check there compares
+    // `requiredNdefSize(chunk)` against `ndef.maxSize` directly (see
+    // nfc_repository.dart). This method reduces to `ndef.maxSize - 40`,
+    // which is 1-4 bytes stricter than that live comparison, so wiring it in
+    // would reject some chunks the app accepts today. Anyone unifying the
+    // two must first prove the NDEF accept/reject decision is unchanged for
+    // every chunk size.
     return NfcTagType.maxPayloadForCapacity(ndef.maxSize) +
         NfarHeaderSize.total;
   }

--- a/lib/features/nfc/domain/tag_codec.dart
+++ b/lib/features/nfc/domain/tag_codec.dart
@@ -1,0 +1,29 @@
+import 'package:nfc_manager/nfc_manager.dart';
+
+import '../../../core/models/chunk.dart';
+
+/// How one storage medium carries an NFAR chunk on a tag.
+///
+/// `NfcRepository` owns sessions, cooldowns and errors; a codec owns the bytes.
+/// Mirrors the web app's `Transport` seam so the two codebases stay legible to
+/// each other.
+abstract interface class TagCodec {
+  /// Short identifier for logs and error messages, e.g. 'NDEF'.
+  String get name;
+
+  /// Whether this codec can handle the tapped tag.
+  bool supports(NfcTag tag);
+
+  /// Largest serialized chunk this tag can hold.
+  ///
+  /// Defined as chunk bytes, NOT the medium's raw size, so the two codecs
+  /// return comparable numbers: the caller checks `chunk.totalSize > capacity`
+  /// without knowing which medium it is talking to.
+  Future<int> capacityBytes(NfcTag tag);
+
+  /// Read a chunk, or null if the tag holds no valid NFAR data.
+  Future<Chunk?> readChunk(NfcTag tag);
+
+  /// Write a chunk. Throws on failure.
+  Future<void> writeChunk(NfcTag tag, Chunk chunk);
+}

--- a/lib/features/nfc/presentation/providers/nfc_provider.dart
+++ b/lib/features/nfc/presentation/providers/nfc_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/constants/nfar_format.dart';
 import '../../../../core/models/chunk.dart';
 import '../../../../core/models/nfc_tag_info.dart';
 import '../../data/nfc_repository.dart';
@@ -83,6 +84,22 @@ class NfcSessionTagTooSmall extends NfcSessionState {
       'Tag too small: needs $requiredSize bytes, has $detectedCapacity bytes';
 }
 
+/// The tapped tag's medium doesn't match the archive's configured tag type.
+/// [tappedMedium] and [configuredMedium] are display names (e.g. codec.name,
+/// NfcTagType.name), not the [TagMedium] enum, so the UI can drop them
+/// straight into a localized message.
+class NfcSessionTagTypeMismatch extends NfcSessionState {
+  const NfcSessionTagTypeMismatch({
+    required this.tappedMedium,
+    required this.configuredMedium,
+    this.tagInfo,
+  });
+
+  final String tappedMedium;
+  final String configuredMedium;
+  final NfcTagInfo? tagInfo;
+}
+
 /// Mode of NFC session.
 enum NfcSessionMode {
   read,
@@ -129,6 +146,7 @@ class NfcSessionNotifier extends StateNotifier<NfcSessionState> {
   /// Start a write session.
   Future<void> startWriteSession({
     required Chunk chunk,
+    required NfcTagType configuredTagType,
     String? message,
   }) async {
     if (!await _repository.isAvailable()) {
@@ -144,6 +162,7 @@ class NfcSessionNotifier extends StateNotifier<NfcSessionState> {
     try {
       _stopSession = await _repository.startWriteSession(
         chunk: chunk,
+        configuredTagType: configuredTagType,
         alertMessage: message ?? 'Hold your device near an NFC tag to write',
         onSuccess: (tagInfo) {
           state = NfcSessionWriteSuccess(
@@ -158,6 +177,13 @@ class NfcSessionNotifier extends StateNotifier<NfcSessionState> {
           state = NfcSessionTagTooSmall(
             requiredSize: requiredSize,
             detectedCapacity: detectedCapacity,
+            tagInfo: tagInfo,
+          );
+        },
+        onTagTypeMismatch: (tappedMedium, configuredMedium, tagInfo) {
+          state = NfcSessionTagTypeMismatch(
+            tappedMedium: tappedMedium,
+            configuredMedium: configuredMedium,
             tagInfo: tagInfo,
           );
         },

--- a/lib/l10n/app_be.arb
+++ b/lib/l10n/app_be.arb
@@ -148,5 +148,10 @@
   "deleteSessionConfirm": "Выдаліць гэту няскончаную сесію?",
   "lastUpdated": "Абноўлена {dateTime}",
   "sessionsCleared": "Усе сесіі ачышчаны",
-  "sessionDeleted": "Сесія выдалена"
+  "sessionDeleted": "Сесія выдалена",
+  "mifareNotSupportedOnDevice": "Падобна, гэта карта Mifare Classic. NFC-чып вашага тэлефона не можа іх чытаць.",
+  "tagTypeMismatch": "Гэта карта {tapped}, але гэты архіў наладжаны для {configured} — змяніце тып меткі ў Наладах.",
+  "@tagTypeMismatch": {
+    "placeholders": { "tapped": { "type": "String" }, "configured": { "type": "String" } }
+  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -867,5 +867,16 @@
   "sessionDeleted": "Session deleted",
   "@sessionDeleted": {
     "description": "Snackbar message after deleting a session"
+  },
+
+  "mifareNotSupportedOnDevice": "This looks like a Mifare Classic card. Your phone's NFC chip can't read them.",
+  "@mifareNotSupportedOnDevice": {
+    "description": "Shown when a Mifare Classic card is tapped on a phone whose NFC controller lacks CRYPTO1 support"
+  },
+
+  "tagTypeMismatch": "That's a {tapped} card, but this archive is configured for {configured} — change the tag type in Settings.",
+  "@tagTypeMismatch": {
+    "description": "Shown when the tapped card's medium differs from the configured tag type",
+    "placeholders": { "tapped": { "type": "String" }, "configured": { "type": "String" } }
   }
 }

--- a/lib/l10n/app_ka.arb
+++ b/lib/l10n/app_ka.arb
@@ -151,5 +151,10 @@
     "placeholders": { "dateTime": { "type": "String" } }
   },
   "sessionsCleared": "ყველა სესია წაიშალა",
-  "sessionDeleted": "სესია წაიშალა"
+  "sessionDeleted": "სესია წაიშალა",
+  "mifareNotSupportedOnDevice": "როგორც ჩანს, ეს Mifare Classic ბარათია. თქვენი ტელეფონის NFC ჩიპს მათი წაკითხვა არ შეუძლია.",
+  "tagTypeMismatch": "ეს არის {tapped} ბარათი, მაგრამ ეს არქივი კონფიგურირებულია {configured}-სთვის — შეცვალეთ ტეგის ტიპი პარამეტრებში.",
+  "@tagTypeMismatch": {
+    "placeholders": { "tapped": { "type": "String" }, "configured": { "type": "String" } }
+  }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -148,5 +148,10 @@
   "deleteSessionConfirm": "Usunąć tę niekompletną sesję?",
   "lastUpdated": "Ostatnia aktualizacja {dateTime}",
   "sessionsCleared": "Wszystkie sesje wyczyszczone",
-  "sessionDeleted": "Sesja usunięta"
+  "sessionDeleted": "Sesja usunięta",
+  "mifareNotSupportedOnDevice": "To wygląda na kartę Mifare Classic. Chip NFC Twojego telefonu nie potrafi ich odczytać.",
+  "tagTypeMismatch": "To karta {tapped}, ale to archiwum jest skonfigurowane dla {configured} — zmień typ tagu w Ustawieniach.",
+  "@tagTypeMismatch": {
+    "placeholders": { "tapped": { "type": "String" }, "configured": { "type": "String" } }
+  }
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -151,5 +151,10 @@
     "placeholders": { "dateTime": { "type": "String" } }
   },
   "sessionsCleared": "Все сессии удалены",
-  "sessionDeleted": "Сессия удалена"
+  "sessionDeleted": "Сессия удалена",
+  "mifareNotSupportedOnDevice": "Похоже, это карта Mifare Classic. NFC-модуль вашего телефона не может их читать.",
+  "tagTypeMismatch": "Это карта {tapped}, но этот архив настроен для {configured} — измените тип метки в Настройках.",
+  "@tagTypeMismatch": {
+    "placeholders": { "tapped": { "type": "String" }, "configured": { "type": "String" } }
+  }
 }

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -151,5 +151,10 @@
     "placeholders": { "dateTime": { "type": "String" } }
   },
   "sessionsCleared": "Tüm oturumlar temizlendi",
-  "sessionDeleted": "Oturum silindi"
+  "sessionDeleted": "Oturum silindi",
+  "mifareNotSupportedOnDevice": "Bu bir Mifare Classic kart gibi görünüyor. Telefonunuzun NFC çipi bunları okuyamaz.",
+  "tagTypeMismatch": "Bu bir {tapped} kart, ancak bu arşiv {configured} için yapılandırılmış — etiket türünü Ayarlar'dan değiştirin.",
+  "@tagTypeMismatch": {
+    "placeholders": { "tapped": { "type": "String" }, "configured": { "type": "String" } }
+  }
 }

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -151,5 +151,10 @@
     "placeholders": { "dateTime": { "type": "String" } }
   },
   "sessionsCleared": "Всі сесії видалено",
-  "sessionDeleted": "Сесію видалено"
+  "sessionDeleted": "Сесію видалено",
+  "mifareNotSupportedOnDevice": "Схоже, це картка Mifare Classic. NFC-чіп вашого телефону не може їх читати.",
+  "tagTypeMismatch": "Це картка {tapped}, але цей архів налаштовано для {configured} — змініть тип мітки в Налаштуваннях.",
+  "@tagTypeMismatch": {
+    "placeholders": { "tapped": { "type": "String" }, "configured": { "type": "String" } }
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,12 +4,16 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'app.dart';
 import 'core/providers/locale_provider.dart';
+import 'features/nfc/data/nfc_repository.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   // Initialize SharedPreferences for locale persistence
   final prefs = await SharedPreferences.getInstance();
+
+  // Query NFC hardware capabilities once before any session can start.
+  await NfcRepository.instance.initCapabilities();
 
   runApp(
     ProviderScope(

--- a/test/mifare_card_layout_test.dart
+++ b/test/mifare_card_layout_test.dart
@@ -66,5 +66,22 @@ void main() {
         ..[27] = 0x2C; // 300
       expect(nfarTotalLength(header), 332); // 32 overhead + 300
     });
+
+    test('nfarTotalLength rejects a payload declaring over-capacity total', () {
+      final header = Uint8List(32)
+        ..setAll(0, [0x4E, 0x46, 0x41, 0x52, 0x01])
+        ..[26] = 0xFF
+        ..[27] = 0xFF; // 65535 bytes payload -> 32 + 65535 = 65567 total
+      expect(() => nfarTotalLength(header),
+          throwsA(isA<FormatException>()));
+    });
+
+    test('nfarTotalLength accepts a payload landing exactly on capacity', () {
+      final header = Uint8List(32)
+        ..setAll(0, [0x4E, 0x46, 0x41, 0x52, 0x01])
+        ..[26] = 0x02
+        ..[27] = 0xD0; // 720 bytes payload -> 32 + 720 = 752 (exact capacity)
+      expect(nfarTotalLength(header), 752);
+    });
   });
 }

--- a/test/mifare_card_layout_test.dart
+++ b/test/mifare_card_layout_test.dart
@@ -1,0 +1,70 @@
+import 'dart:typed_data';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nfc_archiver/core/mifare/card_layout.dart';
+
+void main() {
+  group('layout constants', () {
+    test('47 usable blocks, excluding block 0 and every sector trailer', () {
+      expect(usableBlockIndexes.length, 47);
+      expect(usableBlockIndexes.contains(0), isFalse);
+      for (final b in usableBlockIndexes) {
+        expect(b % 4 == 3, isFalse, reason: 'block $b is a sector trailer');
+      }
+      expect(usableBlockIndexes.first, 1);
+      expect(usableBlockIndexes.last, 62);
+    });
+
+    test('capacity matches the web app', () {
+      expect(cardCapacityBytes, 752);
+      expect(cardPayloadSize, 720);
+    });
+  });
+
+  group('chunkToBlocks', () {
+    test('maps bytes onto usable blocks in order', () {
+      final bytes = Uint8List.fromList(List.generate(32, (i) => i));
+      final writes = chunkToBlocks(bytes);
+      expect(writes.length, 2);
+      expect(writes[0].block, 1);
+      expect(writes[1].block, 2);
+      expect(writes[0].data, bytes.sublist(0, 16));
+    });
+
+    test('zero-pads the final partial block', () {
+      final writes = chunkToBlocks(Uint8List.fromList([1, 2, 3]));
+      expect(writes.length, 1);
+      expect(writes[0].data.length, 16);
+      expect(writes[0].data.sublist(3), Uint8List(13));
+    });
+
+    test('skips sector trailers once past block 2', () {
+      final writes = chunkToBlocks(Uint8List(16 * 4));
+      expect(writes.map((w) => w.block).toList(), [1, 2, 4, 5]);
+    });
+
+    test('rejects a chunk larger than the card', () {
+      expect(() => chunkToBlocks(Uint8List(cardCapacityBytes + 1)),
+          throwsA(isA<MifareCapacityException>()));
+    });
+  });
+
+  group('probing', () {
+    test('firstBlockIsNfar recognises magic + version', () {
+      final block = Uint8List(16)
+        ..setAll(0, [0x4E, 0x46, 0x41, 0x52, 0x01]); // "NFAR" v1
+      expect(firstBlockIsNfar(block), isTrue);
+    });
+
+    test('firstBlockIsNfar rejects a blank block', () {
+      expect(firstBlockIsNfar(Uint8List(16)), isFalse);
+    });
+
+    test('nfarTotalLength reads the big-endian payload size at offset 26', () {
+      final header = Uint8List(32)
+        ..setAll(0, [0x4E, 0x46, 0x41, 0x52, 0x01])
+        ..[26] = 0x01
+        ..[27] = 0x2C; // 300
+      expect(nfarTotalLength(header), 332); // 32 overhead + 300
+    });
+  });
+}

--- a/test/mifare_tag_codec_test.dart
+++ b/test/mifare_tag_codec_test.dart
@@ -17,6 +17,7 @@ class FakeMifareBlockIO implements MifareBlockIO {
   final List<int> authenticatedSectors = [];
   final List<int> writtenBlocks = [];
   bool failAuth = false;
+  bool corruptWrites = false;
 
   @override
   Future<bool> authenticateSector(int sectorIndex, Uint8List keyA) async {
@@ -32,7 +33,15 @@ class FakeMifareBlockIO implements MifareBlockIO {
   @override
   Future<void> writeBlock(int blockIndex, Uint8List data) async {
     writtenBlocks.add(blockIndex);
-    blocks[blockIndex] = Uint8List.fromList(data);
+    if (corruptWrites) {
+      // Simulate a card that silently didn't take the write: store something
+      // other than what was given, so the codec's read-back check fires.
+      final stored = Uint8List.fromList(data);
+      stored[0] = stored[0] ^ 0xFF;
+      blocks[blockIndex] = stored;
+    } else {
+      blocks[blockIndex] = Uint8List.fromList(data);
+    }
   }
 }
 
@@ -46,6 +55,29 @@ Chunk makeChunk(int payloadLen) {
     payload: payload,
     crc32: ChecksumService.instance.calculate(payload),
   );
+}
+
+/// Raw 32-byte NFAR header spanning the first two usable blocks: valid magic
+/// + version, the given big-endian declared payload size at offset 26, and
+/// every other field left zero. Used to seed a card directly (bypassing
+/// writeChunk) so a test can control exactly what the declared length says
+/// without needing a real, fully-formed Chunk.
+Uint8List _rawHeader(int declaredPayloadSize) {
+  final header = Uint8List(32);
+  header[0] = 0x4E; // 'N'
+  header[1] = 0x46; // 'F'
+  header[2] = 0x41; // 'A'
+  header[3] = 0x52; // 'R'
+  header[4] = 0x01; // version
+  header[26] = (declaredPayloadSize >> 8) & 0xFF;
+  header[27] = declaredPayloadSize & 0xFF;
+  return header;
+}
+
+/// Seeds the first two usable blocks (where the NFAR header lives) directly.
+void _seedHeaderBlocks(FakeMifareBlockIO io, Uint8List header32) {
+  io.blocks[usableBlockIndexes[0]] = Uint8List.sublistView(header32, 0, 16);
+  io.blocks[usableBlockIndexes[1]] = Uint8List.sublistView(header32, 16, 32);
 }
 
 void main() {
@@ -100,5 +132,65 @@ void main() {
   test('capacity is the raw card capacity', () async {
     final codec = MifareTagCodec((_) => FakeMifareBlockIO());
     expect(await codec.capacityBytes(FakeTag()), cardCapacityBytes);
+  });
+
+  test(
+      'a card declaring a length past capacity reads null rather than '
+      'throwing', () async {
+    // Valid magic + version (passes firstBlockIsNfar), but a declared
+    // payload size of 0xFFFF pushes nfarTotalLength's total well past
+    // cardCapacityBytes, so nfarTotalLength itself throws FormatException.
+    // readChunk must catch that and return null instead of letting it
+    // escape the restore scan loop.
+    final io = FakeMifareBlockIO();
+    _seedHeaderBlocks(io, _rawHeader(0xFFFF));
+    final codec = MifareTagCodec((_) => io);
+
+    expect(await codec.readChunk(FakeTag()), isNull);
+  });
+
+  test(
+      'a valid header with a CRC that does not match its payload still '
+      'round-trips (CRC is not verified at this layer)', () async {
+    // This test exists to justify (and pin) why readChunk's second
+    // try/catch target -- Chunk.fromBytes -- is guarded even though no
+    // malformed-but-nfarTotalLength-passing input can currently reach it:
+    // Chunk.fromBytes performs no CRC check, and its own length guard
+    // (NfarHeaderOffset.payload + NfarHeaderSize.crc32) is definitionally
+    // equal to nfarTotalLength's (NfarHeaderSize.total), so once
+    // nfarTotalLength has accepted a header, Chunk.fromBytes cannot reject
+    // the same bytes. Verified here: a chunk with a deliberately wrong CRC
+    // still comes back non-null, with the bad CRC preserved as-is -- CRC
+    // verification is ChunkerService.assembleChunks' job, not readChunk's.
+    // The catch around Chunk.fromBytes remains valid defensive code (e.g.
+    // against a future CRC check being added there, or the two length
+    // formulas drifting apart), it is just not exercisable today.
+    final payload = Uint8List.fromList(List.generate(50, (i) => i));
+    final corrupted = Chunk(
+      archiveId: Uint8List(16)..fillRange(0, 16, 4),
+      totalChunks: 1,
+      chunkIndex: 0,
+      payload: payload,
+      crc32: 0xDEADBEEF, // does not match payload
+    );
+    final io = FakeMifareBlockIO();
+    final codec = MifareTagCodec((_) => io);
+
+    await codec.writeChunk(FakeTag(), corrupted);
+    final read = await codec.readChunk(FakeTag());
+
+    expect(read, isNotNull);
+    expect(read!.crc32, 0xDEADBEEF);
+  });
+
+  test('a read-back mismatch throws rather than silently succeeding',
+      () async {
+    final io = FakeMifareBlockIO()..corruptWrites = true;
+    final codec = MifareTagCodec((_) => io);
+
+    await expectLater(
+      codec.writeChunk(FakeTag(), makeChunk(200)),
+      throwsA(isA<StateError>()),
+    );
   });
 }

--- a/test/mifare_tag_codec_test.dart
+++ b/test/mifare_tag_codec_test.dart
@@ -1,0 +1,104 @@
+import 'dart:typed_data';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nfc_archiver/core/mifare/card_layout.dart';
+import 'package:nfc_archiver/core/models/chunk.dart';
+import 'package:nfc_archiver/core/services/checksum_service.dart';
+import 'package:nfc_archiver/features/nfc/domain/mifare_block_io.dart';
+import 'package:nfc_archiver/features/nfc/domain/mifare_tag_codec.dart';
+import 'package:nfc_manager/nfc_manager.dart';
+
+/// nfc_manager exposes a const NfcTag constructor explicitly for testing.
+// ignore: non_constant_identifier_names
+NfcTag FakeTag() => const NfcTag(handle: 'test', data: <String, dynamic>{});
+
+/// In-memory Mifare Classic 1K: 64 blocks of 16 bytes, factory-keyed.
+class FakeMifareBlockIO implements MifareBlockIO {
+  final Map<int, Uint8List> blocks = {};
+  final List<int> authenticatedSectors = [];
+  final List<int> writtenBlocks = [];
+  bool failAuth = false;
+
+  @override
+  Future<bool> authenticateSector(int sectorIndex, Uint8List keyA) async {
+    if (failAuth) return false;
+    authenticatedSectors.add(sectorIndex);
+    return true;
+  }
+
+  @override
+  Future<Uint8List> readBlock(int blockIndex) async =>
+      blocks[blockIndex] ?? Uint8List(16);
+
+  @override
+  Future<void> writeBlock(int blockIndex, Uint8List data) async {
+    writtenBlocks.add(blockIndex);
+    blocks[blockIndex] = Uint8List.fromList(data);
+  }
+}
+
+Chunk makeChunk(int payloadLen) {
+  final payload = Uint8List.fromList(
+      List.generate(payloadLen, (i) => (i + 3) % 256));
+  return Chunk(
+    archiveId: Uint8List(16)..fillRange(0, 16, 4),
+    totalChunks: 1,
+    chunkIndex: 0,
+    payload: payload,
+    crc32: ChecksumService.instance.calculate(payload),
+  );
+}
+
+void main() {
+  test('write then read round-trips a chunk', () async {
+    final io = FakeMifareBlockIO();
+    final codec = MifareTagCodec((_) => io);
+    final chunk = makeChunk(200);
+
+    await codec.writeChunk(FakeTag(), chunk);
+    final read = await codec.readChunk(FakeTag());
+
+    expect(read, isNotNull);
+    expect(read!.payload, chunk.payload);
+    expect(read.chunkIndex, chunk.chunkIndex);
+  });
+
+  test('never writes block 0 or a sector trailer', () async {
+    final io = FakeMifareBlockIO();
+    final codec = MifareTagCodec((_) => io);
+
+    await codec.writeChunk(FakeTag(), makeChunk(cardPayloadSize));
+
+    expect(io.writtenBlocks.contains(0), isFalse);
+    for (final b in io.writtenBlocks) {
+      expect(b % 4 == 3, isFalse, reason: 'wrote sector trailer $b');
+    }
+  });
+
+  test('authenticates a sector before touching its blocks', () async {
+    final io = FakeMifareBlockIO();
+    final codec = MifareTagCodec((_) => io);
+    await codec.writeChunk(FakeTag(), makeChunk(200));
+    expect(io.authenticatedSectors, isNotEmpty);
+    expect(io.authenticatedSectors.first, 0);
+  });
+
+  test('a failed authentication throws rather than writing', () async {
+    final io = FakeMifareBlockIO()..failAuth = true;
+    final codec = MifareTagCodec((_) => io);
+    await expectLater(
+      codec.writeChunk(FakeTag(), makeChunk(200)),
+      throwsA(isA<MifareAuthException>()),
+    );
+    expect(io.writtenBlocks, isEmpty);
+  });
+
+  test('reads null from a blank card rather than throwing', () async {
+    final codec = MifareTagCodec((_) => FakeMifareBlockIO());
+    expect(await codec.readChunk(FakeTag()), isNull);
+  });
+
+  test('capacity is the raw card capacity', () async {
+    final codec = MifareTagCodec((_) => FakeMifareBlockIO());
+    expect(await codec.capacityBytes(FakeTag()), cardCapacityBytes);
+  });
+}

--- a/test/ndef_availability_test.dart
+++ b/test/ndef_availability_test.dart
@@ -9,21 +9,33 @@ void main() {
       // A brief or badly-coupled tap aborts that walk on a perfectly good tag,
       // which surfaces as no Ndef tech but NfcA still present.
       expect(
-        classifyNdefUnavailable(hasNfcA: true, hasMifareUltralight: false),
+        classifyNdefUnavailable(
+          hasNfcA: true,
+          hasMifareUltralight: false,
+          deviceSupportsMifare: true,
+        ),
         NdefUnavailableReason.detectionFailed,
       );
     });
 
     test('a tag exposing only MifareUltralight is also a failed detection', () {
       expect(
-        classifyNdefUnavailable(hasNfcA: false, hasMifareUltralight: true),
+        classifyNdefUnavailable(
+          hasNfcA: false,
+          hasMifareUltralight: true,
+          deviceSupportsMifare: true,
+        ),
         NdefUnavailableReason.detectionFailed,
       );
     });
 
     test('a tag exposing no NFC-A technology is genuinely not NDEF', () {
       expect(
-        classifyNdefUnavailable(hasNfcA: false, hasMifareUltralight: false),
+        classifyNdefUnavailable(
+          hasNfcA: false,
+          hasMifareUltralight: false,
+          deviceSupportsMifare: true,
+        ),
         NdefUnavailableReason.notNdefFormatted,
       );
     });
@@ -41,6 +53,61 @@ void main() {
           messageFor(NdefUnavailableReason.notNdefFormatted);
       expect(message.toLowerCase(), contains('ndef'));
       expect(message, isNot(equals(messageFor(NdefUnavailableReason.detectionFailed))));
+    });
+  });
+
+  group('mifareUnsupported', () {
+    test('NfcA with no Ndef and no MifareClassic on an incapable phone', () {
+      // A Mifare Classic card tapped on a phone whose controller cannot do
+      // CRYPTO1 looks exactly like this. Reporting "try again" would invite
+      // endless retries of something that can never succeed.
+      expect(
+        classifyNdefUnavailable(
+          hasNfcA: true,
+          hasMifareUltralight: false,
+          deviceSupportsMifare: false,
+        ),
+        NdefUnavailableReason.mifareUnsupported,
+      );
+    });
+
+    test('the same signature on a CAPABLE phone is a failed detection', () {
+      expect(
+        classifyNdefUnavailable(
+          hasNfcA: true,
+          hasMifareUltralight: false,
+          deviceSupportsMifare: true,
+        ),
+        NdefUnavailableReason.detectionFailed,
+      );
+    });
+
+    test('MifareUltralight present is always a failed detection', () {
+      expect(
+        classifyNdefUnavailable(
+          hasNfcA: false,
+          hasMifareUltralight: true,
+          deviceSupportsMifare: false,
+        ),
+        NdefUnavailableReason.detectionFailed,
+      );
+    });
+
+    test('no NFC-A at all is still notNdefFormatted', () {
+      expect(
+        classifyNdefUnavailable(
+          hasNfcA: false,
+          hasMifareUltralight: false,
+          deviceSupportsMifare: false,
+        ),
+        NdefUnavailableReason.notNdefFormatted,
+      );
+    });
+
+    test('its message names the hardware limit, not a retry', () {
+      final message = messageFor(NdefUnavailableReason.mifareUnsupported);
+      expect(message.toLowerCase(), contains('mifare'));
+      expect(message.toLowerCase(), isNot(contains('again')));
     });
   });
 }

--- a/test/ndef_capacity_test.dart
+++ b/test/ndef_capacity_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nfc_archiver/core/constants/nfar_format.dart';
+import 'package:nfc_archiver/core/mifare/card_layout.dart';
 
 /// NDEF record overhead for one NFAR chunk, as written to a Type-2 tag:
 /// 1 flags + 1 type length + 4 payload length (long form) + 33 MIME type.
@@ -46,6 +47,28 @@ void main() {
     test('never returns a negative payload for a tiny capacity', () {
       expect(NfcTagType.maxPayloadForCapacity(10), 0);
       expect(NfcTagType.maxPayloadForCapacity(0), 0);
+    });
+  });
+
+  group('Mifare Classic tag type', () {
+    test('carries the web app capacity and payload size', () {
+      expect(NfcTagType.mifareClassic1k.capacity, cardCapacityBytes);
+      expect(NfcTagType.mifareClassic1k.maxPayloadSize, cardPayloadSize);
+      expect(NfcTagType.mifareClassic1k.maxPayloadSize, 720);
+    });
+
+    test('subtracts no NDEF overhead — it is not an NDEF medium', () {
+      expect(NfcTagType.mifareClassic1k.medium, TagMedium.mifareClassic);
+      expect(
+        NfcTagType.mifareClassic1k.capacity -
+            NfcTagType.mifareClassic1k.maxPayloadSize,
+        NfarHeaderSize.total,
+      );
+    });
+
+    test('NDEF tag types keep their existing medium and sizes', () {
+      expect(NfcTagType.ntag215.medium, TagMedium.ndef);
+      expect(NfcTagType.ntag215.maxPayloadSize, 504 - 44 - 32);
     });
   });
 }

--- a/test/nfc_capabilities_test.dart
+++ b/test/nfc_capabilities_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nfc_archiver/features/nfc/data/nfc_capabilities.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(nfcCapabilitiesChannel, null);
+  });
+
+  test('reports true when the platform says the feature is present', () async {
+    messenger.setMockMethodCallHandler(nfcCapabilitiesChannel, (call) async {
+      expect(call.method, 'hasMifareClassic');
+      return true;
+    });
+    expect(await hasMifareClassicSupport(), isTrue);
+  });
+
+  test('reports false when the platform says it is absent', () async {
+    messenger.setMockMethodCallHandler(
+        nfcCapabilitiesChannel, (call) async => false);
+    expect(await hasMifareClassicSupport(), isFalse);
+  });
+
+  test('reports false when the channel is unimplemented (iOS)', () async {
+    messenger.setMockMethodCallHandler(nfcCapabilitiesChannel, (call) async {
+      throw MissingPluginException('no implementation');
+    });
+    expect(await hasMifareClassicSupport(), isFalse);
+  });
+
+  test('reports false rather than throwing on any platform error', () async {
+    messenger.setMockMethodCallHandler(nfcCapabilitiesChannel, (call) async {
+      throw PlatformException(code: 'ERROR');
+    });
+    expect(await hasMifareClassicSupport(), isFalse);
+  });
+}

--- a/test/tag_codec_selection_test.dart
+++ b/test/tag_codec_selection_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nfc_archiver/features/nfc/domain/mifare_tag_codec.dart';
+import 'package:nfc_archiver/features/nfc/domain/ndef_tag_codec.dart';
+import 'package:nfc_archiver/features/nfc/domain/tag_codec.dart';
+import 'package:nfc_manager/nfc_manager.dart';
+
+/// nfc_manager exposes a const NfcTag constructor explicitly for testing.
+/// Duplicated from mifare_tag_codec_test.dart (see Task 6 brief: Dart test
+/// files cannot cleanly import each other's private helpers) as lowerCamelCase
+/// to avoid the non_constant_identifier_names ignore that file needed.
+NfcTag fakeTag() => const NfcTag(handle: 'test', data: <String, dynamic>{});
+
+void main() {
+  test('Mifare is tried before NDEF', () {
+    // NDEF is never written onto Classic, so a tag exposing MifareClassic is
+    // unambiguously ours to handle with the Mifare codec. Order matters: a
+    // Classic card that happens to be NDEF-formatted by another app must still
+    // route to Mifare, or we would read the wrong bytes.
+    final codecs = <TagCodec>[
+      MifareTagCodec((_) => null),
+      NdefTagCodec(),
+    ];
+    expect(codecs.first, isA<MifareTagCodec>());
+  });
+
+  test('MifareTagCodec does not claim a tag with no Mifare IO', () {
+    expect(MifareTagCodec((_) => null).supports(fakeTag()), isFalse);
+  });
+}

--- a/test/tag_codec_selection_test.dart
+++ b/test/tag_codec_selection_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:nfc_archiver/features/nfc/data/nfc_repository.dart';
 import 'package:nfc_archiver/features/nfc/domain/mifare_tag_codec.dart';
 import 'package:nfc_archiver/features/nfc/domain/ndef_tag_codec.dart';
-import 'package:nfc_archiver/features/nfc/domain/tag_codec.dart';
 import 'package:nfc_manager/nfc_manager.dart';
 
 /// nfc_manager exposes a const NfcTag constructor explicitly for testing.
@@ -16,11 +16,13 @@ void main() {
     // unambiguously ours to handle with the Mifare codec. Order matters: a
     // Classic card that happens to be NDEF-formatted by another app must still
     // route to Mifare, or we would read the wrong bytes.
-    final codecs = <TagCodec>[
-      MifareTagCodec((_) => null),
-      NdefTagCodec(),
-    ];
-    expect(codecs.first, isA<MifareTagCodec>());
+    //
+    // Asserts against NfcRepository.instance.codecs itself (not a local
+    // literal) so reordering the production list actually fails this test.
+    final codecs = NfcRepository.instance.codecs;
+    expect(codecs.length, 2);
+    expect(codecs[0], isA<MifareTagCodec>());
+    expect(codecs[1], isA<NdefTagCodec>());
   });
 
   test('MifareTagCodec does not claim a tag with no Mifare IO', () {

--- a/test/tag_medium_mismatch_test.dart
+++ b/test/tag_medium_mismatch_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nfc_archiver/core/constants/nfar_format.dart';
+import 'package:nfc_archiver/features/nfc/data/nfc_repository.dart';
+
+void main() {
+  group('tagMediumMismatches', () {
+    test('Mifare tap against a Mifare-configured archive is not a mismatch',
+        () {
+      expect(
+        tagMediumMismatches(
+          tappedIsMifare: true,
+          configuredMedium: TagMedium.mifareClassic,
+        ),
+        isFalse,
+      );
+    });
+
+    test('NDEF tap against an NDEF-configured archive is not a mismatch', () {
+      expect(
+        tagMediumMismatches(
+          tappedIsMifare: false,
+          configuredMedium: TagMedium.ndef,
+        ),
+        isFalse,
+      );
+    });
+
+    test(
+        'a Mifare tap against an NDEF-configured archive is the dead end '
+        'a NTAG216/generic1k user hits with a Mifare card in hand', () {
+      expect(
+        tagMediumMismatches(
+          tappedIsMifare: true,
+          configuredMedium: TagMedium.ndef,
+        ),
+        isTrue,
+      );
+    });
+
+    test('an NDEF tap against a Mifare-configured archive is also a mismatch',
+        () {
+      expect(
+        tagMediumMismatches(
+          tappedIsMifare: false,
+          configuredMedium: TagMedium.mifareClassic,
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/write_progress_tag_type_mismatch_test.dart
+++ b/test/write_progress_tag_type_mismatch_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:nfc_archiver/features/archive/presentation/screens/write_progress_screen.dart';
+import 'package:nfc_archiver/features/nfc/nfc.dart';
+
+/// A fake [NfcSessionNotifier] that never touches the platform channel: it
+/// lets the test push an arbitrary [NfcSessionState] (as the real
+/// `onTagTypeMismatch` callback would, deep inside a live NFC session) and
+/// records whether `stopSession()` was called in response, without ever
+/// calling `NfcRepository`/`NfcManager`.
+class _FakeNfcSessionNotifier extends NfcSessionNotifier {
+  int stopSessionCalls = 0;
+
+  void emit(NfcSessionState next) {
+    state = next;
+  }
+
+  @override
+  void stopSession() {
+    stopSessionCalls++;
+    state = const NfcSessionIdle();
+  }
+}
+
+void main() {
+  testWidgets(
+      'a tag-type mismatch stops the NFC session (regression for the '
+      'reader staying armed after the error snackbar)', (tester) async {
+    final fakeNfc = _FakeNfcSessionNotifier();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          nfcSessionProvider.overrideWith((ref) => fakeNfc),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: WriteProgressScreen(),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(fakeNfc.stopSessionCalls, 0);
+
+    // Simulate what NfcRepository.startWriteSession's onTagTypeMismatch
+    // callback would push into state after a Mifare/NDEF mismatch tap.
+    fakeNfc.emit(const NfcSessionTagTypeMismatch(
+      tappedMedium: 'Mifare Classic',
+      configuredMedium: 'NTAG213/215/216',
+    ));
+    await tester.pump();
+
+    // The screen's listener must stop the session -- matching what
+    // _showRechunkDialog already does for NfcSessionTagTooSmall -- so the
+    // reader doesn't stay armed with the stale chunk closure once the error
+    // snackbar is up.
+    expect(fakeNfc.stopSessionCalls, 1);
+    expect(find.byType(SnackBar), findsOneWidget);
+  });
+}

--- a/tool/generate_mifare_fixtures.dart
+++ b/tool/generate_mifare_fixtures.dart
@@ -1,0 +1,38 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:nfc_archiver/core/mifare/card_layout.dart';
+import 'package:nfc_archiver/core/models/chunk.dart';
+import 'package:nfc_archiver/core/services/checksum_service.dart';
+
+/// Emits the exact block image the Dart layout produces, so the TypeScript
+/// side can assert byte equality. Run: dart run tool/generate_mifare_fixtures.dart
+void main() {
+  const payloadLength = 300;
+  final payload =
+      Uint8List.fromList(List.generate(payloadLength, (i) => (i + 3) % 256));
+  final chunk = Chunk(
+    archiveId: Uint8List(16)..fillRange(0, 16, 4),
+    totalChunks: 1,
+    chunkIndex: 0,
+    payload: payload,
+    crc32: ChecksumService.instance.calculate(payload),
+  );
+
+  final blocks = chunkToBlocks(chunk.toBytes())
+      .map((w) => {
+            'block': w.block,
+            'hex': w.data.map((b) => b.toRadixString(16).padLeft(2, '0')).join(),
+          })
+      .toList();
+
+  final out = File('webapp/test/fixtures/mifare-card.json');
+  out.createSync(recursive: true);
+  out.writeAsStringSync(
+      const JsonEncoder.withIndent('  ').convert({
+    'payloadLength': payloadLength,
+    'blocks': blocks,
+  }));
+  stdout.writeln('wrote ${out.path} with ${blocks.length} blocks');
+}

--- a/webapp/test/fixtures/mifare-card.json
+++ b/webapp/test/fixtures/mifare-card.json
@@ -1,0 +1,89 @@
+{
+  "payloadLength": 300,
+  "blocks": [
+    {
+      "block": 1,
+      "hex": "4e464152010004040404040404040404"
+    },
+    {
+      "block": 2,
+      "hex": "04040404040400010000012c03040506"
+    },
+    {
+      "block": 4,
+      "hex": "0708090a0b0c0d0e0f10111213141516"
+    },
+    {
+      "block": 5,
+      "hex": "1718191a1b1c1d1e1f20212223242526"
+    },
+    {
+      "block": 6,
+      "hex": "2728292a2b2c2d2e2f30313233343536"
+    },
+    {
+      "block": 8,
+      "hex": "3738393a3b3c3d3e3f40414243444546"
+    },
+    {
+      "block": 9,
+      "hex": "4748494a4b4c4d4e4f50515253545556"
+    },
+    {
+      "block": 10,
+      "hex": "5758595a5b5c5d5e5f60616263646566"
+    },
+    {
+      "block": 12,
+      "hex": "6768696a6b6c6d6e6f70717273747576"
+    },
+    {
+      "block": 13,
+      "hex": "7778797a7b7c7d7e7f80818283848586"
+    },
+    {
+      "block": 14,
+      "hex": "8788898a8b8c8d8e8f90919293949596"
+    },
+    {
+      "block": 16,
+      "hex": "9798999a9b9c9d9e9fa0a1a2a3a4a5a6"
+    },
+    {
+      "block": 17,
+      "hex": "a7a8a9aaabacadaeafb0b1b2b3b4b5b6"
+    },
+    {
+      "block": 18,
+      "hex": "b7b8b9babbbcbdbebfc0c1c2c3c4c5c6"
+    },
+    {
+      "block": 20,
+      "hex": "c7c8c9cacbcccdcecfd0d1d2d3d4d5d6"
+    },
+    {
+      "block": 21,
+      "hex": "d7d8d9dadbdcdddedfe0e1e2e3e4e5e6"
+    },
+    {
+      "block": 22,
+      "hex": "e7e8e9eaebecedeeeff0f1f2f3f4f5f6"
+    },
+    {
+      "block": 24,
+      "hex": "f7f8f9fafbfcfdfeff00010203040506"
+    },
+    {
+      "block": 25,
+      "hex": "0708090a0b0c0d0e0f10111213141516"
+    },
+    {
+      "block": 26,
+      "hex": "1718191a1b1c1d1e1f20212223242526"
+    },
+    {
+      "block": 28,
+      "hex": "2728292a2b2c2d2eddd463c100000000"
+    }
+  ]
+}

--- a/webapp/test/interop-dart.test.ts
+++ b/webapp/test/interop-dart.test.ts
@@ -11,6 +11,7 @@ import { gzipDecompress } from '../src/gzip.js';
 import { restore } from '../src/pipeline.js';
 import { unwrapFilename } from '../src/filename.js';
 import { fromHex } from './hex.js';
+import { chunkToBlocks } from '../src/mifare/card-layout.js';
 
 interface Fixture {
   payloadSize: number;
@@ -72,4 +73,39 @@ test('TS restores a Dart filename-wrapped, compressed+encrypted archive and reco
   const { fileName, data } = unwrapFilename(raw);
   assert.equal(fileName, fixture.wrappedFileName);
   assert.deepEqual(data, fromHex(fixture.wrappedOriginal));
+});
+
+interface MifareFixture {
+  payloadLength: number;
+  blocks: Array<{ block: number; hex: string }>;
+}
+
+// dist/test/ -> ../../test/fixtures (fixtures are not compiled by tsc)
+const mifareFixturePath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../test/fixtures/mifare-card.json',
+);
+const mifareFixture: MifareFixture = JSON.parse(readFileSync(mifareFixturePath, 'utf8'));
+
+test('Dart and TypeScript produce identical Mifare card images', () => {
+  const payload = new Uint8Array(mifareFixture.payloadLength).map((_, i) => (i + 3) % 256);
+  const bytes = encodeChunk({
+    archiveId: new Uint8Array(16).fill(4),
+    totalChunks: 1,
+    chunkIndex: 0,
+    payload,
+    crc32: crc32(payload),
+    flags: 0,
+  });
+
+  const ours = chunkToBlocks(bytes);
+  assert.equal(ours.length, mifareFixture.blocks.length);
+  for (let i = 0; i < ours.length; i++) {
+    assert.equal(ours[i]!.block, mifareFixture.blocks[i]!.block);
+    assert.equal(
+      Array.from(ours[i]!.data, (b) => b.toString(16).padStart(2, '0')).join(''),
+      mifareFixture.blocks[i]!.hex,
+      `block ${ours[i]!.block} differs`,
+    );
+  }
 });


### PR DESCRIPTION
Closes a real interop hole. The web app writes Mifare Classic cards as raw NFAR blocks; the Flutter app was NDEF-only, calling `Ndef.from(tag)` on both its read and write paths and giving up when it returned null. **Those cards were invisible to the phone entirely** — it could neither read nor write them, quietly splitting a user's card collection into two incompatible families.

## Approach

`NfcRepository` no longer assumes a medium. A `TagCodec` seam selects per tapped card:

```
MifareClassic.from(tag) != null  → MifareTagCodec
else Ndef.from(tag) != null      → NdefTagCodec
else                             → the existing "no NDEF" classification
```

Mifare is tried first because this app never writes NDEF onto Classic, so a card exposing `MifareClassic` is unambiguously ours — NDEF-first would let a Classic card that another app had NDEF-formatted route to the wrong codec.

- **`lib/core/mifare/card_layout.dart` is a deliberate port** of `webapp/src/mifare/card-layout.ts`, not an independent implementation, and `tool/generate_mifare_fixtures.dart` + a new assertion in the web app's `interop-dart.test.ts` prove the two produce **byte-identical card images**. It passed first time across 21 blocks.
- **Sector trailers are never written** and only factory key A is used, so cards stay re-writable. The reviewer verified analytically, for all inputs rather than just the tested ones, that no value reaching `writeBlock` can be block 0 or satisfy `b % 4 == 3`.
- **Hardware capability** is detected via a `com.nfcarchiver/nfc_capabilities` platform channel querying `com.nxp.mifare`, and the tag-type option is hidden when absent rather than offered and failing at tap. Every failure path returns `false` rather than throwing, because on iOS an unimplemented channel is the *normal* outcome.
- `classifyNdefUnavailable` gained a third outcome so a Mifare card tapped on incapable hardware says so, instead of inviting an endless retry.
- Two new strings in all 7 ARB files.

## Verification

- **68 Flutter tests** (38 at branch start), **224 web app tests**, `flutter analyze` steady at its 22 pre-existing infos
- The `TagCodec` refactor landed with the suite at 47 before and 47 after — that identity was the proof it changed nothing
- The NDEF write path's accept/reject decision is byte-for-byte unchanged; `NdefTagCodec.capacityBytes` is deliberately **unused** because its formula is 1–4 bytes stricter than the live comparison and would reject chunks the app accepts today

## Not verified — needs a real card

No simulator implements CRYPTO1, so **nothing below the `MifareBlockIO` seam has ever executed**. Unproven until hardware:

- that capable phones populate `tag.data['mifareclassic']` at all — if not, the feature silently degrades to "not NDEF" errors and **no test would catch it**
- whether 47 sequential auth/write/read-back triples complete before a user lifts the card
- whether a card written by the phone is readable by the Chameleon on physical silicon (the fixture proves the byte *images* match, not that the write reached the card)

## Known follow-ups (final review judged both ship-able)

- On non-NXP phones, an NFC-A tag Android didn't tag as `MifareUltralight` (DESFire, NTAG I2C, clones) whose NDEF detection aborted now reports "looks like a Mifare Classic card" instead of "try again". Narrowing the guard would restore it.
- `mifareNotSupportedOnDevice` is translated in all 7 ARBs but unwired — its text is still hardcoded in `ndef_availability.dart`, which needs a typed-error-code refactor first. So the one string this branch adds to the read path reaches non-English users in English.

Spec: `docs/superpowers/specs/2026-07-31-flutter-mifare-classic-design.md`
Plan: `docs/superpowers/plans/2026-07-31-flutter-mifare-classic.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)