### PR TITLE
fix(webapp): one persistent Web NFC scan, and loops that cannot starve

### DIFF
--- a/docs/superpowers/plans/2026-07-31-web-nfc-scan-model-fix.md
+++ b/docs/superpowers/plans/2026-07-31-web-nfc-scan-model-fix.md
@@ -1,0 +1,815 @@
+# Web NFC Scan-Model Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the Web NFC reader from freezing the browser, by giving `BrowserNdefIO` one persistent scan instead of one scan per read, and by making both card loops incapable of starving the main thread.
+
+**Architecture:** `NdefIO` gains `start()`. `BrowserNdefIO` arms exactly one `scan()` per instance, delivers each `reading` to a waiter or a short-lived buffer, and is discarded on disconnect. It also gains an injectable reader factory so the file that actually had the bug becomes testable. Both loops gain a pacing helper and a consecutive-failure breaker.
+
+**Tech Stack:** TypeScript, esbuild, `node --test`, Web NFC (`NDEFReader`).
+
+**Source spec:** `docs/superpowers/specs/2026-07-31-web-nfc-scan-model-fix-design.md`
+
+## Global Constraints
+
+- **Node >= 22.** Prefix every command with `source ~/.nvm/nvm.sh && nvm use --lts` — the shell default is Node 14.
+- **Always `rm -rf dist && npm test`**, never bare `npm test`.
+- All commands run from `webapp/`.
+- **253 tests pass at branch start**; `tsc` clean. No new runtime dependencies, no `any`.
+- **`src/` must stay importable under `node --test`** — no `NDEFReader`, `navigator`, `window` or `document` at module scope or in module-level initialisers.
+- **`chameleon-ultra.js` may be imported ONLY** in `src/transport/sdk-chameleon-device.ts` and `app/ui/device.ts`.
+- **The Chameleon path must not change behaviour.** `NtagTransport`, `AutoTransport`, `chameleon-ble.ts` and `card-layout.ts` are not touched.
+- New user-facing strings go in **all seven** i18n catalogues (`en, ru, uk, be, pl, tr, ka`); `t` is a live binding, never captured at module scope.
+- Commit style `fix(webapp): …` / `test(webapp): …`, ending with:
+  `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>`
+
+## File Structure
+
+**Created:** `src/loop-guards.ts` (pacing + breaker, pure), `test/loop-guards.test.ts`, `test/browser-ndef-io.test.ts`.
+
+**Modified:** `src/transport/ndef-io.ts` (add `start()`), `app/ui/browser-ndef-io.ts` (rewrite), `test/fake-ndef-io.ts`, `src/transport/web-nfc-transport.ts` (`connect()`), `app/ui/device.ts`, `app/ui/restore-panel.ts`, `app/ui/archive-orchestrator.ts`, `app/i18n/*.ts` (7), `webapp/README.md`.
+
+---
+
+### Task 1: Loop guards
+
+**Files:**
+- Create: `src/loop-guards.ts`, `test/loop-guards.test.ts`
+
+**Interfaces:**
+- Produces: `ensureMinInterval(startedAt: number, minMs: number): Promise<void>`, `class FailureBreaker { constructor(limit?: number); record(errorName: string): boolean; reset(): void; }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/loop-guards.test.ts`:
+
+```ts
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { ensureMinInterval, FailureBreaker } from '../src/loop-guards.js';
+
+test('ensureMinInterval resolves immediately once the interval has passed', async () => {
+  const before = Date.now();
+  await ensureMinInterval(Date.now() - 500, 250);
+  assert.ok(Date.now() - before < 100, 'should not have waited');
+});
+
+test('ensureMinInterval waits out the remainder', async () => {
+  const before = Date.now();
+  await ensureMinInterval(Date.now(), 120);
+  assert.ok(Date.now() - before >= 100, 'should have waited roughly the interval');
+});
+
+test('the breaker trips after the limit of identical failures', () => {
+  const b = new FailureBreaker(3);
+  assert.equal(b.record('CardReadError'), false);
+  assert.equal(b.record('CardReadError'), false);
+  assert.equal(b.record('CardReadError'), true);
+});
+
+test('a different error name restarts the count', () => {
+  const b = new FailureBreaker(3);
+  b.record('CardReadError');
+  b.record('CardReadError');
+  assert.equal(b.record('WriteVerifyError'), false, 'a new kind of failure starts over');
+  assert.equal(b.record('WriteVerifyError'), false);
+});
+
+test('reset clears the count', () => {
+  const b = new FailureBreaker(2);
+  b.record('CardReadError');
+  b.reset();
+  assert.equal(b.record('CardReadError'), false);
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+```bash
+source ~/.nvm/nvm.sh && nvm use --lts
+cd webapp && rm -rf dist && npm test
+```
+
+Expected: FAIL — cannot find `../src/loop-guards.js`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/loop-guards.ts`:
+
+```ts
+/**
+ * Guards that keep a retry loop from starving the main thread.
+ *
+ * A card loop retries on error. If the transport rejects instantly — as the
+ * Web NFC adapter did when it re-armed an already-running scan — `continue`
+ * produces an unbroken chain of already-rejected promises. Awaiting one of
+ * those yields a microtask but never returns to the event loop's task queue,
+ * so nothing renders and no input is handled: the browser locks up hard
+ * enough that the user cannot even press Stop.
+ */
+
+/** Wait out the remainder of `minMs` since `startedAt`. */
+export function ensureMinInterval(startedAt: number, minMs: number): Promise<void> {
+  const remaining = minMs - (Date.now() - startedAt);
+  if (remaining <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, remaining));
+}
+
+/**
+ * Trips after `limit` consecutive failures of the same kind, so a loop that
+ * cannot make progress stops and says why instead of retrying forever.
+ *
+ * Callers must not record conditions that mean "the user has not tapped yet"
+ * — see the exclusion lists at each call site.
+ */
+export class FailureBreaker {
+  constructor(private readonly limit: number = 5) {}
+
+  private lastName: string | null = null;
+  private count = 0;
+
+  /** Record a failure. Returns true when the loop should stop. */
+  record(errorName: string): boolean {
+    if (errorName === this.lastName) {
+      this.count += 1;
+    } else {
+      this.lastName = errorName;
+      this.count = 1;
+    }
+    return this.count >= this.limit;
+  }
+
+  reset(): void {
+    this.lastName = null;
+    this.count = 0;
+  }
+}
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+```bash
+cd webapp && rm -rf dist && npm test
+```
+
+Expected: PASS, 5 new tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add webapp/src/loop-guards.ts webapp/test/loop-guards.test.ts
+git commit -m "fix(webapp): add loop pacing and a consecutive-failure breaker"
+```
+
+---
+
+### Task 2: `NdefIO.start()` and the fake
+
+**Files:**
+- Modify: `src/transport/ndef-io.ts`, `test/fake-ndef-io.ts`
+
+**Interfaces:**
+- Produces: `NdefIO.start(): Promise<void>`; `FakeNdefIO` gains `scanArmCount: number`, and `tap()` now resolves a waiting `awaitReading()` directly.
+
+The fake must model the real constraint, or it cannot catch this bug: **starting twice is an error**, and `awaitReading()` never starts anything.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/web-nfc-transport.test.ts`:
+
+```ts
+test('a multi-card scan arms the reader exactly once', async () => {
+  const io = new FakeNdefIO();
+  const t = new WebNfcTransport(io, NtagType.NTAG215);
+  await t.connect();
+  for (let i = 1; i <= 3; i++) {
+    io.tap(`04:0${i}:02:03`);
+    const tag = await t.awaitTag();
+    assert.equal(tag.uid[1], i);
+  }
+  assert.equal(io.scanArmCount, 1, 'each card must reuse the one scan');
+});
+
+test('reading before the scan is started is a programming error', async () => {
+  const io = new FakeNdefIO();
+  io.tap('04:01:02:03');
+  await assert.rejects(() => io.awaitReading(), /not started/i);
+});
+
+test('starting twice is rejected, as the real API does', async () => {
+  const io = new FakeNdefIO();
+  await io.start();
+  await assert.rejects(() => io.start(), /already/i);
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+```bash
+cd webapp && rm -rf dist && npm test
+```
+
+Expected: FAIL — `scanArmCount` and `start` do not exist.
+
+- [ ] **Step 3: Add `start()` to the interface**
+
+In `src/transport/ndef-io.ts`, add to `NdefIO` above `awaitReading`:
+
+```ts
+  /** Arm the single scan. Call once, before any awaitReading(). Rejects if the
+   *  browser refuses — permission denied, unsupported, or already scanning. */
+  start(): Promise<void>;
+```
+
+- [ ] **Step 4: Rewrite the fake**
+
+Replace `test/fake-ndef-io.ts` with:
+
+```ts
+import { TagTimeoutError } from '../src/transport/transport.js';
+import type { NdefIO, NdefReading, NdefRecordInit } from '../src/transport/ndef-io.js';
+
+/**
+ * In-memory Web NFC, modelling the real constraint that made the shipped
+ * adapter freeze the browser: exactly one scan may be armed per instance, and
+ * awaitReading() never arms one. `scanArmCount` is what the regression test
+ * asserts.
+ */
+export class FakeNdefIO implements NdefIO {
+  scanArmCount = 0;
+  writes: NdefRecordInit[][] = [];
+  failNextWrite: Error | null = null;
+  failStart: Error | null = null;
+
+  private started = false;
+  private pending: NdefReading[] = [];
+  private waiter: ((r: NdefReading) => void) | null = null;
+  private current: NdefReading | null = null;
+
+  async start(): Promise<void> {
+    if (this.failStart !== null) throw this.failStart;
+    if (this.started) throw new Error('A scan is already in progress');
+    this.started = true;
+    this.scanArmCount += 1;
+  }
+
+  /** Simulate a tag entering the field. */
+  tap(serialNumber: string, records: NdefReading['records'] = []): void {
+    const reading: NdefReading = { serialNumber, records };
+    this.current = reading;
+    if (this.waiter !== null) {
+      const w = this.waiter;
+      this.waiter = null;
+      w(reading);
+      return;
+    }
+    this.pending.push(reading);
+  }
+
+  async awaitReading(opts?: { timeoutMs?: number; signal?: AbortSignal }): Promise<NdefReading> {
+    if (!this.started) throw new Error('Scan not started');
+    if (opts?.signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+    const buffered = this.pending.shift();
+    if (buffered !== undefined) return buffered;
+    if (opts?.timeoutMs !== undefined) throw new TagTimeoutError('no tag presented');
+    return new Promise<NdefReading>((resolve, reject) => {
+      this.waiter = resolve;
+      opts?.signal?.addEventListener('abort', () => {
+        this.waiter = null;
+        reject(new DOMException('Aborted', 'AbortError'));
+      }, { once: true });
+    });
+  }
+
+  async write(records: NdefRecordInit[]): Promise<void> {
+    if (this.failNextWrite !== null) {
+      const err = this.failNextWrite;
+      this.failNextWrite = null;
+      throw err;
+    }
+    this.writes.push(records);
+    if (this.current !== null) {
+      // Re-present the same tag with its new contents, as a re-tap would.
+      this.tap(this.current.serialNumber, records.map((r) => ({
+        recordType: r.recordType, mediaType: r.mediaType, data: r.data,
+      })));
+    }
+  }
+
+  stop(): void {
+    this.started = false;
+    this.pending = [];
+    this.waiter = null;
+    this.current = null;
+  }
+}
+```
+
+- [ ] **Step 5: Fix the callers the new contract breaks**
+
+`awaitReading()` now throws unless `start()` ran. Every test that drives `FakeNdefIO` through a transport must `await transport.connect()` first (Task 3 wires `connect()` to `start()`; until then add `await io.start()` directly).
+
+Run the suite and fix each failure by adding the missing `connect()`/`start()`, **not** by relaxing the fake:
+
+```bash
+cd webapp && rm -rf dist && npm test
+```
+
+Check `test/web-nfc-transport.test.ts` (including its `runTransportContract` block) and `test/archive-orchestrator.test.ts`.
+
+- [ ] **Step 6: Verify**
+
+```bash
+cd webapp && rm -rf dist && npm test
+```
+
+Expected: PASS. The `scanArmCount` test passes because the fake never arms on read — the real proof comes in Task 3.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add webapp/src/transport/ndef-io.ts webapp/test/fake-ndef-io.ts webapp/test/web-nfc-transport.test.ts webapp/test/archive-orchestrator.test.ts
+git commit -m "fix(webapp): add NdefIO.start() and model the one-scan rule in the fake"
+```
+
+---
+
+### Task 3: Rewrite `BrowserNdefIO`
+
+**Files:**
+- Modify: `app/ui/browser-ndef-io.ts`
+- Create: `test/browser-ndef-io.test.ts`
+
+**Interfaces:**
+- Consumes: `NdefIO`, `NdefReading`, `NdefRecordInit`, `TagTimeoutError`, `CardCapacityError`.
+- Produces: `class BrowserNdefIO implements NdefIO` with `constructor(makeReader?: () => NdefReaderLike)`, and `export interface NdefReaderLike`.
+
+**This is the file that had the bug, and the injectable factory is what finally makes it testable.** It touches browser globals only inside function bodies, so with the factory injected the whole file imports and runs under `node --test`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/browser-ndef-io.test.ts`:
+
+```ts
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { BrowserNdefIO, type NdefReaderLike } from '../app/ui/browser-ndef-io.js';
+
+/** A stand-in NDEFReader that records how often a scan was armed and lets a
+ *  test deliver reading events by hand. */
+class FakeReader implements NdefReaderLike {
+  scanCount = 0;
+  onreading: ((e: { serialNumber: string; message: { records: [] } }) => void) | null = null;
+  onreadingerror: ((e: unknown) => void) | null = null;
+  failScan: Error | null = null;
+
+  async scan(options: { signal: AbortSignal }): Promise<void> {
+    if (this.failScan !== null) throw this.failScan;
+    this.scanCount += 1;
+    if (options.signal.aborted) throw new DOMException('Aborted', 'AbortError');
+  }
+  async write(): Promise<void> {}
+
+  deliver(serialNumber: string): void {
+    this.onreading?.({ serialNumber, message: { records: [] } });
+  }
+}
+
+test('many readings are served by a single armed scan', async () => {
+  const reader = new FakeReader();
+  const io = new BrowserNdefIO(() => reader);
+  await io.start();
+
+  for (let i = 1; i <= 3; i++) {
+    const pending = io.awaitReading();
+    reader.deliver(`04:0${i}`);
+    const reading = await pending;
+    assert.equal(reading.serialNumber, `04:0${i}`);
+  }
+  assert.equal(reader.scanCount, 1, 'the shipped bug re-armed the scan per read');
+});
+
+test('start() rejects when the browser refuses the scan', async () => {
+  const reader = new FakeReader();
+  reader.failScan = new DOMException('denied', 'NotAllowedError');
+  const io = new BrowserNdefIO(() => reader);
+  await assert.rejects(() => io.start(), /denied/);
+});
+
+test('a reading with nobody waiting is served to the next caller', async () => {
+  const reader = new FakeReader();
+  const io = new BrowserNdefIO(() => reader);
+  await io.start();
+  reader.deliver('04:aa');
+  assert.equal((await io.awaitReading()).serialNumber, '04:aa');
+});
+
+test('two concurrent waits are a programming error', async () => {
+  const reader = new FakeReader();
+  const io = new BrowserNdefIO(() => reader);
+  await io.start();
+  const first = io.awaitReading();
+  await assert.rejects(() => io.awaitReading(), /already waiting/i);
+  reader.deliver('04:bb');
+  await first;
+});
+
+test('stop() ends the scan and clears the buffer', async () => {
+  const reader = new FakeReader();
+  const io = new BrowserNdefIO(() => reader);
+  await io.start();
+  reader.deliver('04:cc');
+  io.stop();
+  await assert.rejects(() => io.awaitReading(), /not started/i);
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+```bash
+cd webapp && rm -rf dist && npm test
+```
+
+Expected: FAIL — `BrowserNdefIO` takes no constructor argument and `NdefReaderLike` is not exported.
+
+- [ ] **Step 3: Rewrite the implementation**
+
+Replace the class in `app/ui/browser-ndef-io.ts` (keep the existing `NdefReadingEventLike` interface and `webNfcAvailable()`; **export** `NdefReaderLike`):
+
+```ts
+/** How long a reading with no waiter stays usable. Covers the few-millisecond
+ *  gap between one card completing and the loop asking for the next; anything
+ *  older would be a tap from a different moment replayed into this operation. */
+const BUFFER_MS = 2000;
+
+export class BrowserNdefIO implements NdefIO {
+  /** Injectable so this file is testable under node --test, where NDEFReader
+   *  does not exist. Production passes nothing. */
+  constructor(
+    private readonly makeReader: () => NdefReaderLike = () => {
+      const Ctor = (globalThis as { NDEFReader?: new () => NdefReaderLike }).NDEFReader;
+      if (Ctor === undefined) throw new Error('Web NFC is not available in this browser');
+      return new Ctor();
+    },
+  ) {}
+
+  private reader: NdefReaderLike | null = null;
+  private scanning: AbortController | null = null;
+  private waiter: { resolve: (r: NdefReading) => void; reject: (e: unknown) => void } | null = null;
+  private buffered: { reading: NdefReading; at: number } | null = null;
+
+  async start(): Promise<void> {
+    if (this.reader !== null) throw new Error('A scan is already in progress');
+    const reader = this.makeReader();
+    const ac = new AbortController();
+
+    reader.onreading = (event) => {
+      const reading: NdefReading = {
+        serialNumber: event.serialNumber ?? '',
+        records: event.message.records.map((rec) => ({
+          recordType: rec.recordType,
+          mediaType: rec.mediaType,
+          data: rec.data === undefined
+            ? undefined
+            : new Uint8Array(rec.data.buffer, rec.data.byteOffset, rec.data.byteLength),
+        })),
+      };
+      const w = this.waiter;
+      if (w !== null) {
+        this.waiter = null;
+        w.resolve(reading);
+        return;
+      }
+      this.buffered = { reading, at: Date.now() };
+    };
+
+    reader.onreadingerror = () => {
+      const w = this.waiter;
+      if (w !== null) {
+        this.waiter = null;
+        w.reject(new Error('Could not read the tag — hold it still and try again'));
+      }
+    };
+
+    // The one and only scan for this instance. Re-arming a reader is what froze
+    // the browser: it rejects synchronously, and a retry loop then spins.
+    await reader.scan({ signal: ac.signal });
+    this.reader = reader;
+    this.scanning = ac;
+  }
+
+  async awaitReading(opts?: { timeoutMs?: number; signal?: AbortSignal }): Promise<NdefReading> {
+    if (this.reader === null) throw new Error('Scan not started');
+    if (this.waiter !== null) throw new Error('Already waiting for a reading');
+    if (opts?.signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+
+    const buffered = this.buffered;
+    this.buffered = null;
+    if (buffered !== null && Date.now() - buffered.at <= BUFFER_MS) return buffered.reading;
+
+    return new Promise<NdefReading>((resolve, reject) => {
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      const settle = (): void => {
+        if (timer !== null) clearTimeout(timer);
+        opts?.signal?.removeEventListener('abort', onAbort);
+        this.waiter = null;
+      };
+      const onAbort = (): void => { settle(); reject(new DOMException('Aborted', 'AbortError')); };
+
+      this.waiter = {
+        resolve: (r) => { settle(); resolve(r); },
+        reject: (e) => { settle(); reject(e); },
+      };
+      opts?.signal?.addEventListener('abort', onAbort, { once: true });
+      if (opts?.timeoutMs !== undefined) {
+        timer = setTimeout(() => {
+          settle();
+          reject(new TagTimeoutError(`No tag presented within ${opts.timeoutMs}ms`));
+        }, opts.timeoutMs);
+      }
+    });
+  }
+
+  async write(records: NdefRecordInit[]): Promise<void> {
+    const reader = this.reader;
+    if (reader === null) throw new Error('Scan not started');
+    try {
+      await reader.write({ records });
+    } catch (e) {
+      if (e instanceof DOMException &&
+          (e.name === 'NotSupportedError' || e.name === 'NetworkError')) {
+        throw new CardCapacityError(
+          'The card rejected the write — it may be smaller than the selected tag type',
+        );
+      }
+      throw e;
+    }
+  }
+
+  stop(): void {
+    this.scanning?.abort();
+    this.scanning = null;
+    if (this.reader !== null) {
+      this.reader.onreading = null;
+      this.reader.onreadingerror = null;
+      this.reader = null;
+    }
+    this.waiter?.reject(new DOMException('Aborted', 'AbortError'));
+    this.waiter = null;
+    this.buffered = null;
+  }
+}
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+```bash
+cd webapp && rm -rf dist && npm test
+```
+
+Expected: PASS, 5 new tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add webapp/app/ui/browser-ndef-io.ts webapp/test/browser-ndef-io.test.ts
+git commit -m "fix(webapp): arm exactly one Web NFC scan per adapter instance"
+```
+
+---
+
+### Task 4: Connect starts the scan
+
+**Files:**
+- Modify: `src/transport/web-nfc-transport.ts`, `app/ui/device.ts`
+
+**Interfaces:**
+- Consumes: `NdefIO.start()` (Task 2).
+- Produces: `WebNfcTransport.connect()` now arms the scan; `activateWebNfc()` awaits it.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/web-nfc-transport.test.ts`:
+
+```ts
+test('connect arms the scan, and a refusal surfaces from connect', async () => {
+  const ok = new FakeNdefIO();
+  await new WebNfcTransport(ok, NtagType.NTAG215).connect();
+  assert.equal(ok.scanArmCount, 1);
+
+  const bad = new FakeNdefIO();
+  bad.failStart = new Error('NFC permission denied');
+  await assert.rejects(
+    () => new WebNfcTransport(bad, NtagType.NTAG215).connect(),
+    /permission denied/,
+  );
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+```bash
+cd webapp && rm -rf dist && npm test
+```
+
+Expected: FAIL — `scanArmCount` is 0, because `connect()` is still empty.
+
+- [ ] **Step 3: Wire the transport**
+
+In `src/transport/web-nfc-transport.ts`, replace the empty `connect()`:
+
+```ts
+  async connect(): Promise<void> {
+    // Arm the single scan here rather than lazily on first read: the permission
+    // prompt then appears when the user asked for NFC, inside their gesture,
+    // and a refusal surfaces at the button instead of inside a scan loop.
+    await this.io.start();
+  }
+```
+
+- [ ] **Step 4: Make the device bar await it**
+
+In `app/ui/device.ts`, inside `activateWebNfc()`, replace the assignment so the transport is connected before the UI claims success:
+
+```ts
+      const t0 = new WebNfcTransport(new BrowserNdefIO(), selectedNtagType());
+      await t0.connect();
+      transport = t0;
+```
+
+Leave the rest of the `try` block and the existing `catch (e) { await failHandOff(...) }` untouched — the catch already tears down, re-renders, updates buttons and notifies.
+
+- [ ] **Step 5: Verify**
+
+```bash
+cd webapp && rm -rf dist && npm test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add webapp/src/transport/web-nfc-transport.ts webapp/app/ui/device.ts webapp/test/web-nfc-transport.test.ts
+git commit -m "fix(webapp): arm the Web NFC scan when connecting, not on first read"
+```
+
+---
+
+### Task 5: Guards in both loops
+
+**Files:**
+- Modify: `app/ui/restore-panel.ts`, `app/ui/archive-orchestrator.ts`, `app/i18n/*.ts` (all 7)
+- Test: `test/archive-orchestrator.test.ts`
+
+**Interfaces:**
+- Consumes: `ensureMinInterval`, `FailureBreaker` (Task 1).
+- Produces: new i18n key `scanGaveUp`.
+
+**The exclusions are the load-bearing part.** `TagTimeoutError` fires every 20 s with the Chameleon while the user hunts for the next card — counting it would abort a healthy archive after 90 seconds of not tapping.
+
+- [ ] **Step 1: Add the string to all seven catalogues**
+
+In `app/i18n/en.ts`:
+
+```ts
+  scanGaveUp: (message: string) => `Stopped after repeated failures: ${message}`,
+```
+
+Add the same key, translated, to `ru.ts`, `uk.ts`, `be.ts`, `pl.ts`, `tr.ts`, `ka.ts`. `tsc` fails until all seven have it.
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `test/archive-orchestrator.test.ts`:
+
+```ts
+test('the write loop stops after repeated identical failures instead of spinning', async () => {
+  let attempts = 0;
+  const failing = {
+    ...new MockTransport(),
+    name: 'always-fails',
+    async awaitTag() { attempts += 1; throw new CardReadError('boom'); },
+  } as unknown as Transport;
+
+  const io = makeIO(failing);
+  await new ArchiveOrchestrator(io).run(failing, {
+    data: new Uint8Array(50), fileName: 'x.bin', compress: false, payloadSize: 100,
+  });
+
+  assert.ok(attempts <= 6, `expected the breaker to stop it, got ${attempts} attempts`);
+  assert.ok(io.statuses.some((s) => s.includes('Stopped after repeated failures')));
+});
+```
+
+Adapt `makeIO` and `MockTransport` to whatever the file already uses; the assertions are what matter.
+
+- [ ] **Step 3: Run the test and verify it fails**
+
+```bash
+cd webapp && rm -rf dist && npm test
+```
+
+Expected: FAIL — the loop retries forever, so the test times out or `attempts` is huge.
+
+- [ ] **Step 4: Guard the archive loop**
+
+In `app/ui/archive-orchestrator.ts`, import `ensureMinInterval` and `FailureBreaker` from `../../src/loop-guards.js`, create `const breaker = new FailureBreaker();` before the `while (!done)` loop, and record `const iterationStart = Date.now();` as the loop's first statement.
+
+In the `catch (e)` block, before the existing `TagTimeoutError` / `UnsupportedTagError` / `OverwriteRequiredError` branches, add pacing; and in the final catch-all branch, add the breaker:
+
+```ts
+        await ensureMinInterval(iterationStart, 250);
+```
+
+```ts
+        // Waiting for the user is not failing: TagTimeoutError, an overwrite
+        // prompt and an abort must never count toward the breaker.
+        const name = e instanceof Error ? e.name : 'unknown';
+        if (breaker.record(name)) {
+          this.io.setStatus(t.scanGaveUp(humanError(e)));
+          this.io.log.error('archive', 'Stopped after repeated failures', { error: String(e) });
+          return;
+        }
+```
+
+Call `breaker.reset()` immediately after a successful `ctrl.writeNextCard(...)`.
+
+- [ ] **Step 5: Guard the restore loop**
+
+In `app/ui/restore-panel.ts`, apply the same shape to the `for (;;)` loop: `const breaker = new FailureBreaker();` before it, `const iterationStart = Date.now();` as its first statement, `breaker.reset()` after a successful `scanStep`, and in the catch — after the `AbortError` break and the `TagTimeoutError` continue, both of which stay unguarded — add `await ensureMinInterval(iterationStart, 250);` plus the breaker check that sets `t.scanGaveUp(humanError(e))` and `break`s out of the loop.
+
+- [ ] **Step 6: Verify**
+
+```bash
+cd webapp && rm -rf dist && npm test
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add webapp/app/ui/restore-panel.ts webapp/app/ui/archive-orchestrator.ts webapp/app/i18n/ webapp/test/archive-orchestrator.test.ts
+git commit -m "fix(webapp): pace both card loops and stop them after repeated failures"
+```
+
+---
+
+### Task 6: Documentation
+
+**Files:**
+- Modify: `webapp/README.md`
+
+- [ ] **Step 1: Correct the hardware-risk section**
+
+The Readers section currently warns that `scan({signal})` may not reject on abort, leaving a pending `awaitReading()` unresolved. **That risk was wrong** — abort works; what fails is re-scanning the same reader afterwards, and that is now impossible by construction.
+
+Replace it with what is actually true after this change: one scan is armed per connection and reused for every card; a reading arriving with no waiter is held for two seconds; both loops pace their retries and stop after five consecutive failures of the same kind. Keep the `NotSupportedError`/`NetworkError` → `CardCapacityError` note, which is still spec-derived and unverified.
+
+State plainly what remains unproven on hardware: that `scan()` succeeds at all, and that `onreading` fires repeatedly for one persistent scan across many taps.
+
+- [ ] **Step 2: Verify the production build**
+
+```bash
+cd webapp && rm -rf dist site && BUILD_SHA=$(git rev-parse HEAD) npm run build:site
+```
+
+Expected: `site/ built and verified — nfar-build:<sha>, bundle <N> B`.
+
+- [ ] **Step 3: Final check**
+
+```bash
+cd webapp && rm -rf dist && npm test
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add webapp/README.md
+git commit -m "docs(webapp): correct the Web NFC scan-model risk note"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| One scan per instance, asserted by tests | 3 (real adapter), 2 (fake models the rule) |
+| `start()` on the seam | 2 |
+| Reading buffer, 2000 ms | 3 |
+| Single waiter; concurrent wait rejects | 3 |
+| Connect arms the scan; refusal surfaces at the button | 4 |
+| Pacing helper, 250 ms, both loops | 1, 5 |
+| Breaker, 5 identical, with exclusions | 1, 5 |
+| Docs correction | 6 |
+
+**Deviation from the spec, deliberate:** the spec did not mention an injectable reader factory. Task 3 adds one, because without it `BrowserNdefIO` — the file that actually had the bug — remains untestable, and the "regression test" would only prove the fake behaves. With injection the real class is exercised under `node --test` and `reader.scanCount === 1` is a genuine assertion about shipped code. This also partly retires the ledger note that `device.ts`-adjacent files are untestable; `device.ts` itself is still not, because of `chameleon-ultra.js`.
+
+**Placeholder scan:** one soft spot, flagged rather than hidden — Task 5 Step 2's test must be adapted to whatever `makeIO`/`MockTransport` helpers `archive-orchestrator.test.ts` already defines, which I could not reproduce verbatim without reading that file at implementation time. The assertions are specified exactly; only the harness wiring is left to the implementer. If adapting it turns out to need more than a few lines, say so rather than reshaping the test.
+
+**Type consistency:** `ensureMinInterval(startedAt, minMs)` and `FailureBreaker.record(errorName) → boolean` / `.reset()` are used identically in Tasks 1 and 5. `NdefIO.start(): Promise<void>` is added in Task 2 and consumed in Tasks 3 and 4. `FakeNdefIO.scanArmCount` / `.failStart` are produced in Task 2 and asserted in Tasks 2 and 4. `NdefReaderLike` is exported in Task 3 and implemented by that task's `FakeReader`.

--- a/docs/superpowers/specs/2026-07-31-web-nfc-scan-model-fix-design.md
+++ b/docs/superpowers/specs/2026-07-31-web-nfc-scan-model-fix-design.md
@@ -1,0 +1,131 @@
+# Web NFC scan model: one persistent scan, and loops that cannot starve
+
+**Date:** 2026-07-31
+**Scope:** `webapp/` only. Fixes a production defect that hard-freezes the browser, and adds two guards so the same class of failure can never again be undiagnosable. No change to the NFAR format, on-tag bytes, the Chameleon transport, or the Flutter app.
+
+## The defect
+
+Reported from a real device (Pixel 8 Pro, GrapheneOS/Vanadium): connect over phone NFC, press **Scan cards**, and the browser freezes so hard that neither the Stop button nor tab switching responds. Tapping a card produces a vibration but nothing reaches the page.
+
+Diagnosed over wireless ADB. The evidence was decisive:
+
+| Measurement | Value |
+|---|---|
+| `NfcService: setReaderMode` (page arms a scan) | **1** |
+| `onTagRfDiscovered` (OS reads a tag) | **8** |
+| Renderer process CPU | **186%** |
+| Console output from the app | **0 lines** |
+
+### Root cause
+
+Web NFC's model is **one scan, many `reading` events**. `BrowserNdefIO.awaitReading()` was built as *one call = one scan*:
+
+```ts
+this.scanning?.abort();          // kill the live scan
+const ac = new AbortController();
+this.scanning = ac;
+reader.scan({ signal: ac.signal })   // ...and re-arm the SAME reader, same tick
+```
+
+So the second card aborts the running scan and immediately calls `scan()` again on the same `NDEFReader` instance, which rejects synchronously inside the renderer. The restore loop catches it and does a bare `continue`, producing an infinite cycle of immediately-rejected promises.
+
+`setReaderMode` appearing exactly once is what proves this: a genuine retry would reach the NFC service each time. It does not, because the rejection never leaves the renderer.
+
+The freeze is **microtask starvation** — awaiting an already-rejected promise yields a microtask but never returns to the event loop's task queue, so nothing renders and no input is handled. And because our own abort turned reader mode off, the eight subsequent taps were discovered by Android and delivered nowhere.
+
+### Two failures, not one
+
+1. **The scan model is wrong** — the direct cause.
+2. **The loops can starve the main thread** — what turned a bug into an unrecoverable freeze whose error was unreachable, because both loops log to an in-app buffer that cannot be read while the UI is wedged.
+
+Fixing only (1) would leave the app one fast-rejection away from the same outcome.
+
+## Decisions (confirmed with user)
+
+1. **The persistent scan starts at connect time**, not lazily on first use.
+2. **A reading arriving with no waiter is buffered — most recent only, briefly.**
+3. Fix both failures; do not ship the scan-model fix alone.
+
+## Architecture
+
+### The invariant
+
+> **`scan()` is called exactly once per `BrowserNdefIO` instance, and the instance is discarded on disconnect.**
+
+This is asserted by tests, not left to convention.
+
+### `BrowserNdefIO` becomes a scan owner
+
+`NdefIO` gains `start(): Promise<void>`.
+
+- **`start()`** creates the `NDEFReader`, installs `onreading`/`onreadingerror` **once**, and calls `scan({signal})` **once**. If `scan()` rejects, `start()` rejects.
+- **`awaitReading(opts)`** never calls `scan()`. It consumes a fresh buffered reading if one exists, otherwise registers itself as the single waiter, honouring `signal` and `timeoutMs`.
+- **`stop()`** aborts the scan, drops the reader, and clears the waiter and buffer. The instance is then dead; reconnecting constructs a new one.
+
+`onreading` resolves the waiter if there is one, and otherwise buffers.
+
+Only one waiter exists at a time. A second concurrent `awaitReading()` is a programming error and rejects immediately rather than silently replacing the first — the app never does this, and a silent replacement would be the same class of bug being fixed here.
+
+### The reading buffer
+
+A single slot, timestamped, valid for **2000 ms**.
+
+It exists for exactly one case: a tap landing in the few-millisecond gap between one card completing and the loop requesting the next. Without it that tap is silently lost, and across a ten-card pile the user is right to say a tap was ignored.
+
+Anything older than the window is discarded rather than replayed, so a tap made while idle cannot be fed into an operation started later.
+
+### What "connected" means
+
+`WebNfcTransport.connect()` — today an empty method kept only for interface parity — calls `io.start()`. `activateWebNfc()` then `await`s `transport.connect()` exactly as the Chameleon path already does, so both readers connect through the same shape and `device.ts` needs no knowledge of `NdefIO`. Three consequences:
+
+- the NFC permission prompt appears when the user asks for NFC
+- the call happens inside a real user gesture, which Web NFC can require
+- a refusal or an unsupported browser surfaces at the button, not inside a scan loop
+
+A rejection routes through the existing `failHandOff()`, which already tears down, re-renders, updates the buttons and notifies listeners.
+
+### Starvation guards
+
+**Pacing.** A dependency-free helper in `src/`:
+
+```ts
+export function ensureMinInterval(startedAt: number, minMs: number): Promise<void>
+```
+
+It awaits the remainder of `minMs` since `startedAt`, or resolves immediately if that has already elapsed. Both loops record an iteration start and call it on **every** error path, with `minMs = 250`. A retry can then never occur more than about four times a second regardless of transport behaviour.
+
+**Circuit breaker.** After **5 consecutive failures with the same error name**, the loop stops, releases the reader, and surfaces the error. The counter resets on any success.
+
+**Waiting is not failing.** The breaker must ignore conditions that mean "the user has not tapped yet", or it would abort a perfectly healthy session. Excluded from the count:
+
+- `TagTimeoutError` — with the Chameleon this fires every 20 s while the user hunts for the next card; five in a row is barely a minute and a half of not tapping, and aborting there would be a worse bug than the one being fixed
+- `OverwriteRequiredError` in the archive loop — that is a user prompt, not a failure
+- `AbortError` — that is the user pressing Stop
+
+Everything else counts. This converts "spins forever showing nothing" into "stops and says what broke".
+
+**Both guards apply to the archive write loop as well as the restore scan loop.** The archive loop's existing `usable()` check only catches a *swapped* transport; on a fast rejection where the transport is still current it does a bare `continue`. The Chameleon's 300 ms poll and 20 s timeout have been hiding that.
+
+## Testing
+
+- **The regression test for this bug:** `FakeNdefIO` records how many times a scan was armed. A test drives several `awaitReading()` calls across multiple simulated taps and asserts the count is exactly 1. This fails against the current code.
+- Buffer behaviour: a reading arriving with no waiter is consumed by the next `awaitReading()`; one older than the window is discarded and the caller waits for a real tap.
+- `start()` rejecting propagates to a failed connect rather than a half-connected state.
+- A second concurrent `awaitReading()` rejects.
+- `ensureMinInterval` resolves immediately when the interval has passed and delays when it has not.
+- The circuit breaker: a loop driven with repeated identical failures exits after 5 and surfaces the error, and the counter resets after an intervening success.
+
+## Non-goals
+
+- Any change to `NtagTransport`, `AutoTransport`, the Chameleon path, or on-tag bytes
+- Localizing the existing hardcoded strings in `browser-ndef-io.ts`
+- Making `device.ts` testable under `node --test` (it imports `chameleon-ultra.js`, which touches `BluetoothUUID` at module scope) — that refactor is real but separate
+- Mifare Classic over Web NFC, which remains impossible
+
+## What this still cannot verify
+
+That `scan()` succeeds on real hardware, and that `onreading` fires repeatedly for a single persistent scan across many taps. Both need the device again.
+
+The difference is that a failure now surfaces as a visible message instead of a frozen browser, so the next validation round is a read of the status line rather than a USB cable and a logcat capture.
+
+Separately confirmed during diagnosis: this device does **not** report `com.nxp.mifare`, so PR #50's Mifare Classic support cannot be validated on it at all.

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -97,23 +97,45 @@ Phone NFC's limits are the Web NFC API's, not a missing feature:
 a restore scan, or a card inspection in progress) — the same `readerBusy`
 interlock that also gates **Inspect card**.
 
-**Unverified on real hardware:** `app/ui/browser-ndef-io.ts` is the only file
-that touches `NDEFReader`, and two of its behaviours are written from the Web
-NFC specification, not from an observed Chrome session:
+**Scan model.** `app/ui/browser-ndef-io.ts` (`BrowserNdefIO`) is the only file
+that touches `NDEFReader`. It arms exactly one scan per connection —
+`WebNfcTransport.connect()` calls `io.start()` once, up front, in the user's
+gesture, so a refusal surfaces at the **Use phone NFC** button rather than
+inside a scan loop — and that single scan is reused for every card for the
+rest of the session; nothing ever calls `scan()` a second time on the same
+reader. A reading that arrives with no `awaitReading()` call waiting for it
+(the gap between one card finishing and the loop asking for the next) is held
+for two seconds and served to whichever call comes next, then discarded.
+`app/ui/archive-orchestrator.ts` and `app/ui/restore-panel.ts` both pace their
+retry loops to at least 250 ms/iteration and stop after five consecutive
+failures of the *same* error name, via `ensureMinInterval` / `FailureBreaker`
+in `src/loop-guards.ts`. Neither counts `TagTimeoutError`,
+`OverwriteRequiredError`, or an abort against that limit — waiting for the
+user to tap is not failing. The restore loop additionally excludes
+`UnsupportedTagError`: a restore pile legitimately contains foreign cards, so
+tapping several while sorting a stack is normal use. The archive loop counts
+`UnsupportedTagError` like any other failure, because a wrong-media tap during
+an active write is a genuine failure to progress.
 
-- the `DOMException` → `CardCapacityError` mapping (`NotSupportedError` /
-  `NetworkError` on a write that doesn't fit) may not match what Chrome
-  actually raises for an undersized card;
-- `awaitReading()` assumes `scan({ signal })` rejects with `AbortError` once
-  the passed `AbortSignal` fires. If Chrome instead just stops firing
-  `onreading`/`onreadingerror` without ever settling that promise, the pending
-  `awaitReading()` call never resolves or rejects — so whatever is awaiting a
-  tag (`awaitTag()` in `WebNfcTransport`, called from `writeNextCard()` /
-  `scanNextCard()` in `app/controller.ts`) is left waiting indefinitely. Those
-  call sites pass only `{ signal }`, no `timeoutMs`, so nothing rescues it.
-  Treat both as open questions until validated on an Android phone
-  running Chrome; [`HARDWARE_TESTING.md`](HARDWARE_TESTING.md) does not yet
-  have a phone-NFC checklist (it's Chameleon-only today).
+This replaces an earlier, real production incident: the previous version of
+`awaitReading()` called `scan()` again on every call, which aborted the still-live
+scan and re-armed the same `NDEFReader` in the same tick — a call that rejects
+*synchronously* on Chrome. The unthrottled retry loop around it then spun
+tightly enough to lock up the renderer (186% CPU, one `setReaderMode` call
+against eight tag discoveries in logcat) so hard the user couldn't press Stop
+or switch tabs on a Pixel 8 Pro. Abort itself was never the problem.
+
+Kept from before, still true: the `DOMException` → `CardCapacityError` mapping
+(`NotSupportedError` / `NetworkError` on a write that doesn't fit) is written
+from the Web NFC specification, not from an observed Chrome session, and may
+not match what Chrome actually raises for an undersized card.
+
+**Still unproven on real hardware:** whether `scan()` succeeds at all on a
+phone, and whether `onreading` then fires repeatedly off that one persistent
+scan across many taps, the way the whole design assumes. Treat both as open
+questions until validated on an Android phone running Chrome;
+[`HARDWARE_TESTING.md`](HARDWARE_TESTING.md) does not yet have a phone-NFC
+checklist (it's Chameleon-only today).
 
 ## Localization
 

--- a/webapp/app/i18n/be.ts
+++ b/webapp/app/i18n/be.ts
@@ -62,6 +62,7 @@ export const be: Messages = {
   unsupportedTapOther: 'Метка не падтрымліваецца — прыкладзіце Mifare Classic 1K або NTAG.',
   skippedTapDifferent: 'Прапушчана. Прыкладзіце іншую карту…',
   retryAfter: (message) => `${message} — прыкладзіце зноў, каб паўтарыць.`,
+  scanGaveUp: (message) => `Спынена з-за паўторных памылак: ${message}`,
 
   // — overwrite dialog —
   overwrite: 'Перазапісаць',

--- a/webapp/app/i18n/en.ts
+++ b/webapp/app/i18n/en.ts
@@ -60,6 +60,7 @@ export const en = {
   unsupportedTapOther: 'Unsupported tag — tap a Mifare Classic 1K or NTAG.',
   skippedTapDifferent: 'Skipped. Tap a different card…',
   retryAfter: (message: string) => `${message} — re-tap to retry.`,
+  scanGaveUp: (message: string) => `Stopped after repeated failures: ${message}`,
 
   // — overwrite dialog —
   overwrite: 'Overwrite',

--- a/webapp/app/i18n/ka.ts
+++ b/webapp/app/i18n/ka.ts
@@ -59,6 +59,7 @@ export const ka: Messages = {
   unsupportedTapOther: 'ტეგი მხარდაუჭერელია — მიადეთ Mifare Classic 1K ან NTAG.',
   skippedTapDifferent: 'გამოტოვებულია. მიადეთ სხვა ბარათი…',
   retryAfter: (message) => `${message} — გასამეორებლად მიადეთ ხელახლა.`,
+  scanGaveUp: (message) => `შეჩერდა განმეორებითი შეცდომების გამო: ${message}`,
 
   // — overwrite dialog —
   overwrite: 'გადაწერა',

--- a/webapp/app/i18n/pl.ts
+++ b/webapp/app/i18n/pl.ts
@@ -62,6 +62,7 @@ export const pl: Messages = {
   unsupportedTapOther: 'Nieobsługiwany tag — przyłóż Mifare Classic 1K lub NTAG.',
   skippedTapDifferent: 'Pominięto. Przyłóż inną kartę…',
   retryAfter: (message) => `${message} — przyłóż ponownie, aby spróbować jeszcze raz.`,
+  scanGaveUp: (message) => `Zatrzymano po powtarzających się błędach: ${message}`,
 
   // — overwrite dialog —
   overwrite: 'Nadpisz',

--- a/webapp/app/i18n/ru.ts
+++ b/webapp/app/i18n/ru.ts
@@ -62,6 +62,7 @@ export const ru: Messages = {
   unsupportedTapOther: 'Метка не поддерживается — приложите Mifare Classic 1K или NTAG.',
   skippedTapDifferent: 'Пропущено. Приложите другую карту…',
   retryAfter: (message) => `${message} — приложите снова для повтора.`,
+  scanGaveUp: (message) => `Остановлено из-за повторных ошибок: ${message}`,
 
   // — overwrite dialog —
   overwrite: 'Перезаписать',

--- a/webapp/app/i18n/tr.ts
+++ b/webapp/app/i18n/tr.ts
@@ -59,6 +59,7 @@ export const tr: Messages = {
   unsupportedTapOther: 'Desteklenmeyen etiket — Mifare Classic 1K veya NTAG okutun.',
   skippedTapDifferent: 'Atlandı. Farklı bir kart okutun…',
   retryAfter: (message) => `${message} — yeniden denemek için tekrar okutun.`,
+  scanGaveUp: (message) => `Tekrarlanan hatalar nedeniyle durduruldu: ${message}`,
 
   // — overwrite dialog —
   overwrite: 'Üzerine yaz',

--- a/webapp/app/i18n/uk.ts
+++ b/webapp/app/i18n/uk.ts
@@ -62,6 +62,7 @@ export const uk: Messages = {
   unsupportedTapOther: 'Мітка не підтримується — прикладіть Mifare Classic 1K або NTAG.',
   skippedTapDifferent: 'Пропущено. Прикладіть іншу картку…',
   retryAfter: (message) => `${message} — прикладіть знову, щоб повторити.`,
+  scanGaveUp: (message) => `Зупинено через повторні помилки: ${message}`,
 
   // — overwrite dialog —
   overwrite: 'Перезаписати',

--- a/webapp/app/ui/archive-orchestrator.ts
+++ b/webapp/app/ui/archive-orchestrator.ts
@@ -11,6 +11,7 @@ import { ArchiveController, OverwriteRequiredError, type ArchiveRequest } from '
 import { TagTimeoutError, UnsupportedTagError, type Transport } from '../../src/transport/transport.js';
 import { humanError } from './errors.js';
 import { t } from '../i18n/index.js';
+import { ensureMinInterval, FailureBreaker } from '../../src/loop-guards.js';
 import type { Logger } from '../../src/log/logger.js';
 
 /** The user's answer when a tapped card already holds NFAR data:
@@ -73,7 +74,9 @@ export class ArchiveOrchestrator {
     // without this check is an unthrottled retry spin that never reconnects.
     let inUse = transport;
     const usable = (): boolean => this.io.isConnected() && this.io.activeTransport() === inUse;
+    const breaker = new FailureBreaker();
     while (!done) {
+      const iterationStart = Date.now();
       if (!usable()) {
         const swapped = this.io.isConnected();
         this.io.setStatus(swapped ? t.readerSwitchedResume : t.readerDisconnectedResume);
@@ -91,10 +94,11 @@ export class ArchiveOrchestrator {
         if (res.rechunkedTo) {
           this.io.setStatus(t.rechunked(res.rechunkedTo.payloadSize, res.rechunkedTo.total));
         }
+        breaker.reset();
       } catch (e) {
         if (!usable()) continue; // disconnect or reader swap — handled at the loop top
+        await ensureMinInterval(iterationStart, 250);
         if (e instanceof TagTimeoutError) { this.io.setStatus(t.noCardTapHold); continue; }
-        if (e instanceof UnsupportedTagError) { this.io.setStatus(t.unsupportedTapOther); continue; }
         if (e instanceof OverwriteRequiredError) {
           const choice = await this.io.confirmOverwrite();
           if (choice === 'skip') { this.io.setStatus(t.skippedTapDifferent); continue; }
@@ -104,6 +108,7 @@ export class ArchiveOrchestrator {
             total = res.progress.total;
             done = res.done;
             this.render(res.progress.written, total, done);
+            breaker.reset();
           } catch (e2) {
             if (!usable()) continue;
             this.io.setStatus(t.retryAfter(humanError(e2)));
@@ -111,6 +116,18 @@ export class ArchiveOrchestrator {
           }
           continue;
         }
+        // Waiting for the user is not failing: TagTimeoutError, an overwrite
+        // prompt and an abort must never count toward the breaker — everything
+        // else (including an unsupported tag) does.
+        if (!(e instanceof DOMException && e.name === 'AbortError')) {
+          const name = e instanceof Error ? e.name : 'unknown';
+          if (breaker.record(name)) {
+            this.io.setStatus(t.scanGaveUp(humanError(e)));
+            this.io.log.error('archive', 'Stopped after repeated failures', { error: String(e) });
+            return;
+          }
+        }
+        if (e instanceof UnsupportedTagError) { this.io.setStatus(t.unsupportedTapOther); continue; }
         // Any other per-card failure (verify/auth/capacity/mid-write I-O): retry, never abort.
         this.io.setStatus(t.retryAfter(humanError(e)));
         this.io.log.warn('archive', 'Card write failed — will retry', { error: String(e) });

--- a/webapp/app/ui/archive-orchestrator.ts
+++ b/webapp/app/ui/archive-orchestrator.ts
@@ -126,19 +126,28 @@ export class ArchiveOrchestrator {
           }
           continue;
         }
+        // An unsupported tag can only arise AFTER a real tap, so it is
+        // rate-limited by the user and cannot produce the runaway retry the
+        // breaker exists to stop. Counting it would be actively harmful: run()
+        // builds a fresh ArchiveController per press, so tripping the breaker
+        // means re-prepare() and re-tap from card 1 — five wrong-media taps at
+        // card 40 of 50 would discard 40 cards of work. Exempt, matching the
+        // restore loop (see restore-panel.ts).
+        if (e instanceof UnsupportedTagError) { this.io.setStatus(t.unsupportedTapOther); continue; }
         // Waiting for the user is not failing: TagTimeoutError, an overwrite
-        // prompt and an abort (above) must never count toward the breaker.
-        // Everything else — including an unsupported tag — does: unlike the
-        // restore loop, where a pile of cards legitimately contains foreign
-        // media, a wrong-media tap during an active write is a genuine
-        // failure to make progress (see restore-panel.ts for the mirror case).
+        // prompt, an unsupported tag and an abort (all above) must never count
+        // toward the breaker. Everything else does — CardReadError,
+        // WriteVerifyError, and anything a broken transport throws without a
+        // tap, which is exactly the fast-failure spin worth stopping.
         const name = e instanceof Error ? e.name : 'unknown';
         if (breaker.record(name)) {
+          // Leaving the bar up would freeze it mid-count on a session that has
+          // stopped for good; the status line carries the reason.
+          this.io.hideProgress();
           this.io.setStatus(t.scanGaveUp(humanError(e)));
           this.io.log.error('archive', 'Stopped after repeated failures', { error: String(e) });
           return;
         }
-        if (e instanceof UnsupportedTagError) { this.io.setStatus(t.unsupportedTapOther); continue; }
         // Any other per-card failure (verify/auth/capacity/mid-write I-O): retry, never abort.
         this.io.setStatus(t.retryAfter(humanError(e)));
         this.io.log.warn('archive', 'Card write failed — will retry', { error: String(e) });

--- a/webapp/app/ui/archive-orchestrator.ts
+++ b/webapp/app/ui/archive-orchestrator.ts
@@ -97,6 +97,16 @@ export class ArchiveOrchestrator {
         breaker.reset();
       } catch (e) {
         if (!usable()) continue; // disconnect or reader swap — handled at the loop top
+        // Stopping must be immediate — checked before pacing, mirroring the
+        // restore loop's ordering exactly. Unreachable today (writeNextCard is
+        // always called with an undefined signal; no Stop control is wired to
+        // archive writes), but the moment one is, this keeps it from being
+        // delayed by ensureMinInterval and then swallowed into a retry.
+        if (e instanceof DOMException && e.name === 'AbortError') {
+          this.io.setStatus(t.cancelled);
+          this.io.log.info('archive', 'Write cancelled');
+          return;
+        }
         await ensureMinInterval(iterationStart, 250);
         if (e instanceof TagTimeoutError) { this.io.setStatus(t.noCardTapHold); continue; }
         if (e instanceof OverwriteRequiredError) {
@@ -117,15 +127,16 @@ export class ArchiveOrchestrator {
           continue;
         }
         // Waiting for the user is not failing: TagTimeoutError, an overwrite
-        // prompt and an abort must never count toward the breaker — everything
-        // else (including an unsupported tag) does.
-        if (!(e instanceof DOMException && e.name === 'AbortError')) {
-          const name = e instanceof Error ? e.name : 'unknown';
-          if (breaker.record(name)) {
-            this.io.setStatus(t.scanGaveUp(humanError(e)));
-            this.io.log.error('archive', 'Stopped after repeated failures', { error: String(e) });
-            return;
-          }
+        // prompt and an abort (above) must never count toward the breaker.
+        // Everything else — including an unsupported tag — does: unlike the
+        // restore loop, where a pile of cards legitimately contains foreign
+        // media, a wrong-media tap during an active write is a genuine
+        // failure to make progress (see restore-panel.ts for the mirror case).
+        const name = e instanceof Error ? e.name : 'unknown';
+        if (breaker.record(name)) {
+          this.io.setStatus(t.scanGaveUp(humanError(e)));
+          this.io.log.error('archive', 'Stopped after repeated failures', { error: String(e) });
+          return;
         }
         if (e instanceof UnsupportedTagError) { this.io.setStatus(t.unsupportedTapOther); continue; }
         // Any other per-card failure (verify/auth/capacity/mid-write I-O): retry, never abort.

--- a/webapp/app/ui/browser-ndef-io.ts
+++ b/webapp/app/ui/browser-ndef-io.ts
@@ -15,10 +15,17 @@ interface NdefReadingEventLike {
   message: { records: Array<{ recordType: string; mediaType?: string; data?: DataView }> };
 }
 
-/** The three NDEFReader members this file touches — not the full DOM lib.dom surface. */
-interface NdefReaderLike {
+/** The three NDEFReader members this file touches — not the full DOM lib.dom surface.
+ *
+ * `onreading` is written via the method-shorthand-in-object-type trick (extract
+ * the member type instead of declaring the field with a function-type literal)
+ * so the parameter is checked bivariantly rather than contravariantly. Without
+ * it, `strictFunctionTypes` would reject any test double whose synthetic event
+ * type is narrower than `NdefReadingEventLike` — exactly the kind of fake this
+ * interface exists to make possible under node --test. */
+export interface NdefReaderLike {
   scan(options: { signal: AbortSignal }): Promise<void>;
-  onreading: ((event: NdefReadingEventLike) => void) | null;
+  onreading: { bivarianceHack(event: NdefReadingEventLike): void }['bivarianceHack'] | null;
   onreadingerror: ((event: unknown) => void) | null;
   write(message: { records: NdefRecordInit[] }): Promise<void>;
 }
@@ -27,108 +34,105 @@ export function webNfcAvailable(): boolean {
   return typeof (globalThis as { NDEFReader?: unknown }).NDEFReader === 'function';
 }
 
+/** How long a reading with no waiter stays usable. Covers the few-millisecond
+ *  gap between one card completing and the loop asking for the next; anything
+ *  older would be a tap from a different moment replayed into this operation. */
+const BUFFER_MS = 2000;
+
 export class BrowserNdefIO implements NdefIO {
+  /** Injectable so this file is testable under node --test, where NDEFReader
+   *  does not exist. Production passes nothing. */
+  constructor(
+    private readonly makeReader: () => NdefReaderLike = () => {
+      const Ctor = (globalThis as { NDEFReader?: new () => NdefReaderLike }).NDEFReader;
+      if (Ctor === undefined) throw new Error('Web NFC is not available in this browser');
+      return new Ctor();
+    },
+  ) {}
+
   private reader: NdefReaderLike | null = null;
   private scanning: AbortController | null = null;
-  private started = false;
+  private waiter: { resolve: (r: NdefReading) => void; reject: (e: unknown) => void } | null = null;
+  private buffered: { reading: NdefReading; at: number } | null = null;
 
-  // Minimal stub to satisfy the NdefIO interface added in the scan-model fix
-  // (Task 2). This class still re-arms scan() on every awaitReading() call —
-  // the exact bug this whole fix targets — and is replaced wholesale by
-  // Task 3's rewrite, which is where start() actually arms the one scan.
   async start(): Promise<void> {
-    if (this.started) throw new Error('A scan is already in progress');
-    this.started = true;
+    if (this.reader !== null) throw new Error('A scan is already in progress');
+    const reader = this.makeReader();
+    const ac = new AbortController();
+
+    reader.onreading = (event) => {
+      const reading: NdefReading = {
+        serialNumber: event.serialNumber ?? '',
+        records: event.message.records.map((rec) => ({
+          recordType: rec.recordType,
+          mediaType: rec.mediaType,
+          data: rec.data === undefined
+            ? undefined
+            : new Uint8Array(rec.data.buffer, rec.data.byteOffset, rec.data.byteLength),
+        })),
+      };
+      const w = this.waiter;
+      if (w !== null) {
+        this.waiter = null;
+        w.resolve(reading);
+        return;
+      }
+      this.buffered = { reading, at: Date.now() };
+    };
+
+    reader.onreadingerror = () => {
+      const w = this.waiter;
+      if (w !== null) {
+        this.waiter = null;
+        w.reject(new Error('Could not read the tag — hold it still and try again'));
+      }
+    };
+
+    // The one and only scan for this instance. Re-arming a reader is what froze
+    // the browser: it rejects synchronously, and a retry loop then spins.
+    await reader.scan({ signal: ac.signal });
+    this.reader = reader;
+    this.scanning = ac;
   }
 
   async awaitReading(opts?: { timeoutMs?: number; signal?: AbortSignal }): Promise<NdefReading> {
+    if (this.reader === null) throw new Error('Scan not started');
+    if (this.waiter !== null) throw new Error('Already waiting for a reading');
     if (opts?.signal?.aborted) throw new DOMException('Aborted', 'AbortError');
 
-    const Ctor = (globalThis as { NDEFReader?: new () => NdefReaderLike }).NDEFReader;
-    if (Ctor === undefined) throw new Error('Web NFC is not available in this browser');
-    this.reader ??= new Ctor();
-    const reader = this.reader;
-
-    this.scanning?.abort();
-    const ac = new AbortController();
-    this.scanning = ac;
-    // Named so cleanup() can detach it. The caller's signal outlives one call —
-    // restore uses a single AbortController for a whole scan session — so a
-    // 50-card scan would otherwise leave 50 dead listeners on it.
-    const forwardAbort = (): void => ac.abort();
-    opts?.signal?.addEventListener('abort', forwardAbort, { once: true });
+    const buffered = this.buffered;
+    this.buffered = null;
+    if (buffered !== null && Date.now() - buffered.at <= BUFFER_MS) return buffered.reading;
 
     return new Promise<NdefReading>((resolve, reject) => {
       let timer: ReturnType<typeof setTimeout> | null = null;
-
-      // Every settlement path — resolve, reject, whichever fires first — runs
-      // through here once, so "clear the timer / detach the handlers / free
-      // this.scanning" holds by construction instead of by remembering to
-      // repeat it at each call site. Safe to invoke more than once: a second
-      // call is a no-op (timer already cleared, handlers already null-or-not-
-      // ours, and resolve/reject on an already-settled promise is a no-op).
-      //
-      // A settling wait may only tear down state it still owns: the handlers
-      // live on the *shared* reader, so this guard is not optional the way it
-      // would be for a private field. Overlapping calls abort the previous
-      // AbortController synchronously (this.scanning?.abort() below) but the
-      // previous call's own scan().catch(cleanup) doesn't run until a later
-      // microtask — by then a newer call may already have installed its own
-      // onreading/onreadingerror on this same reader. Nulling them here
-      // unconditionally would wipe a newer call's handlers out from under it.
-      const cleanup = (): void => {
+      const settle = (): void => {
         if (timer !== null) clearTimeout(timer);
-        // Unconditional: the timer and this listener are private to this call
-        // (both close over `ac`), unlike the handlers on the shared reader.
-        opts?.signal?.removeEventListener('abort', forwardAbort);
-        if (this.scanning === ac) {
-          reader.onreading = null;
-          reader.onreadingerror = null;
-          this.scanning = null;
-        }
+        opts?.signal?.removeEventListener('abort', onAbort);
+        this.waiter = null;
       };
+      const onAbort = (): void => { settle(); reject(new DOMException('Aborted', 'AbortError')); };
 
+      this.waiter = {
+        resolve: (r) => { settle(); resolve(r); },
+        reject: (e) => { settle(); reject(e); },
+      };
+      opts?.signal?.addEventListener('abort', onAbort, { once: true });
       if (opts?.timeoutMs !== undefined) {
         timer = setTimeout(() => {
-          ac.abort();
-          cleanup();
+          settle();
           reject(new TagTimeoutError(`No tag presented within ${opts.timeoutMs}ms`));
         }, opts.timeoutMs);
       }
-
-      reader.onreading = (event) => {
-        cleanup();
-        resolve({
-          serialNumber: event.serialNumber ?? '',
-          records: event.message.records.map((rec) => ({
-            recordType: rec.recordType,
-            mediaType: rec.mediaType,
-            data: rec.data === undefined
-              ? undefined
-              : new Uint8Array(rec.data.buffer, rec.data.byteOffset, rec.data.byteLength),
-          })),
-        });
-      };
-      reader.onreadingerror = () => {
-        cleanup();
-        reject(new Error('Could not read the tag — hold it still and try again'));
-      };
-      reader.scan({ signal: ac.signal }).catch((e: unknown) => {
-        cleanup();
-        reject(e);
-      });
     });
   }
 
   async write(records: NdefRecordInit[]): Promise<void> {
     const reader = this.reader;
-    if (reader === null) throw new Error('Start a scan before writing');
+    if (reader === null) throw new Error('Scan not started');
     try {
       await reader.write({ records });
     } catch (e) {
-      // Chrome reports "does not fit" and several hardware refusals as
-      // DOMExceptions. Capacity is the one the user can act on, and Web NFC
-      // gives us no way to check it in advance.
       if (e instanceof DOMException &&
           (e.name === 'NotSupportedError' || e.name === 'NetworkError')) {
         throw new CardCapacityError(
@@ -142,5 +146,13 @@ export class BrowserNdefIO implements NdefIO {
   stop(): void {
     this.scanning?.abort();
     this.scanning = null;
+    if (this.reader !== null) {
+      this.reader.onreading = null;
+      this.reader.onreadingerror = null;
+      this.reader = null;
+    }
+    this.waiter?.reject(new DOMException('Aborted', 'AbortError'));
+    this.waiter = null;
+    this.buffered = null;
   }
 }

--- a/webapp/app/ui/browser-ndef-io.ts
+++ b/webapp/app/ui/browser-ndef-io.ts
@@ -30,6 +30,16 @@ export function webNfcAvailable(): boolean {
 export class BrowserNdefIO implements NdefIO {
   private reader: NdefReaderLike | null = null;
   private scanning: AbortController | null = null;
+  private started = false;
+
+  // Minimal stub to satisfy the NdefIO interface added in the scan-model fix
+  // (Task 2). This class still re-arms scan() on every awaitReading() call —
+  // the exact bug this whole fix targets — and is replaced wholesale by
+  // Task 3's rewrite, which is where start() actually arms the one scan.
+  async start(): Promise<void> {
+    if (this.started) throw new Error('A scan is already in progress');
+    this.started = true;
+  }
 
   async awaitReading(opts?: { timeoutMs?: number; signal?: AbortSignal }): Promise<NdefReading> {
     if (opts?.signal?.aborted) throw new DOMException('Aborted', 'AbortError');

--- a/webapp/app/ui/browser-ndef-io.ts
+++ b/webapp/app/ui/browser-ndef-io.ts
@@ -59,6 +59,13 @@ export class BrowserNdefIO implements NdefIO {
   // first await, so a second call sees it synchronously and rejects on
   // the spot instead of racing.
   private starting = false;
+  // Set by stop(), never cleared: one scan per instance, and once stopped this
+  // instance is spent. Without it, a stop() issued while start() is still
+  // awaiting reader.scan() sees `scanning`/`reader` still null, aborts nothing,
+  // and the pending scan then installs a live armed reader on an instance the
+  // caller believes it stopped — a reader left armed after teardown, the exact
+  // lifecycle leak this file exists to prevent.
+  private stopped = false;
   private waiter: { resolve: (r: NdefReading) => void; reject: (e: unknown) => void } | null = null;
   private buffered: { reading: NdefReading; at: number } | null = null;
 
@@ -100,6 +107,16 @@ export class BrowserNdefIO implements NdefIO {
       // The one and only scan for this instance. Re-arming a reader is what froze
       // the browser: it rejects synchronously, and a retry loop then spins.
       await reader.scan({ signal: ac.signal });
+      // stop() may have landed while that was in flight. It could not abort a
+      // controller it had never seen, so undo the arming here instead of
+      // publishing it: abort the scan, detach the handlers, and leave `reader`
+      // null so awaitReading/write keep reporting "Scan not started".
+      if (this.stopped) {
+        ac.abort();
+        reader.onreading = null;
+        reader.onreadingerror = null;
+        return;
+      }
       this.reader = reader;
       this.scanning = ac;
     } finally {
@@ -156,6 +173,7 @@ export class BrowserNdefIO implements NdefIO {
   }
 
   stop(): void {
+    this.stopped = true;
     this.scanning?.abort();
     this.scanning = null;
     if (this.reader !== null) {

--- a/webapp/app/ui/browser-ndef-io.ts
+++ b/webapp/app/ui/browser-ndef-io.ts
@@ -15,17 +15,10 @@ interface NdefReadingEventLike {
   message: { records: Array<{ recordType: string; mediaType?: string; data?: DataView }> };
 }
 
-/** The three NDEFReader members this file touches — not the full DOM lib.dom surface.
- *
- * `onreading` is written via the method-shorthand-in-object-type trick (extract
- * the member type instead of declaring the field with a function-type literal)
- * so the parameter is checked bivariantly rather than contravariantly. Without
- * it, `strictFunctionTypes` would reject any test double whose synthetic event
- * type is narrower than `NdefReadingEventLike` — exactly the kind of fake this
- * interface exists to make possible under node --test. */
+/** The three NDEFReader members this file touches — not the full DOM lib.dom surface. */
 export interface NdefReaderLike {
   scan(options: { signal: AbortSignal }): Promise<void>;
-  onreading: { bivarianceHack(event: NdefReadingEventLike): void }['bivarianceHack'] | null;
+  onreading: ((event: NdefReadingEventLike) => void) | null;
   onreadingerror: ((event: unknown) => void) | null;
   write(message: { records: NdefRecordInit[] }): Promise<void>;
 }
@@ -36,63 +29,82 @@ export function webNfcAvailable(): boolean {
 
 /** How long a reading with no waiter stays usable. Covers the few-millisecond
  *  gap between one card completing and the loop asking for the next; anything
- *  older would be a tap from a different moment replayed into this operation. */
+ *  older would be a tap from a different moment replayed into this operation.
+ *  This also covers the post-timeout case: after awaitReading() rejects with
+ *  TagTimeoutError the scan is still armed (start() only calls scan() once),
+ *  so a tap that lands shortly after the timeout is buffered here and served
+ *  to the *next* awaitReading() call rather than lost. That is intended. */
 const BUFFER_MS = 2000;
 
 export class BrowserNdefIO implements NdefIO {
-  /** Injectable so this file is testable under node --test, where NDEFReader
-   *  does not exist. Production passes nothing. */
+  /** Both injectable so this file is testable under node --test: NDEFReader
+   *  doesn't exist there, and BUFFER_MS staleness needs a fake clock to test
+   *  without a real 2-second sleep. Production passes neither. */
   constructor(
     private readonly makeReader: () => NdefReaderLike = () => {
       const Ctor = (globalThis as { NDEFReader?: new () => NdefReaderLike }).NDEFReader;
       if (Ctor === undefined) throw new Error('Web NFC is not available in this browser');
       return new Ctor();
     },
+    private readonly now: () => number = Date.now,
   ) {}
 
   private reader: NdefReaderLike | null = null;
   private scanning: AbortController | null = null;
+  // Synchronous re-entrancy guard. `reader` is only assigned after the
+  // `await reader.scan(...)` below resolves, so two start() calls issued
+  // without awaiting the first would both pass a `this.reader !== null`
+  // check and arm two scans on this instance — the exact bug this file
+  // exists to prevent. `starting` closes that gap: it is set before the
+  // first await, so a second call sees it synchronously and rejects on
+  // the spot instead of racing.
+  private starting = false;
   private waiter: { resolve: (r: NdefReading) => void; reject: (e: unknown) => void } | null = null;
   private buffered: { reading: NdefReading; at: number } | null = null;
 
   async start(): Promise<void> {
-    if (this.reader !== null) throw new Error('A scan is already in progress');
-    const reader = this.makeReader();
-    const ac = new AbortController();
+    if (this.reader !== null || this.starting) throw new Error('A scan is already in progress');
+    this.starting = true;
+    try {
+      const reader = this.makeReader();
+      const ac = new AbortController();
 
-    reader.onreading = (event) => {
-      const reading: NdefReading = {
-        serialNumber: event.serialNumber ?? '',
-        records: event.message.records.map((rec) => ({
-          recordType: rec.recordType,
-          mediaType: rec.mediaType,
-          data: rec.data === undefined
-            ? undefined
-            : new Uint8Array(rec.data.buffer, rec.data.byteOffset, rec.data.byteLength),
-        })),
+      reader.onreading = (event) => {
+        const reading: NdefReading = {
+          serialNumber: event.serialNumber ?? '',
+          records: event.message.records.map((rec) => ({
+            recordType: rec.recordType,
+            mediaType: rec.mediaType,
+            data: rec.data === undefined
+              ? undefined
+              : new Uint8Array(rec.data.buffer, rec.data.byteOffset, rec.data.byteLength),
+          })),
+        };
+        const w = this.waiter;
+        if (w !== null) {
+          this.waiter = null;
+          w.resolve(reading);
+          return;
+        }
+        this.buffered = { reading, at: this.now() };
       };
-      const w = this.waiter;
-      if (w !== null) {
-        this.waiter = null;
-        w.resolve(reading);
-        return;
-      }
-      this.buffered = { reading, at: Date.now() };
-    };
 
-    reader.onreadingerror = () => {
-      const w = this.waiter;
-      if (w !== null) {
-        this.waiter = null;
-        w.reject(new Error('Could not read the tag — hold it still and try again'));
-      }
-    };
+      reader.onreadingerror = () => {
+        const w = this.waiter;
+        if (w !== null) {
+          this.waiter = null;
+          w.reject(new Error('Could not read the tag — hold it still and try again'));
+        }
+      };
 
-    // The one and only scan for this instance. Re-arming a reader is what froze
-    // the browser: it rejects synchronously, and a retry loop then spins.
-    await reader.scan({ signal: ac.signal });
-    this.reader = reader;
-    this.scanning = ac;
+      // The one and only scan for this instance. Re-arming a reader is what froze
+      // the browser: it rejects synchronously, and a retry loop then spins.
+      await reader.scan({ signal: ac.signal });
+      this.reader = reader;
+      this.scanning = ac;
+    } finally {
+      this.starting = false;
+    }
   }
 
   async awaitReading(opts?: { timeoutMs?: number; signal?: AbortSignal }): Promise<NdefReading> {
@@ -102,7 +114,7 @@ export class BrowserNdefIO implements NdefIO {
 
     const buffered = this.buffered;
     this.buffered = null;
-    if (buffered !== null && Date.now() - buffered.at <= BUFFER_MS) return buffered.reading;
+    if (buffered !== null && this.now() - buffered.at <= BUFFER_MS) return buffered.reading;
 
     return new Promise<NdefReading>((resolve, reject) => {
       let timer: ReturnType<typeof setTimeout> | null = null;

--- a/webapp/app/ui/device.ts
+++ b/webapp/app/ui/device.ts
@@ -172,12 +172,27 @@ export function initDeviceBar(): void {
    *  a different chip. Always routed through teardownActiveReader() so the
    *  outgoing reader is closed and its epoch retired, and always notifies, so a
    *  write loop in flight adopts the new transport (see ArchiveOrchestrator's
-   *  transport-identity gate) instead of driving the retired one. */
+   *  transport-identity gate) instead of driving the retired one.
+   *
+   *  Epoch-guarded exactly like the Chameleon path below: connect() awaits
+   *  Chrome's NFC permission prompt, and while it pends the user can start
+   *  another hand-off (press Connect, or change #target-tag — that handler is
+   *  fire-and-forget `void activateWebNfc()`). Without the guard the stale
+   *  connect resolves afterwards and overwrites transport/reader/connected,
+   *  orphaning the reader that superseded it, and leaves an armed NDEFReader
+   *  nothing holds a reference to. If the epoch moved, this activation lost:
+   *  close the scan it armed and return without touching shared state. */
   const activateWebNfc = async (): Promise<void> => {
     await teardownActiveReader();
+    const myEpoch = readerEpoch;
     try {
       const t0 = new WebNfcTransport(new BrowserNdefIO(), selectedNtagType());
       await t0.connect();
+      if (myEpoch !== readerEpoch) {
+        await t0.disconnect();
+        log.info('device', 'Phone NFC activation superseded — discarding the stale scan');
+        return;
+      }
       transport = t0;
       reader = 'web-nfc';
       connected = true;

--- a/webapp/app/ui/device.ts
+++ b/webapp/app/ui/device.ts
@@ -176,7 +176,9 @@ export function initDeviceBar(): void {
   const activateWebNfc = async (): Promise<void> => {
     await teardownActiveReader();
     try {
-      transport = new WebNfcTransport(new BrowserNdefIO(), selectedNtagType());
+      const t0 = new WebNfcTransport(new BrowserNdefIO(), selectedNtagType());
+      await t0.connect();
+      transport = t0;
       reader = 'web-nfc';
       connected = true;
       renderConn();

--- a/webapp/app/ui/restore-panel.ts
+++ b/webapp/app/ui/restore-panel.ts
@@ -58,9 +58,15 @@ export function initRestorePanel(): void {
         } catch (e) {
           if (e instanceof DOMException && e.name === 'AbortError') break;
           if (e instanceof TagTimeoutError) continue;
+          // A restore pile legitimately contains foreign cards — tapping
+          // several unsupported ones while sorting through a stack is normal
+          // use, not a stuck loop, so this must never count toward the
+          // breaker. (Unlike the archive loop, where a wrong-media tap during
+          // an active write IS a genuine failure to progress — see
+          // archive-orchestrator.ts for the mirror case.)
+          if (e instanceof UnsupportedTagError) { setStatus(t.unsupportedTapOther); log.warn('scan', 'Unsupported tag'); continue; }
           // Waiting for the user is not failing: TagTimeoutError and an abort
-          // must never count toward the breaker — everything else (including
-          // an unsupported tag) does.
+          // (above) must never count toward the breaker — everything else does.
           await ensureMinInterval(iterationStart, 250);
           const name = e instanceof Error ? e.name : 'unknown';
           if (breaker.record(name)) {
@@ -68,7 +74,6 @@ export function initRestorePanel(): void {
             log.error('scan', 'Stopped after repeated failures', { error: String(e) });
             break;
           }
-          if (e instanceof UnsupportedTagError) { setStatus(t.unsupportedTapOther); log.warn('scan', 'Unsupported tag'); continue; }
           setStatus(t.skippedCard(humanError(e)));
           log.warn('scan', 'Skipped a card', { error: String(e) });
           continue;

--- a/webapp/app/ui/restore-panel.ts
+++ b/webapp/app/ui/restore-panel.ts
@@ -6,6 +6,7 @@ import { filesController } from './files-panel.js';
 import { humanError } from './errors.js';
 import { log } from '../../src/log/logger.js';
 import { t } from '../i18n/index.js';
+import { ensureMinInterval, FailureBreaker } from '../../src/loop-guards.js';
 
 const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
 
@@ -46,14 +47,27 @@ export function initRestorePanel(): void {
     setStatus(t.scanning);
     setReaderBusy(true);
     log.info('scan', 'Scan started');
+    const breaker = new FailureBreaker();
     try {
       for (;;) {
+        const iterationStart = Date.now();
         try {
           await orch.scanStep(scanAbort.signal);
+          breaker.reset();
           setStatus(t.tapMoreCards);
         } catch (e) {
           if (e instanceof DOMException && e.name === 'AbortError') break;
           if (e instanceof TagTimeoutError) continue;
+          // Waiting for the user is not failing: TagTimeoutError and an abort
+          // must never count toward the breaker — everything else (including
+          // an unsupported tag) does.
+          await ensureMinInterval(iterationStart, 250);
+          const name = e instanceof Error ? e.name : 'unknown';
+          if (breaker.record(name)) {
+            setStatus(t.scanGaveUp(humanError(e)));
+            log.error('scan', 'Stopped after repeated failures', { error: String(e) });
+            break;
+          }
           if (e instanceof UnsupportedTagError) { setStatus(t.unsupportedTapOther); log.warn('scan', 'Unsupported tag'); continue; }
           setStatus(t.skippedCard(humanError(e)));
           log.warn('scan', 'Skipped a card', { error: String(e) });

--- a/webapp/app/ui/restore-panel.ts
+++ b/webapp/app/ui/restore-panel.ts
@@ -1,6 +1,6 @@
 /** Restore tab: thin adapter — builds the DOM/browser IO for RestoreOrchestrator and runs the scan-step loop. */
 import { RestoreOrchestrator, type RestoreIO } from './restore-orchestrator.js';
-import { TagTimeoutError, UnsupportedTagError } from '../../src/transport/transport.js';
+import { CardAuthError, TagTimeoutError, UnsupportedTagError } from '../../src/transport/transport.js';
 import { currentTransport, onConnectionChange, setReaderBusy } from './device.js';
 import { filesController } from './files-panel.js';
 import { humanError } from './errors.js';
@@ -59,12 +59,21 @@ export function initRestorePanel(): void {
           if (e instanceof DOMException && e.name === 'AbortError') break;
           if (e instanceof TagTimeoutError) continue;
           // A restore pile legitimately contains foreign cards — tapping
-          // several unsupported ones while sorting through a stack is normal
-          // use, not a stuck loop, so this must never count toward the
-          // breaker. (Unlike the archive loop, where a wrong-media tap during
-          // an active write IS a genuine failure to progress — see
-          // archive-orchestrator.ts for the mirror case.)
-          if (e instanceof UnsupportedTagError) { setStatus(t.unsupportedTapOther); log.warn('scan', 'Unsupported tag'); continue; }
+          // several of them while sorting through a stack is normal use, not a
+          // stuck loop, so neither may count toward the breaker. Both errors
+          // are needed to cover "foreign card": UnsupportedTagError is only
+          // raised for SAK values outside 0x00/0x08, so a foreign *Mifare
+          // Classic* (SAK 0x08 — hotel key, transit card, office badge) routes
+          // to the Classic transport instead and fails on its non-factory keys
+          // with CardAuthError. Same user situation, different error.
+          // (The archive loop exempts UnsupportedTagError for the same reason:
+          // it can only arise after a real tap, so it is user-rate-limited and
+          // cannot produce the spin the breaker exists to stop.)
+          if (e instanceof UnsupportedTagError || e instanceof CardAuthError) {
+            setStatus(t.unsupportedTapOther);
+            log.warn('scan', 'Foreign card — skipped', { error: String(e) });
+            continue;
+          }
           // Waiting for the user is not failing: TagTimeoutError and an abort
           // (above) must never count toward the breaker — everything else does.
           await ensureMinInterval(iterationStart, 250);

--- a/webapp/src/loop-guards.ts
+++ b/webapp/src/loop-guards.ts
@@ -9,9 +9,17 @@
  * enough that the user cannot even press Stop.
  */
 
-/** Wait out the remainder of `minMs` since `startedAt`. */
+/** Wait out the remainder of `minMs` since `startedAt`.
+ *
+ *  Clamped at `minMs`: `startedAt` comes from the wall clock, which can step
+ *  BACKWARDS mid-loop (an NTP correction, or the user changing the clock or
+ *  timezone on a phone while scanning). Unclamped, `remaining` then far exceeds
+ *  `minMs` and this schedules a timeout of that length — during which the loop
+ *  sleeps deaf to its abort signal, so the scan looks hung and Stop appears
+ *  dead. That is the very failure mode these guards exist to remove, so a
+ *  nonsensical clock can never buy more than one interval of delay. */
 export function ensureMinInterval(startedAt: number, minMs: number): Promise<void> {
-  const remaining = minMs - (Date.now() - startedAt);
+  const remaining = Math.min(minMs, minMs - (Date.now() - startedAt));
   if (remaining <= 0) return Promise.resolve();
   return new Promise((resolve) => setTimeout(resolve, remaining));
 }

--- a/webapp/src/loop-guards.ts
+++ b/webapp/src/loop-guards.ts
@@ -1,0 +1,47 @@
+/**
+ * Guards that keep a retry loop from starving the main thread.
+ *
+ * A card loop retries on error. If the transport rejects instantly — as the
+ * Web NFC adapter did when it re-armed an already-running scan — `continue`
+ * produces an unbroken chain of already-rejected promises. Awaiting one of
+ * those yields a microtask but never returns to the event loop's task queue,
+ * so nothing renders and no input is handled: the browser locks up hard
+ * enough that the user cannot even press Stop.
+ */
+
+/** Wait out the remainder of `minMs` since `startedAt`. */
+export function ensureMinInterval(startedAt: number, minMs: number): Promise<void> {
+  const remaining = minMs - (Date.now() - startedAt);
+  if (remaining <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, remaining));
+}
+
+/**
+ * Trips after `limit` consecutive failures of the same kind, so a loop that
+ * cannot make progress stops and says why instead of retrying forever.
+ *
+ * Callers must not record conditions that mean "the user has not tapped yet"
+ * — see the exclusion lists at each call site.
+ */
+export class FailureBreaker {
+  constructor(private readonly limit: number = 5) {}
+
+  private lastName: string | null = null;
+  private count = 0;
+
+  /** Record a failure. Returns true when the loop should stop. */
+  record(errorName: string): boolean {
+    if (errorName === this.lastName) {
+      this.count += 1;
+    } else {
+      this.lastName = errorName;
+      this.count = 1;
+    }
+    return this.count >= this.limit;
+  }
+
+  reset(): void {
+    this.lastName = null;
+    this.count = 0;
+  }
+}

--- a/webapp/src/transport/ndef-io.ts
+++ b/webapp/src/transport/ndef-io.ts
@@ -26,6 +26,9 @@ export interface NdefReading {
 }
 
 export interface NdefIO {
+  /** Arm the single scan. Call once, before any awaitReading(). Rejects if the
+   *  browser refuses — permission denied, unsupported, or already scanning. */
+  start(): Promise<void>;
   /** Resolves with the first tag presented. Rejects on timeout or abort. */
   awaitReading(opts?: { timeoutMs?: number; signal?: AbortSignal }): Promise<NdefReading>;
   /** Write to the tag currently in the field. */

--- a/webapp/src/transport/web-nfc-transport.ts
+++ b/webapp/src/transport/web-nfc-transport.ts
@@ -32,7 +32,10 @@ export class WebNfcTransport implements Transport {
   constructor(private readonly io: NdefIO, private readonly tagType: NtagType) {}
 
   async connect(): Promise<void> {
-    // Nothing to open: the browser owns the radio. Present for interface parity.
+    // Arm the single scan here rather than lazily on first read: the permission
+    // prompt then appears when the user asked for NFC, inside their gesture,
+    // and a refusal surfaces at the button instead of inside a scan loop.
+    await this.io.start();
   }
 
   async disconnect(): Promise<void> {

--- a/webapp/test/archive-orchestrator.test.ts
+++ b/webapp/test/archive-orchestrator.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { MockTransport } from '../src/transport/mock-transport.js';
-import { WriteVerifyError, type PresentedTag, type Transport } from '../src/transport/transport.js';
+import { CardReadError, WriteVerifyError, type PresentedTag, type Transport } from '../src/transport/transport.js';
 import { ArchiveOrchestrator, type ArchiveIO } from '../app/ui/archive-orchestrator.js';
 import { RestoreController } from '../app/controller.js';
 import { decodeChunk, encodeChunk } from '../src/chunk.js';
@@ -220,4 +220,21 @@ test('"overwrite all remaining" prompts once, then overwrites the rest silently'
     indices.push(decodeChunk(await inner.readChunk()).chunkIndex);
   }
   assert.deepEqual([...indices].sort((a, b) => a - b), [0, 1, 2], 'every card holds a new chunk');
+});
+
+test('the write loop stops after repeated identical failures instead of spinning', async () => {
+  let attempts = 0;
+  const failing = {
+    ...new MockTransport(),
+    name: 'always-fails',
+    async awaitTag() { attempts += 1; throw new CardReadError('boom'); },
+  } as unknown as Transport;
+
+  const { io, statuses } = makeIO(failing);
+  await new ArchiveOrchestrator(io).run(failing, {
+    data: new Uint8Array(50), fileName: 'x.bin', compress: false, payloadSize: 100,
+  });
+
+  assert.ok(attempts <= 6, `expected the breaker to stop it, got ${attempts} attempts`);
+  assert.ok(statuses.some((s) => s.includes('Stopped after repeated failures')));
 });

--- a/webapp/test/archive-orchestrator.test.ts
+++ b/webapp/test/archive-orchestrator.test.ts
@@ -138,6 +138,9 @@ test('swapping readers mid-archive adopts the new transport instead of spinning 
   const ioB = new FakeNdefIO();
   const tA = new WebNfcTransport(ioA, NtagType.NTAG215);
   const tB = new WebNfcTransport(ioB, NtagType.NTAG216);
+  // connect() isn't wired to start() until Task 3/4 — arm both scans directly.
+  await ioA.start();
+  await ioB.start();
   ioA.tap('0a:00:00:01');
   ioB.tap('0b:00:00:02');
   ioB.tap('0b:00:00:03');

--- a/webapp/test/archive-orchestrator.test.ts
+++ b/webapp/test/archive-orchestrator.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { MockTransport } from '../src/transport/mock-transport.js';
-import { CardReadError, WriteVerifyError, type PresentedTag, type Transport } from '../src/transport/transport.js';
+import { CardReadError, UnsupportedTagError, WriteVerifyError, type PresentedTag, type Transport } from '../src/transport/transport.js';
 import { ArchiveOrchestrator, type ArchiveIO } from '../app/ui/archive-orchestrator.js';
 import { RestoreController } from '../app/controller.js';
 import { decodeChunk, encodeChunk } from '../src/chunk.js';
@@ -28,6 +28,24 @@ class FlakyWriteTransport implements Transport {
     if (this.writes === this.failOnWrite) throw new WriteVerifyError('simulated verify failure');
     return this.inner.writeChunk(bytes);
   }
+}
+
+/** Wraps a MockTransport and rejects the first N taps with UnsupportedTagError,
+ *  as the user works through a stack that starts with foreign cards. */
+class ForeignTagTransport implements Transport {
+  readonly name = 'foreign';
+  private taps = 0;
+  constructor(private readonly inner: MockTransport, private readonly foreignTaps: number) {}
+  connect() { return this.inner.connect(); }
+  disconnect() { return this.inner.disconnect(); }
+  async awaitTag(opts?: { timeoutMs?: number; signal?: AbortSignal }): Promise<PresentedTag> {
+    this.taps += 1;
+    if (this.taps <= this.foreignTaps) throw new UnsupportedTagError('not an NFAR-capable tag');
+    return this.inner.awaitTag(opts);
+  }
+  peekIsNfar() { return this.inner.peekIsNfar(); }
+  readChunk() { return this.inner.readChunk(); }
+  writeChunk(bytes: Uint8Array) { return this.inner.writeChunk(bytes); }
 }
 
 /** `active` is the transport the device bar owns — the loop compares the one it
@@ -138,7 +156,8 @@ test('swapping readers mid-archive adopts the new transport instead of spinning 
   const ioB = new FakeNdefIO();
   const tA = new WebNfcTransport(ioA, NtagType.NTAG215);
   const tB = new WebNfcTransport(ioB, NtagType.NTAG216);
-  // connect() isn't wired to start() until Task 3/4 — arm both scans directly.
+  // Arm both scans directly rather than via connect(): this test hands the
+  // orchestrator two already-live transports, with no device bar to connect them.
   await ioA.start();
   await ioB.start();
   ioA.tap('0a:00:00:01');
@@ -230,11 +249,37 @@ test('the write loop stops after repeated identical failures instead of spinning
     async awaitTag() { attempts += 1; throw new CardReadError('boom'); },
   } as unknown as Transport;
 
-  const { io, statuses } = makeIO(failing);
+  const { io, statuses, wasHidden } = makeIO(failing);
   await new ArchiveOrchestrator(io).run(failing, {
     data: new Uint8Array(50), fileName: 'x.bin', compress: false, payloadSize: 100,
   });
 
   assert.ok(attempts <= 6, `expected the breaker to stop it, got ${attempts} attempts`);
   assert.ok(statuses.some((s) => s.includes('Stopped after repeated failures')));
+  // The session has stopped for good — a progress bar frozen mid-count would
+  // read as a write still in flight.
+  assert.equal(wasHidden(), true, 'progress hidden when the breaker gives up');
+});
+
+test('repeated wrong-media taps never trip the archive breaker', async () => {
+  // Tapping foreign cards while sorting a stack is normal use, and an
+  // unsupported tag can only arise after a real tap, so it can never be the
+  // fast-failure spin the breaker exists to stop. Counting it would discard the
+  // whole prepared archive — run() builds a fresh controller per press, so the
+  // user would have to start again from card 1.
+  const inner = new MockTransport();
+  const t = new ForeignTagTransport(inner, 6); // more than the breaker's limit of 5
+  const { io, statuses, wasHidden } = makeIO(t);
+  inner.enqueueTag(uid(0)); // the one good card, tapped after the foreign ones
+
+  await new ArchiveOrchestrator(io).run(t, {
+    data: new Uint8Array(50), fileName: 'x.bin', compress: false, payloadSize: 100,
+  });
+
+  assert.equal(wasHidden(), false, 'the session survived the foreign taps');
+  assert.ok(!statuses.some((s) => s.includes('Stopped after repeated failures')),
+    'the breaker must not trip on unsupported tags');
+  inner.enqueueTag(uid(0));
+  await inner.awaitTag();
+  assert.equal(decodeChunk(await inner.readChunk()).chunkIndex, 0, 'the archive still completed');
 });

--- a/webapp/test/browser-ndef-io.test.ts
+++ b/webapp/test/browser-ndef-io.test.ts
@@ -1,0 +1,71 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { BrowserNdefIO, type NdefReaderLike } from '../app/ui/browser-ndef-io.js';
+
+/** A stand-in NDEFReader that records how often a scan was armed and lets a
+ *  test deliver reading events by hand. */
+class FakeReader implements NdefReaderLike {
+  scanCount = 0;
+  onreading: ((e: { serialNumber: string; message: { records: [] } }) => void) | null = null;
+  onreadingerror: ((e: unknown) => void) | null = null;
+  failScan: Error | null = null;
+
+  async scan(options: { signal: AbortSignal }): Promise<void> {
+    if (this.failScan !== null) throw this.failScan;
+    this.scanCount += 1;
+    if (options.signal.aborted) throw new DOMException('Aborted', 'AbortError');
+  }
+  async write(): Promise<void> {}
+
+  deliver(serialNumber: string): void {
+    this.onreading?.({ serialNumber, message: { records: [] } });
+  }
+}
+
+test('many readings are served by a single armed scan', async () => {
+  const reader = new FakeReader();
+  const io = new BrowserNdefIO(() => reader);
+  await io.start();
+
+  for (let i = 1; i <= 3; i++) {
+    const pending = io.awaitReading();
+    reader.deliver(`04:0${i}`);
+    const reading = await pending;
+    assert.equal(reading.serialNumber, `04:0${i}`);
+  }
+  assert.equal(reader.scanCount, 1, 'the shipped bug re-armed the scan per read');
+});
+
+test('start() rejects when the browser refuses the scan', async () => {
+  const reader = new FakeReader();
+  reader.failScan = new DOMException('denied', 'NotAllowedError');
+  const io = new BrowserNdefIO(() => reader);
+  await assert.rejects(() => io.start(), /denied/);
+});
+
+test('a reading with nobody waiting is served to the next caller', async () => {
+  const reader = new FakeReader();
+  const io = new BrowserNdefIO(() => reader);
+  await io.start();
+  reader.deliver('04:aa');
+  assert.equal((await io.awaitReading()).serialNumber, '04:aa');
+});
+
+test('two concurrent waits are a programming error', async () => {
+  const reader = new FakeReader();
+  const io = new BrowserNdefIO(() => reader);
+  await io.start();
+  const first = io.awaitReading();
+  await assert.rejects(() => io.awaitReading(), /already waiting/i);
+  reader.deliver('04:bb');
+  await first;
+});
+
+test('stop() ends the scan and clears the buffer', async () => {
+  const reader = new FakeReader();
+  const io = new BrowserNdefIO(() => reader);
+  await io.start();
+  reader.deliver('04:cc');
+  io.stop();
+  await assert.rejects(() => io.awaitReading(), /not started/i);
+});

--- a/webapp/test/browser-ndef-io.test.ts
+++ b/webapp/test/browser-ndef-io.test.ts
@@ -3,10 +3,16 @@ import assert from 'node:assert/strict';
 import { BrowserNdefIO, type NdefReaderLike } from '../app/ui/browser-ndef-io.js';
 
 /** A stand-in NDEFReader that records how often a scan was armed and lets a
- *  test deliver reading events by hand. */
+ *  test deliver reading events by hand. `onreading`'s parameter is typed as
+ *  the full event shape (not narrowed to what `deliver` happens to send) so
+ *  this class satisfies `NdefReaderLike`'s function-type-literal member under
+ *  `strictFunctionTypes` without loosening that production type. */
 class FakeReader implements NdefReaderLike {
   scanCount = 0;
-  onreading: ((e: { serialNumber: string; message: { records: [] } }) => void) | null = null;
+  onreading: ((e: {
+    serialNumber: string;
+    message: { records: Array<{ recordType: string; mediaType?: string; data?: DataView }> };
+  }) => void) | null = null;
   onreadingerror: ((e: unknown) => void) | null = null;
   failScan: Error | null = null;
 
@@ -68,4 +74,27 @@ test('stop() ends the scan and clears the buffer', async () => {
   reader.deliver('04:cc');
   io.stop();
   await assert.rejects(() => io.awaitReading(), /not started/i);
+});
+
+test('a second start() while one is in flight is rejected without arming a second scan', async () => {
+  const reader = new FakeReader();
+  const io = new BrowserNdefIO(() => reader);
+  const first = io.start();
+  await assert.rejects(() => io.start(), /already in progress/i);
+  await first;
+  assert.equal(reader.scanCount, 1);
+});
+
+test('a buffered reading older than BUFFER_MS is discarded, not replayed', async () => {
+  const reader = new FakeReader();
+  let clock = 0;
+  const io = new BrowserNdefIO(() => reader, () => clock);
+  await io.start();
+
+  reader.deliver('04:dd'); // buffered at clock=0, with nobody waiting
+  clock = 2001; // BUFFER_MS is 2000ms — this reading is now stale
+
+  const pending = io.awaitReading();
+  reader.deliver('04:ee'); // a fresh tap arrives after the wait is armed
+  assert.equal((await pending).serialNumber, '04:ee');
 });

--- a/webapp/test/browser-ndef-io.test.ts
+++ b/webapp/test/browser-ndef-io.test.ts
@@ -15,10 +15,16 @@ class FakeReader implements NdefReaderLike {
   }) => void) | null = null;
   onreadingerror: ((e: unknown) => void) | null = null;
   failScan: Error | null = null;
+  /** Set to hold scan() open, so a test can act while arming is in flight. */
+  gate: Promise<void> | null = null;
+  /** The signal of the most recent scan, to assert it was aborted. */
+  lastSignal: AbortSignal | null = null;
 
   async scan(options: { signal: AbortSignal }): Promise<void> {
     if (this.failScan !== null) throw this.failScan;
     this.scanCount += 1;
+    this.lastSignal = options.signal;
+    if (this.gate !== null) await this.gate;
     if (options.signal.aborted) throw new DOMException('Aborted', 'AbortError');
   }
   async write(): Promise<void> {}
@@ -83,6 +89,27 @@ test('a second start() while one is in flight is rejected without arming a secon
   await assert.rejects(() => io.start(), /already in progress/i);
   await first;
   assert.equal(reader.scanCount, 1);
+});
+
+test('stop() during an in-flight start() does not leave an armed reader behind', async () => {
+  // stop() arriving while scan() is still pending sees `scanning`/`reader` both
+  // null, so it can abort nothing. Before the `stopped` flag, the scan then
+  // resolved and installed a live armed reader on an instance the caller had
+  // already stopped — a reader still listening after teardown.
+  const reader = new FakeReader();
+  let release!: () => void;
+  reader.gate = new Promise<void>((resolve) => { release = resolve; });
+  const io = new BrowserNdefIO(() => reader);
+
+  const starting = io.start();
+  io.stop();
+  release();
+  await starting;
+
+  assert.equal(reader.lastSignal?.aborted, true, 'the scan it armed was aborted');
+  assert.equal(reader.onreading, null, 'the reading handler was detached');
+  assert.equal(reader.onreadingerror, null, 'the error handler was detached');
+  await assert.rejects(() => io.awaitReading(), /not started/i, 'no reader was installed');
 });
 
 test('a buffered reading older than BUFFER_MS is discarded, not replayed', async () => {

--- a/webapp/test/fake-ndef-io.ts
+++ b/webapp/test/fake-ndef-io.ts
@@ -2,25 +2,55 @@ import { TagTimeoutError } from '../src/transport/transport.js';
 import type { NdefIO, NdefReading, NdefRecordInit } from '../src/transport/ndef-io.js';
 
 /**
- * In-memory Web NFC. Queue readings with `tap()`; `write()` replaces the
- * records of the tag most recently presented, mirroring how Chrome writes to
- * the tag still in the field.
+ * In-memory Web NFC, modelling the real constraint that made the shipped
+ * adapter freeze the browser: exactly one scan may be armed per instance, and
+ * awaitReading() never arms one. `scanArmCount` is what the regression test
+ * asserts.
  */
 export class FakeNdefIO implements NdefIO {
-  private queue: NdefReading[] = [];
-  private current: NdefReading | null = null;
+  scanArmCount = 0;
   writes: NdefRecordInit[][] = [];
   failNextWrite: Error | null = null;
+  failStart: Error | null = null;
 
-  tap(serialNumber: string, records: NdefReading['records'] = []): void {
-    this.queue.push({ serialNumber, records });
+  private started = false;
+  private pending: NdefReading[] = [];
+  private waiter: ((r: NdefReading) => void) | null = null;
+  private current: NdefReading | null = null;
+
+  async start(): Promise<void> {
+    if (this.failStart !== null) throw this.failStart;
+    if (this.started) throw new Error('A scan is already in progress');
+    this.started = true;
+    this.scanArmCount += 1;
   }
 
-  async awaitReading(): Promise<NdefReading> {
-    const next = this.queue.shift();
-    if (next === undefined) throw new TagTimeoutError('no tag presented');
-    this.current = next;
-    return next;
+  /** Simulate a tag entering the field. */
+  tap(serialNumber: string, records: NdefReading['records'] = []): void {
+    const reading: NdefReading = { serialNumber, records };
+    this.current = reading;
+    if (this.waiter !== null) {
+      const w = this.waiter;
+      this.waiter = null;
+      w(reading);
+      return;
+    }
+    this.pending.push(reading);
+  }
+
+  async awaitReading(opts?: { timeoutMs?: number; signal?: AbortSignal }): Promise<NdefReading> {
+    if (!this.started) throw new Error('Scan not started');
+    if (opts?.signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+    const buffered = this.pending.shift();
+    if (buffered !== undefined) return buffered;
+    if (opts?.timeoutMs !== undefined) throw new TagTimeoutError('no tag presented');
+    return new Promise<NdefReading>((resolve, reject) => {
+      this.waiter = resolve;
+      opts?.signal?.addEventListener('abort', () => {
+        this.waiter = null;
+        reject(new DOMException('Aborted', 'AbortError'));
+      }, { once: true });
+    });
   }
 
   async write(records: NdefRecordInit[]): Promise<void> {
@@ -31,21 +61,17 @@ export class FakeNdefIO implements NdefIO {
     }
     this.writes.push(records);
     if (this.current !== null) {
-      const updatedReading: NdefReading = {
-        serialNumber: this.current.serialNumber,
-        records: records.map((r) => ({
-          recordType: r.recordType,
-          mediaType: r.mediaType,
-          data: r.data,
-        })),
-      };
-      // Re-present the same tag so a read-back or contract re-tap sees it.
-      this.queue.unshift(updatedReading);
+      // Re-present the same tag with its new contents, as a re-tap would.
+      this.tap(this.current.serialNumber, records.map((r) => ({
+        recordType: r.recordType, mediaType: r.mediaType, data: r.data,
+      })));
     }
   }
 
   stop(): void {
-    this.queue = [];
+    this.started = false;
+    this.pending = [];
+    this.waiter = null;
     this.current = null;
   }
 }

--- a/webapp/test/loop-guards.test.ts
+++ b/webapp/test/loop-guards.test.ts
@@ -14,6 +14,16 @@ test('ensureMinInterval waits out the remainder', async () => {
   assert.ok(Date.now() - before >= 100, 'should have waited roughly the interval');
 });
 
+test('a startedAt in the future cannot stretch the wait past minMs', async () => {
+  // A backward wall-clock step (NTP correction, or the user changing the clock
+  // or timezone mid-scan) leaves startedAt ahead of now. Unclamped this would
+  // sleep for the whole skew, deaf to the abort signal — Stop would look dead.
+  const before = Date.now();
+  await ensureMinInterval(Date.now() + 60_000, 120);
+  const waited = Date.now() - before;
+  assert.ok(waited < 1000, `wait must be bounded by minMs, waited ${waited}ms`);
+});
+
 test('the breaker trips after the limit of identical failures', () => {
   const b = new FailureBreaker(3);
   assert.equal(b.record('CardReadError'), false);

--- a/webapp/test/loop-guards.test.ts
+++ b/webapp/test/loop-guards.test.ts
@@ -1,0 +1,37 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { ensureMinInterval, FailureBreaker } from '../src/loop-guards.js';
+
+test('ensureMinInterval resolves immediately once the interval has passed', async () => {
+  const before = Date.now();
+  await ensureMinInterval(Date.now() - 500, 250);
+  assert.ok(Date.now() - before < 100, 'should not have waited');
+});
+
+test('ensureMinInterval waits out the remainder', async () => {
+  const before = Date.now();
+  await ensureMinInterval(Date.now(), 120);
+  assert.ok(Date.now() - before >= 100, 'should have waited roughly the interval');
+});
+
+test('the breaker trips after the limit of identical failures', () => {
+  const b = new FailureBreaker(3);
+  assert.equal(b.record('CardReadError'), false);
+  assert.equal(b.record('CardReadError'), false);
+  assert.equal(b.record('CardReadError'), true);
+});
+
+test('a different error name restarts the count', () => {
+  const b = new FailureBreaker(3);
+  b.record('CardReadError');
+  b.record('CardReadError');
+  assert.equal(b.record('WriteVerifyError'), false, 'a new kind of failure starts over');
+  assert.equal(b.record('WriteVerifyError'), false);
+});
+
+test('reset clears the count', () => {
+  const b = new FailureBreaker(2);
+  b.record('CardReadError');
+  b.reset();
+  assert.equal(b.record('CardReadError'), false);
+});

--- a/webapp/test/web-nfc-transport.test.ts
+++ b/webapp/test/web-nfc-transport.test.ts
@@ -59,7 +59,6 @@ test('awaitTag reports the UID and the selected type capacity', async () => {
   io.tap('04:01:02:03');
   const t = new WebNfcTransport(io, NtagType.NTAG215);
   await t.connect();
-  await io.start(); // connect() isn't wired to start() until Task 3/4
   const tag = await t.awaitTag();
   assert.deepEqual(Array.from(tag.uid), [4, 1, 2, 3]);
   assert.equal(tag.maxChunkPayload, webNfcChunkPayload(NtagType.NTAG215));
@@ -72,7 +71,6 @@ test('peekIsNfar uses the cached reading — no second tap', async () => {
   io.tap('04:01:02:03', records);
   const t = new WebNfcTransport(io, NtagType.NTAG215);
   await t.connect();
-  await io.start(); // connect() isn't wired to start() until Task 3/4
   await t.awaitTag();
   assert.equal(await t.peekIsNfar(), true);
   // A second tap was never queued; if peek had consumed one this would throw.
@@ -84,7 +82,6 @@ test('a blank tag peeks false rather than throwing', async () => {
   io.tap('04:09:09:09', []);
   const t = new WebNfcTransport(io, NtagType.NTAG215);
   await t.connect();
-  await io.start(); // connect() isn't wired to start() until Task 3/4
   await t.awaitTag();
   assert.equal(await t.peekIsNfar(), false);
   // A real card WAS presented and read — it simply holds no NFAR data. That is
@@ -97,7 +94,6 @@ test('a foreign NDEF record peeks false', async () => {
   io.tap('04:09:09:09', [{ recordType: 'text', data: new Uint8Array([1, 2, 3]) }]);
   const t = new WebNfcTransport(io, NtagType.NTAG215);
   await t.connect();
-  await io.start(); // connect() isn't wired to start() until Task 3/4
   await t.awaitTag();
   assert.equal(await t.peekIsNfar(), false);
 });
@@ -107,7 +103,6 @@ test('writeChunk emits one MIME record with the NFAR media type', async () => {
   io.tap('04:01:02:03');
   const t = new WebNfcTransport(io, NtagType.NTAG215);
   await t.connect();
-  await io.start(); // connect() isn't wired to start() until Task 3/4
   await t.awaitTag();
   const { bytes } = nfarRecords(50);
   await t.writeChunk(bytes);
@@ -121,7 +116,6 @@ test('awaitTag rejects TagTimeoutError when no tag is presented', async () => {
   const io = new FakeNdefIO();
   const t = new WebNfcTransport(io, NtagType.NTAG215);
   await t.connect();
-  await io.start(); // connect() isn't wired to start() until Task 3/4
   // The tightened fake only fails fast when timeoutMs is set — with none, it
   // waits for a tap that will never come (real Web NFC has no built-in
   // timeout either). A bare awaitTag() would hang the suite, so this asserts
@@ -136,7 +130,6 @@ test('writeChunk accepts a chunk exactly at the payload boundary and rejects one
   io1.tap('04:01:02:03');
   const t1 = new WebNfcTransport(io1, NtagType.NTAG215);
   await t1.connect();
-  await io1.start(); // connect() isn't wired to start() until Task 3/4
   await t1.awaitTag();
   const { bytes: atMax } = nfarRecords(max);
   await t1.writeChunk(atMax); // must not throw — exactly fills the CC-declared NDEF area
@@ -145,7 +138,6 @@ test('writeChunk accepts a chunk exactly at the payload boundary and rejects one
   io2.tap('04:01:02:03');
   const t2 = new WebNfcTransport(io2, NtagType.NTAG215);
   await t2.connect();
-  await io2.start(); // connect() isn't wired to start() until Task 3/4
   await t2.awaitTag();
   const { bytes: overMax } = nfarRecords(max + 1);
   await assert.rejects(() => t2.writeChunk(overMax), CardCapacityError);
@@ -157,7 +149,6 @@ test('a failed awaitTag() clears the stale cache from the previous tag', async (
   io.tap('04:01:02:03', records);
   const t = new WebNfcTransport(io, NtagType.NTAG215);
   await t.connect();
-  await io.start(); // connect() isn't wired to start() until Task 3/4
   await t.awaitTag();
   assert.equal(await t.peekIsNfar(), true);
 
@@ -178,7 +169,6 @@ test('writeChunk invalidates the cache — a stale peek/read cannot serve pre-wr
   io.tap('04:01:02:03', oldRecords);
   const t = new WebNfcTransport(io, NtagType.NTAG215);
   await t.connect();
-  await io.start(); // connect() isn't wired to start() until Task 3/4
   await t.awaitTag();
   assert.equal(await t.peekIsNfar(), true); // sanity: old content visible pre-write
 
@@ -205,7 +195,6 @@ test('awaitTag rejects a blank serial instead of minting a colliding identity', 
   io.tap('', nfarRecords(50).records);
   const t = new WebNfcTransport(io, NtagType.NTAG215);
   await t.connect();
-  await io.start(); // connect() isn't wired to start() until Task 3/4
   await assert.rejects(() => t.awaitTag(), UnidentifiedTagError);
   // The unusable reading must not be cached either: peek/read on a card whose
   // identity we could not establish would speak for an unknown card.
@@ -222,7 +211,6 @@ test('blank-serial cards cannot collide into one archive identity', async () => 
   io.tap('');
   const t = new WebNfcTransport(io, NtagType.NTAG215);
   await t.connect();
-  await io.start(); // connect() isn't wired to start() until Task 3/4
   const ctrl = new ArchiveController(t);
   const total = await ctrl.prepare({
     data: crypto.getRandomValues(new Uint8Array(1200)),
@@ -239,7 +227,6 @@ test('a blank-serial card fails a restore scan loudly instead of being dropped',
   io.tap('', nfarRecords(50).records);
   const t = new WebNfcTransport(io, NtagType.NTAG215);
   await t.connect();
-  await io.start(); // connect() isn't wired to start() until Task 3/4
   const ctrl = new RestoreController(t);
   await assert.rejects(() => ctrl.scanNextCard(), UnidentifiedTagError);
   assert.deepEqual(ctrl.detectedArchives(), [], 'no archive may be attributed to an unidentified card');
@@ -247,12 +234,8 @@ test('a blank-serial card fails a restore scan loudly instead of being dropped',
 
 runTransportContract('WebNfcTransport+FakeNdefIO', () => {
   const io = new FakeNdefIO();
-  // runTransportContract's factory is synchronous and calls only
-  // transport.connect() (a no-op until Task 3/4 wires it to start()), so arm
-  // the scan here instead. FakeNdefIO.start() has no internal await, so this
-  // runs to completion synchronously before the factory returns — the scan is
-  // armed before any test body runs.
-  void io.start();
+  // connect() (called by runTransportContract itself) now arms the scan, so
+  // the factory need only build the transport.
   const transport = new WebNfcTransport(io, NtagType.NTAG215);
   return {
     transport,
@@ -269,7 +252,6 @@ test('a multi-card scan arms the reader exactly once', async () => {
   const io = new FakeNdefIO();
   const t = new WebNfcTransport(io, NtagType.NTAG215);
   await t.connect();
-  await io.start(); // connect() doesn't wire to start() until Task 3/4
   for (let i = 1; i <= 3; i++) {
     io.tap(`04:0${i}:02:03`);
     const tag = await t.awaitTag();
@@ -288,4 +270,17 @@ test('starting twice is rejected, as the real API does', async () => {
   const io = new FakeNdefIO();
   await io.start();
   await assert.rejects(() => io.start(), /already/i);
+});
+
+test('connect arms the scan, and a refusal surfaces from connect', async () => {
+  const ok = new FakeNdefIO();
+  await new WebNfcTransport(ok, NtagType.NTAG215).connect();
+  assert.equal(ok.scanArmCount, 1);
+
+  const bad = new FakeNdefIO();
+  bad.failStart = new Error('NFC permission denied');
+  await assert.rejects(
+    () => new WebNfcTransport(bad, NtagType.NTAG215).connect(),
+    /permission denied/,
+  );
 });

--- a/webapp/test/web-nfc-transport.test.ts
+++ b/webapp/test/web-nfc-transport.test.ts
@@ -59,6 +59,7 @@ test('awaitTag reports the UID and the selected type capacity', async () => {
   io.tap('04:01:02:03');
   const t = new WebNfcTransport(io, NtagType.NTAG215);
   await t.connect();
+  await io.start(); // connect() isn't wired to start() until Task 3/4
   const tag = await t.awaitTag();
   assert.deepEqual(Array.from(tag.uid), [4, 1, 2, 3]);
   assert.equal(tag.maxChunkPayload, webNfcChunkPayload(NtagType.NTAG215));
@@ -71,6 +72,7 @@ test('peekIsNfar uses the cached reading — no second tap', async () => {
   io.tap('04:01:02:03', records);
   const t = new WebNfcTransport(io, NtagType.NTAG215);
   await t.connect();
+  await io.start(); // connect() isn't wired to start() until Task 3/4
   await t.awaitTag();
   assert.equal(await t.peekIsNfar(), true);
   // A second tap was never queued; if peek had consumed one this would throw.
@@ -82,6 +84,7 @@ test('a blank tag peeks false rather than throwing', async () => {
   io.tap('04:09:09:09', []);
   const t = new WebNfcTransport(io, NtagType.NTAG215);
   await t.connect();
+  await io.start(); // connect() isn't wired to start() until Task 3/4
   await t.awaitTag();
   assert.equal(await t.peekIsNfar(), false);
   // A real card WAS presented and read — it simply holds no NFAR data. That is
@@ -94,6 +97,7 @@ test('a foreign NDEF record peeks false', async () => {
   io.tap('04:09:09:09', [{ recordType: 'text', data: new Uint8Array([1, 2, 3]) }]);
   const t = new WebNfcTransport(io, NtagType.NTAG215);
   await t.connect();
+  await io.start(); // connect() isn't wired to start() until Task 3/4
   await t.awaitTag();
   assert.equal(await t.peekIsNfar(), false);
 });
@@ -103,6 +107,7 @@ test('writeChunk emits one MIME record with the NFAR media type', async () => {
   io.tap('04:01:02:03');
   const t = new WebNfcTransport(io, NtagType.NTAG215);
   await t.connect();
+  await io.start(); // connect() isn't wired to start() until Task 3/4
   await t.awaitTag();
   const { bytes } = nfarRecords(50);
   await t.writeChunk(bytes);
@@ -113,9 +118,15 @@ test('writeChunk emits one MIME record with the NFAR media type', async () => {
 });
 
 test('awaitTag rejects TagTimeoutError when no tag is presented', async () => {
-  const t = new WebNfcTransport(new FakeNdefIO(), NtagType.NTAG215);
+  const io = new FakeNdefIO();
+  const t = new WebNfcTransport(io, NtagType.NTAG215);
   await t.connect();
-  await assert.rejects(() => t.awaitTag(), TagTimeoutError);
+  await io.start(); // connect() isn't wired to start() until Task 3/4
+  // The tightened fake only fails fast when timeoutMs is set — with none, it
+  // waits for a tap that will never come (real Web NFC has no built-in
+  // timeout either). A bare awaitTag() would hang the suite, so this asserts
+  // through an explicit timeout, same as the transport contract does.
+  await assert.rejects(() => t.awaitTag({ timeoutMs: 20 }), TagTimeoutError);
 });
 
 test('writeChunk accepts a chunk exactly at the payload boundary and rejects one byte more', async () => {
@@ -125,6 +136,7 @@ test('writeChunk accepts a chunk exactly at the payload boundary and rejects one
   io1.tap('04:01:02:03');
   const t1 = new WebNfcTransport(io1, NtagType.NTAG215);
   await t1.connect();
+  await io1.start(); // connect() isn't wired to start() until Task 3/4
   await t1.awaitTag();
   const { bytes: atMax } = nfarRecords(max);
   await t1.writeChunk(atMax); // must not throw — exactly fills the CC-declared NDEF area
@@ -133,6 +145,7 @@ test('writeChunk accepts a chunk exactly at the payload boundary and rejects one
   io2.tap('04:01:02:03');
   const t2 = new WebNfcTransport(io2, NtagType.NTAG215);
   await t2.connect();
+  await io2.start(); // connect() isn't wired to start() until Task 3/4
   await t2.awaitTag();
   const { bytes: overMax } = nfarRecords(max + 1);
   await assert.rejects(() => t2.writeChunk(overMax), CardCapacityError);
@@ -144,11 +157,14 @@ test('a failed awaitTag() clears the stale cache from the previous tag', async (
   io.tap('04:01:02:03', records);
   const t = new WebNfcTransport(io, NtagType.NTAG215);
   await t.connect();
+  await io.start(); // connect() isn't wired to start() until Task 3/4
   await t.awaitTag();
   assert.equal(await t.peekIsNfar(), true);
 
   // Nothing queued: this awaitTag() rejects. Card A's reading must not linger.
-  await assert.rejects(() => t.awaitTag(), TagTimeoutError);
+  // timeoutMs is required for the tightened fake to fail fast rather than wait
+  // forever for a tap that never comes.
+  await assert.rejects(() => t.awaitTag({ timeoutMs: 20 }), TagTimeoutError);
   assert.equal(await t.peekIsNfar(), false);
   await assert.rejects(() => t.readChunk(), UnidentifiedTagError);
 });
@@ -162,6 +178,7 @@ test('writeChunk invalidates the cache — a stale peek/read cannot serve pre-wr
   io.tap('04:01:02:03', oldRecords);
   const t = new WebNfcTransport(io, NtagType.NTAG215);
   await t.connect();
+  await io.start(); // connect() isn't wired to start() until Task 3/4
   await t.awaitTag();
   assert.equal(await t.peekIsNfar(), true); // sanity: old content visible pre-write
 
@@ -188,6 +205,7 @@ test('awaitTag rejects a blank serial instead of minting a colliding identity', 
   io.tap('', nfarRecords(50).records);
   const t = new WebNfcTransport(io, NtagType.NTAG215);
   await t.connect();
+  await io.start(); // connect() isn't wired to start() until Task 3/4
   await assert.rejects(() => t.awaitTag(), UnidentifiedTagError);
   // The unusable reading must not be cached either: peek/read on a card whose
   // identity we could not establish would speak for an unknown card.
@@ -204,6 +222,7 @@ test('blank-serial cards cannot collide into one archive identity', async () => 
   io.tap('');
   const t = new WebNfcTransport(io, NtagType.NTAG215);
   await t.connect();
+  await io.start(); // connect() isn't wired to start() until Task 3/4
   const ctrl = new ArchiveController(t);
   const total = await ctrl.prepare({
     data: crypto.getRandomValues(new Uint8Array(1200)),
@@ -220,6 +239,7 @@ test('a blank-serial card fails a restore scan loudly instead of being dropped',
   io.tap('', nfarRecords(50).records);
   const t = new WebNfcTransport(io, NtagType.NTAG215);
   await t.connect();
+  await io.start(); // connect() isn't wired to start() until Task 3/4
   const ctrl = new RestoreController(t);
   await assert.rejects(() => ctrl.scanNextCard(), UnidentifiedTagError);
   assert.deepEqual(ctrl.detectedArchives(), [], 'no archive may be attributed to an unidentified card');
@@ -227,6 +247,12 @@ test('a blank-serial card fails a restore scan loudly instead of being dropped',
 
 runTransportContract('WebNfcTransport+FakeNdefIO', () => {
   const io = new FakeNdefIO();
+  // runTransportContract's factory is synchronous and calls only
+  // transport.connect() (a no-op until Task 3/4 wires it to start()), so arm
+  // the scan here instead. FakeNdefIO.start() has no internal await, so this
+  // runs to completion synchronously before the factory returns — the scan is
+  // armed before any test body runs.
+  void io.start();
   const transport = new WebNfcTransport(io, NtagType.NTAG215);
   return {
     transport,
@@ -237,4 +263,29 @@ runTransportContract('WebNfcTransport+FakeNdefIO', () => {
 }, {
   capacityBytes: ntagFactoryNdefCapacity(NtagType.NTAG215),
   maxChunkPayload: webNfcChunkPayload(NtagType.NTAG215),
+});
+
+test('a multi-card scan arms the reader exactly once', async () => {
+  const io = new FakeNdefIO();
+  const t = new WebNfcTransport(io, NtagType.NTAG215);
+  await t.connect();
+  await io.start(); // connect() doesn't wire to start() until Task 3/4
+  for (let i = 1; i <= 3; i++) {
+    io.tap(`04:0${i}:02:03`);
+    const tag = await t.awaitTag();
+    assert.equal(tag.uid[1], i);
+  }
+  assert.equal(io.scanArmCount, 1, 'each card must reuse the one scan');
+});
+
+test('reading before the scan is started is a programming error', async () => {
+  const io = new FakeNdefIO();
+  io.tap('04:01:02:03');
+  await assert.rejects(() => io.awaitReading(), /not started/i);
+});
+
+test('starting twice is rejected, as the real API does', async () => {
+  const io = new FakeNdefIO();
+  await io.start();
+  await assert.rejects(() => io.start(), /already/i);
 });


### PR DESCRIPTION
**Fixes a live production defect.** Connecting phone NFC and pressing "Scan cards" froze the browser hard enough that neither Stop nor tab switching responded. Reported from a Pixel 8 Pro and diagnosed over wireless ADB.

## Root cause

Web NFC's model is **one scan, many `reading` events**. `BrowserNdefIO` was built as *one `awaitReading()` = one scan*:

```ts
this.scanning?.abort();              // kill the live scan
reader.scan({ signal: ac.signal })   // ...and re-arm the SAME reader, same tick
```

So the second card aborted the running scan and re-armed the same `NDEFReader`, which rejects **synchronously in the renderer**. The restore loop's bare `continue` turned that into an unbroken chain of already-rejected promises — awaiting one yields a microtask but never returns to the event loop's task queue, so nothing renders and no input is handled.

The evidence was decisive:

| Measurement | Value |
|---|---|
| `NfcService: setReaderMode` (page arms a scan) | **1** |
| `onTagRfDiscovered` (OS reads a tag) | **8** |
| Renderer CPU | **186%** |
| Console output from the app | **0 lines** |

One arm against eight discoveries is what proves the rejection never left the renderer. The vibrations were Android's NFC service — our own abort had turned reader mode off, so every later tap was discovered and delivered nowhere.

## The fix

**One scan per connection.** `NdefIO` gains `start()`; `BrowserNdefIO` arms exactly one `scan()` per instance and is discarded on disconnect. `WebNfcTransport.connect()` calls it, so the permission prompt now appears when the user asks for NFC — inside their gesture — and a refusal surfaces at the button instead of inside a scan loop. A reading arriving with no waiter is held 2 s then discarded, covering the millisecond gap between cards without replaying a stale tap.

**Loops that cannot starve.** A shared `ensureMinInterval` paces every error path at 250 ms, and a `FailureBreaker` stops a loop after 5 consecutive failures of the same kind — deliberately *not* counting `TagTimeoutError`, `OverwriteRequiredError`, `AbortError`, `UnsupportedTagError` or `CardAuthError`, because waiting for the user and skipping a foreign card are not failures. Applied to the archive loop too, whose `usable()` check only ever caught a *swapped* transport.

**`BrowserNdefIO` is now testable.** It takes an injectable reader factory, so the file that actually had the bug is exercised under `node --test` for the first time.

## Verification

254 → **274 tests**, `tsc` clean, bundle 293,762 B.

The regression test is genuine, not a description of the fix: reverting the source files and re-running gives **4 fail / 270 pass**. The clock-clamp test takes **60,181 ms** pre-fix versus ~120 ms after — the unbounded sleep caught in the act.

## Not verified — read this before merging

**The feature has still never completed a successful card operation on hardware.** This fix is reasoned, not proven.

One risk introduced by the fix itself: `activateWebNfc()` now `await`s teardown *before* calling `scan()`, and that await may consume the user-activation window Chrome requires. If phone NFC stops connecting entirely, that is the first suspect.

Also still unproven: that `scan()` resolves at all on Chrome/Android; that `onreading` fires repeatedly for one armed scan; that a real card reports a non-empty `serialNumber`.

Suggested first hardware session, in order: connect and watch for the prompt → 3-card restore scan with logcat showing **one** `setReaderMode` against N discoveries and Stop responsive → one card left resting → 2-card archive → foreign Mifare mid-pile → Disconnect mid-operation.

## Known follow-ups, non-blocking

- The archive loop still counts `CardAuthError`, so five foreign-Mifare taps *during a write* discard the whole archive. Union of two findings that neither covered; pre-existing.
- `activateWebNfc()`'s `catch` is unguarded, so a stale *rejection* can tear down a newer reader. The Chameleon path has the identical hole; one line closes both.
- `CardAuthError`'s exemption `continue`s before the pacing call, so its bound is BLE round-trip latency rather than 250 ms. Cannot freeze the browser; each occurrence needs a tag in field.

Spec: `docs/superpowers/specs/2026-07-31-web-nfc-scan-model-fix-design.md`
Plan: `docs/superpowers/plans/2026-07-31-web-nfc-scan-model-fix.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)