### PR TITLE
fix(webapp): reader mutual exclusion, and MIME-typed downloads

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -93,9 +93,18 @@ Phone NFC's limits are the Web NFC API's, not a missing feature:
   collides every such card onto one key (the archive would stall forever on
   card 2), and a random one would let the same card be written twice.
 
-**Disconnect** is disabled while the active reader is busy (an archive write,
-a restore scan, or a card inspection in progress) — the same `readerBusy`
-interlock that also gates **Inspect card**.
+**Reader ownership.** Archiving, restore scanning and card inspection all
+drive the same reader through the same `Transport`, and none of them tolerates
+a second loop calling `awaitTag()` underneath it. `app/ui/reader-lock.ts` holds
+one owner at a time: **Archive to cards** and **Scan cards** each grey the
+other out (with a tooltip saying why), and **Inspect card** is disabled while
+either runs. `release()` is owner-checked, so the subsystem that finishes first
+cannot free a lock another still holds.
+
+**Disconnect is deliberately never gated on that lock.** It is the app's only
+universal escape hatch — the archive loop has no Stop control — and both loops
+handle a mid-flight teardown cleanly, so it doubles as the way to abandon a
+stuck write.
 
 **Scan model.** `app/ui/browser-ndef-io.ts` (`BrowserNdefIO`) is the only file
 that touches `NDEFReader`. It arms exactly one scan per connection —

--- a/webapp/app/download-mime.ts
+++ b/webapp/app/download-mime.ts
@@ -1,0 +1,49 @@
+/**
+ * Content type for a restored file, resolved from its name.
+ *
+ * A `new Blob([bytes])` with no type downloads as application/octet-stream.
+ * The bytes are correct either way, but on Android the viewer launched from
+ * the download receives that type, finds no charset, and falls back to a
+ * platform default — which renders UTF-8 Cyrillic as mojibake while leaving
+ * ASCII looking perfect. Declaring the charset is what tells it how to decode.
+ *
+ * This is the browser-side twin of the `share_plus` MIME rule in CLAUDE.md,
+ * where Android's ContentResolver reports application/octet-stream for the
+ * same reason. The Flutter app uses the `mime` package; the webapp core takes
+ * no runtime dependencies, so this is a small table of what we actually
+ * archive rather than a full registry.
+ */
+
+/** Types whose bytes we produce as UTF-8 and whose viewers must be told so. */
+const TEXT_TYPES: Record<string, string> = {
+  txt: 'text/plain',
+  md: 'text/markdown',
+  csv: 'text/csv',
+  html: 'text/html',
+  xml: 'text/xml',
+};
+
+/** Types carrying their own encoding, for which a charset parameter is
+ *  meaningless or (for JSON, per RFC 8259) undefined. */
+const BINARY_TYPES: Record<string, string> = {
+  json: 'application/json',
+  pdf: 'application/pdf',
+  zip: 'application/zip',
+  gz: 'application/gzip',
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+};
+
+export function mimeForFilename(name: string): string {
+  const dot = name.lastIndexOf('.');
+  // dot === 0 is a dotfile (".bashrc"): the name IS the suffix, not an
+  // extension. dot === name.length - 1 is a trailing dot with nothing after it.
+  if (dot <= 0 || dot === name.length - 1) return 'application/octet-stream';
+  const ext = name.slice(dot + 1).toLowerCase();
+  const text = TEXT_TYPES[ext];
+  if (text !== undefined) return `${text};charset=utf-8`;
+  return BINARY_TYPES[ext] ?? 'application/octet-stream';
+}

--- a/webapp/app/i18n/be.ts
+++ b/webapp/app/i18n/be.ts
@@ -24,6 +24,7 @@ export const be: Messages = {
   connectedPhoneNfc: 'Выкарыстоўваецца NFC тэлефона.',
   readerDisconnectedClickConnect: 'Счытвальнік адключаны — націсніце «Падключыць», каб працягнуць.',
   inspectNeedsChameleon: 'Для агляду карты патрэбны Chameleon — NFC тэлефона не мае прамога доступу да карты.',
+  readerBusyElsewhere: 'Счытвальнік заняты іншай аперацыяй — спачатку завяршыце або спыніце яе.',
   autoDetectNeedsChameleon: 'Абярыце тып меткі: NFC тэлефона не можа вызначыць ёмістасць карты.',
 
   // — tabs —

--- a/webapp/app/i18n/en.ts
+++ b/webapp/app/i18n/en.ts
@@ -23,6 +23,7 @@ export const en = {
   connectedPhoneNfc: 'Using phone NFC.',
   readerDisconnectedClickConnect: 'Reader disconnected — click Connect to resume.',
   inspectNeedsChameleon: 'Card inspection needs a Chameleon — phone NFC has no raw card access.',
+  readerBusyElsewhere: 'The reader is busy with another operation — finish or stop it first.',
   autoDetectNeedsChameleon: 'Pick a tag type: phone NFC cannot detect card capacity.',
 
   // — tabs —

--- a/webapp/app/i18n/ka.ts
+++ b/webapp/app/i18n/ka.ts
@@ -21,6 +21,7 @@ export const ka: Messages = {
   connectedPhoneNfc: 'გამოიყენება ტელეფონის NFC.',
   readerDisconnectedClickConnect: 'წამკითხველი გაითიშა — გასაგრძელებლად დააჭირეთ „დაკავშირებას“.',
   inspectNeedsChameleon: 'ბარათის დათვალიერებას სჭირდება Chameleon — ტელეფონის NFC-ს არ აქვს პირდაპირი წვდომა ბარათთან.',
+  readerBusyElsewhere: 'წამკითხველი სხვა ოპერაციითაა დაკავებული — ჯერ დაასრულეთ ან შეაჩერეთ იგი.',
   autoDetectNeedsChameleon: 'აირჩიეთ ბარათის ტიპი: ტელეფონის NFC ვერ ამოიცნობს ბარათის ტევადობას.',
 
   // — tabs —

--- a/webapp/app/i18n/pl.ts
+++ b/webapp/app/i18n/pl.ts
@@ -24,6 +24,7 @@ export const pl: Messages = {
   connectedPhoneNfc: 'Używane NFC telefonu.',
   readerDisconnectedClickConnect: 'Czytnik rozłączony — kliknij „Połącz”, aby kontynuować.',
   inspectNeedsChameleon: 'Zbadanie karty wymaga Chameleona — NFC telefonu nie ma bezpośredniego dostępu do karty.',
+  readerBusyElsewhere: 'Czytnik jest zajęty inną operacją — najpierw ją zakończ lub zatrzymaj.',
   autoDetectNeedsChameleon: 'Wybierz typ znacznika: NFC telefonu nie potrafi wykryć pojemności karty.',
 
   // — tabs —

--- a/webapp/app/i18n/ru.ts
+++ b/webapp/app/i18n/ru.ts
@@ -24,6 +24,7 @@ export const ru: Messages = {
   connectedPhoneNfc: 'Используется NFC телефона.',
   readerDisconnectedClickConnect: 'Считыватель отключён — нажмите «Подключить», чтобы продолжить.',
   inspectNeedsChameleon: 'Для осмотра карты нужен Chameleon — у NFC телефона нет прямого доступа к карте.',
+  readerBusyElsewhere: 'Считыватель занят другой операцией — сначала завершите или остановите её.',
   autoDetectNeedsChameleon: 'Выберите тип метки: NFC телефона не может определить ёмкость карты.',
 
   // — tabs —

--- a/webapp/app/i18n/tr.ts
+++ b/webapp/app/i18n/tr.ts
@@ -21,6 +21,7 @@ export const tr: Messages = {
   connectedPhoneNfc: "Telefonun NFC'si kullanılıyor.",
   readerDisconnectedClickConnect: "Okuyucu bağlantısı kesildi — devam etmek için Bağlan'a tıklayın.",
   inspectNeedsChameleon: "Kart incelemesi için Chameleon gerekir — telefonun NFC'sinin ham karta erişimi yoktur.",
+  readerBusyElsewhere: 'Okuyucu başka bir işlemle meşgul — önce onu bitirin veya durdurun.',
   autoDetectNeedsChameleon: "Bir etiket türü seçin: telefonun NFC'si kart kapasitesini algılayamaz.",
 
   // — tabs —

--- a/webapp/app/i18n/uk.ts
+++ b/webapp/app/i18n/uk.ts
@@ -24,6 +24,7 @@ export const uk: Messages = {
   connectedPhoneNfc: 'Використовується NFC телефону.',
   readerDisconnectedClickConnect: 'Зчитувач відключено — натисніть «Підключити», щоб продовжити.',
   inspectNeedsChameleon: 'Для огляду картки потрібен Chameleon — NFC телефону не має прямого доступу до картки.',
+  readerBusyElsewhere: 'Зчитувач зайнятий іншою операцією — спершу завершіть або зупиніть її.',
   autoDetectNeedsChameleon: 'Виберіть тип мітки: NFC телефону не може визначити ємність картки.',
 
   // — tabs —

--- a/webapp/app/ui/archive-panel.ts
+++ b/webapp/app/ui/archive-panel.ts
@@ -7,7 +7,7 @@ import { CARD_PAYLOAD_SIZE } from '../../src/mifare/card-layout.js';
 import { activeReaderName, currentTransport, isConnected, onConnectionChange } from './device.js';
 import { readerLock } from './reader-lock.js';
 import { humanError } from './errors.js';
-import { t } from '../i18n/index.js';
+import { t, onLocaleChange } from '../i18n/index.js';
 import { log } from '../../src/log/logger.js';
 
 const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
@@ -122,6 +122,9 @@ export function initArchivePanel(): void {
     btn.title = owner !== null && owner !== 'archive' ? t.readerBusyElsewhere : '';
   };
   readerLock.onChange(syncArchiveButton);
+  // Same reason as restore-panel's: a `t`-derived title is invisible to
+  // applyStaticText(), so it must be re-derived on a locale change.
+  onLocaleChange(syncArchiveButton);
 
   onConnectionChange((connected) => {
     syncArchiveButton();

--- a/webapp/app/ui/archive-panel.ts
+++ b/webapp/app/ui/archive-panel.ts
@@ -4,7 +4,8 @@ import type { Transport } from '../../src/transport/transport.js';
 import { estimateCardCount } from '../estimate.js';
 import { NtagType, ntagChunkPayloadSize, webNfcChunkPayload } from '../../src/nfc/type2.js';
 import { CARD_PAYLOAD_SIZE } from '../../src/mifare/card-layout.js';
-import { activeReaderName, currentTransport, isConnected, onConnectionChange, setReaderBusy } from './device.js';
+import { activeReaderName, currentTransport, isConnected, onConnectionChange } from './device.js';
+import { readerLock } from './reader-lock.js';
 import { humanError } from './errors.js';
 import { t } from '../i18n/index.js';
 import { log } from '../../src/log/logger.js';
@@ -77,7 +78,11 @@ export function initArchivePanel(): void {
     overwriteDialog.showModal();
   });
 
-  let archiving = false;
+  // Whether THIS panel is driving the reader. Previously a private `archiving`
+  // boolean; it is now derived from the shared lock so that a running scan
+  // blocks a write and vice versa — two loops calling awaitTag() on one reader
+  // is what made every card of a 16-card archive fail on 2026-07-31.
+  const archivingNow = (): boolean => readerLock.current() === 'archive';
 
   let fileBytes: Uint8Array | null = null;
   let fileName = '';
@@ -110,8 +115,16 @@ export function initArchivePanel(): void {
   for (const id of ['text', 'compress', 'apass']) $(id).addEventListener('input', scheduleCounter);
   $('target-tag').addEventListener('change', scheduleCounter);
 
+  const syncArchiveButton = (): void => {
+    const owner = readerLock.current();
+    const btn = $('archive') as HTMLButtonElement;
+    btn.disabled = !isConnected() || owner !== null;
+    btn.title = owner !== null && owner !== 'archive' ? t.readerBusyElsewhere : '';
+  };
+  readerLock.onChange(syncArchiveButton);
+
   onConnectionChange((connected) => {
-    ($('archive') as HTMLButtonElement).disabled = !connected || archiving;
+    syncArchiveButton();
     // The fallback changes the basis of the card-count estimate (720 B/chunk ->
     // NTAG215's), and a programmatic `sel.value = …` fires no change event, so
     // the counter would otherwise keep showing the old figure until the first tap.
@@ -120,16 +133,17 @@ export function initArchivePanel(): void {
     // write is in progress, this element carries live progress/error text
     // (see ArchiveOrchestrator's io.setStatus calls) that a reader hand-off
     // must not stomp.
-    if (connected && !archiving) {
+    if (connected && !archivingNow()) {
       setStatus(activeReaderName() === 'web-nfc' ? t.autoDetectNeedsChameleon : t.archiveReady);
     }
   });
 
   $('archive').addEventListener('click', async () => {
-    if (archiving) return;
     const transport = currentTransport();
     if (!transport) return;
     const src = currentSource();
+    // Acquire only after the cheap rejections, or an early return would leak
+    // the lock and wedge the reader for every other panel.
     if (!src) { setStatus(t.archivePickFirst); return; }
     const compress = ($('compress') as HTMLInputElement).checked;
     const pass = ($('apass') as HTMLInputElement).value;
@@ -157,9 +171,7 @@ export function initArchivePanel(): void {
       log,
     };
 
-    archiving = true;
-    setReaderBusy(true);
-    ($('archive') as HTMLButtonElement).disabled = true;
+    if (!readerLock.acquire('archive')) { setStatus(t.readerBusyElsewhere); return; }
     try {
       await new ArchiveOrchestrator(io).run(transport, {
         data: src.data, fileName: src.fileName, compress,
@@ -169,9 +181,7 @@ export function initArchivePanel(): void {
       hideProgress();
       setStatus(humanError(e));
     } finally {
-      setReaderBusy(false);
-      archiving = false;
-      ($('archive') as HTMLButtonElement).disabled = !isConnected();
+      readerLock.release('archive');
     }
   });
 }

--- a/webapp/app/ui/device.ts
+++ b/webapp/app/ui/device.ts
@@ -14,6 +14,7 @@ import { NtagType } from '../../src/nfc/type2.js';
 import type { Transport } from '../../src/transport/transport.js';
 import { type RawAntiColl } from '../diagnostics.js';
 import { openInspector } from './inspect-panel.js';
+import { readerLock } from './reader-lock.js';
 import { humanError } from './errors.js';
 import { log } from '../../src/log/logger.js';
 import { t, onLocaleChange } from '../i18n/index.js';
@@ -25,7 +26,6 @@ let transport: Transport | null = null;
 let connected = false;
 const listeners: Array<(connected: boolean) => void> = [];
 
-let readerBusy = false;
 
 /** Which reader is behind `transport`, if any. Chameleon exposes raw page
  *  access (Inspect); Web NFC does not — panels use this to adjust accordingly. */
@@ -44,13 +44,10 @@ export function activeReaderName(): 'chameleon' | 'web-nfc' | null {
   return reader;
 }
 
-/** Panels report when they own the reader. Two callers interleaving BLE
- *  commands on one reader can corrupt an in-flight write, which is why the
- *  Archive button already guards on its own `archiving` flag. */
-export function setReaderBusy(busy: boolean): void {
-  readerBusy = busy;
-  updateDeviceButtons();
-}
+// Ownership now lives in readerLock, which the panels acquire directly. This
+// module only reacts: any change to who holds the reader re-derives the
+// device-bar buttons.
+readerLock.onChange(() => { updateDeviceButtons(); });
 
 /** `#target-tag`'s selection, mapped to the NtagType Web NFC needs up front —
  *  it has no capability container, so capacity can't be discovered from the
@@ -65,9 +62,18 @@ function selectedNtagType(): NtagType {
 }
 
 function updateDeviceButtons(): void {
+  // Inspect needs exclusive raw access and has no reason to preempt a running
+  // operation, so it stays gated on the lock.
   ($('inspect') as HTMLButtonElement).disabled =
-    !connected || readerBusy || reader !== 'chameleon';
-  ($('disconnect') as HTMLButtonElement).disabled = !connected || readerBusy;
+    !connected || readerLock.current() !== null || reader !== 'chameleon';
+  // Disconnect deliberately is NOT gated on the lock. It is the app's only
+  // universal escape hatch: the archive loop has no Stop control at all, so
+  // gating this would leave a wedged write with no way out — the exact trap
+  // that stranded a user on 2026-07-31. Both loops handle a mid-flight
+  // teardown cleanly (the archive loop's `usable()` check, and BrowserNdefIO's
+  // stop() rejecting the pending waiter with AbortError), so abandoning an
+  // operation this way is safe rather than merely tolerated.
+  ($('disconnect') as HTMLButtonElement).disabled = !connected;
   ($('inspect') as HTMLButtonElement).title =
     reader === 'web-nfc' ? t.inspectNeedsChameleon : '';
 }
@@ -294,6 +300,10 @@ export function initDeviceBar(): void {
         return new Uint8Array(resp);
       },
     };
-    openInspector(new SdkChameleonDevice(dev), raw, setReaderBusy);
+    // The Inspect button is disabled whenever the lock is held, so this can
+    // only run from a free lock; acquire's return needs no check.
+    openInspector(new SdkChameleonDevice(dev), raw, (busy) => {
+      if (busy) readerLock.acquire('inspect'); else readerLock.release('inspect');
+    });
   });
 }

--- a/webapp/app/ui/files-panel.ts
+++ b/webapp/app/ui/files-panel.ts
@@ -5,6 +5,7 @@ import { renderFileList, humanSize } from './files-view.js';
 import { PasswordRequiredError } from '../controller.js';
 import { DecryptionError } from '../../src/crypto.js';
 import { humanError } from './errors.js';
+import { mimeForFilename } from '../download-mime.js';
 import { log } from '../../src/log/logger.js';
 import { t } from '../i18n/index.js';
 
@@ -19,7 +20,7 @@ async function download(id: string, setStatus: (m: string) => void): Promise<voi
     try {
       const { data, name } = await filesController.prepareDownload(id, pw);
       const a = document.createElement('a');
-      a.href = URL.createObjectURL(new Blob([data as BlobPart]));
+      a.href = URL.createObjectURL(new Blob([data as BlobPart], { type: mimeForFilename(name) }));
       a.download = name;
       a.click();
       URL.revokeObjectURL(a.href);

--- a/webapp/app/ui/inspect-panel.ts
+++ b/webapp/app/ui/inspect-panel.ts
@@ -22,7 +22,7 @@ let currentAbort: AbortController | null = null;
 export function openInspector(
   dev: ChameleonDevice,
   raw: RawAntiColl,
-  setReaderBusy: (busy: boolean) => void,
+  setBusy: (busy: boolean) => void,
 ): void {
   if (running) return;
   const dialog = $('inspect-dialog') as HTMLDialogElement;
@@ -78,7 +78,7 @@ export function openInspector(
 
   dialog.showModal();
   running = true;
-  setReaderBusy(true);
+  setBusy(true);
   log.info('inspect', 'Inspection started');
   void runInspection(dev, raw, io, ac.signal)
     .catch((e: unknown) => { if (currentAbort === ac) status.textContent = String(e); })
@@ -88,7 +88,7 @@ export function openInspector(
       // would never fire (there is none pending) while a still-running one
       // would leave the button permanently disabled if guarded on the epoch.
       running = false;
-      setReaderBusy(false);
+      setBusy(false);
       log.info('inspect', 'Inspection finished', { rows: rows.length });
     });
 }

--- a/webapp/app/ui/reader-lock.ts
+++ b/webapp/app/ui/reader-lock.ts
@@ -1,0 +1,65 @@
+/**
+ * Exclusive ownership of the connected reader.
+ *
+ * Scanning, archiving and card inspection all drive the same physical reader
+ * through the same `Transport`, and none of them tolerates a second loop
+ * calling `awaitTag()` underneath it. Web NFC makes that explicit —
+ * `BrowserNdefIO` holds exactly one waiter and rejects a second with
+ * "Already waiting for a reading" — but the hazard is not Web NFC's: over a
+ * Chameleon two concurrent loops simply race for tags, which is worse for
+ * being silent.
+ *
+ * Observed in production: a restore scan left running while an archive was
+ * started took every tap, so all 16 cards failed and the circuit breaker
+ * discarded the archive.
+ *
+ * This replaces a plain `readerBusy` boolean that all three subsystems wrote.
+ * Because a boolean has no notion of who set it, whichever finished FIRST
+ * cleared it for the rest — so `release` here is owner-checked and a refused
+ * `acquire` changes nothing.
+ */
+
+export type ReaderUser = 'scan' | 'archive' | 'inspect';
+
+type Listener = (owner: ReaderUser | null) => void;
+
+export class ReaderLock {
+  private owner: ReaderUser | null = null;
+  private readonly listeners = new Set<Listener>();
+
+  /** Who holds the reader, or null if it is free. */
+  current(): ReaderUser | null {
+    return this.owner;
+  }
+
+  /** Take the reader. Returns false if anyone already holds it — including
+   *  `who` itself: no caller needs re-entrancy, and permitting it would let a
+   *  single `release()` free a lock two call sites believe they hold. */
+  acquire(who: ReaderUser): boolean {
+    if (this.owner !== null) return false;
+    this.owner = who;
+    this.notify();
+    return true;
+  }
+
+  /** Release the reader. A non-owner's call is ignored, so the `finally` of a
+   *  subsystem that never acquired cannot free someone else's lock. */
+  release(who: ReaderUser): void {
+    if (this.owner !== who) return;
+    this.owner = null;
+    this.notify();
+  }
+
+  /** Subscribe to ownership changes. Returns an unsubscribe function. */
+  onChange(fn: Listener): () => void {
+    this.listeners.add(fn);
+    return () => { this.listeners.delete(fn); };
+  }
+
+  private notify(): void {
+    for (const fn of this.listeners) fn(this.owner);
+  }
+}
+
+/** The app's single reader. Tests construct their own `ReaderLock`. */
+export const readerLock = new ReaderLock();

--- a/webapp/app/ui/restore-panel.ts
+++ b/webapp/app/ui/restore-panel.ts
@@ -1,9 +1,11 @@
 /** Restore tab: thin adapter — builds the DOM/browser IO for RestoreOrchestrator and runs the scan-step loop. */
 import { RestoreOrchestrator, type RestoreIO } from './restore-orchestrator.js';
 import { CardAuthError, TagTimeoutError, UnsupportedTagError } from '../../src/transport/transport.js';
-import { currentTransport, onConnectionChange, setReaderBusy } from './device.js';
+import { currentTransport, isConnected, onConnectionChange } from './device.js';
+import { readerLock } from './reader-lock.js';
 import { filesController } from './files-panel.js';
 import { humanError } from './errors.js';
+import { mimeForFilename } from '../download-mime.js';
 import { log } from '../../src/log/logger.js';
 import { t } from '../i18n/index.js';
 import { ensureMinInterval, FailureBreaker } from '../../src/loop-guards.js';
@@ -20,7 +22,9 @@ export function initRestorePanel(): void {
     promptPassword: (message) => window.prompt(message),
     download: (data, name) => {
       const a = document.createElement('a');
-      a.href = URL.createObjectURL(new Blob([data as BlobPart]));
+      // Typed, not bare: an untyped Blob downloads as application/octet-stream,
+      // and Android's viewer then has no charset for restored UTF-8 text.
+      a.href = URL.createObjectURL(new Blob([data as BlobPart], { type: mimeForFilename(name) }));
       a.download = name;
       a.click();
       URL.revokeObjectURL(a.href);
@@ -32,20 +36,32 @@ export function initRestorePanel(): void {
   };
   const orch = new RestoreOrchestrator(io);
 
+  // Both buttons derive from connection state AND who holds the reader, so an
+  // archive write in progress greys out Scan instead of letting a second loop
+  // contend for taps. Driven by the lock's change notification, which fires
+  // synchronously on acquire and release.
+  const syncButtons = (): void => {
+    const owner = readerLock.current();
+    const scan = $('scan') as HTMLButtonElement;
+    scan.disabled = !isConnected() || owner !== null;
+    scan.title = owner !== null && owner !== 'scan' ? t.readerBusyElsewhere : '';
+    ($('stop-scan') as HTMLButtonElement).disabled = owner !== 'scan';
+  };
   onConnectionChange((connected) => {
-    ($('scan') as HTMLButtonElement).disabled = !connected;
+    syncButtons();
     if (connected) setStatus(t.restoreReady);
   });
+  readerLock.onChange(syncButtons);
 
   $('scan').addEventListener('click', async () => {
     const transport = currentTransport();
     if (!transport) return;
+    // Refused if an archive (or an inspection) already owns the reader. The
+    // button is disabled in that case, so this is the belt to that braces.
+    if (!readerLock.acquire('scan')) return;
     orch.startSession(transport);
     scanAbort = new AbortController();
-    ($('scan') as HTMLButtonElement).disabled = true;
-    ($('stop-scan') as HTMLButtonElement).disabled = false;
     setStatus(t.scanning);
-    setReaderBusy(true);
     log.info('scan', 'Scan started');
     const breaker = new FailureBreaker();
     try {
@@ -89,9 +105,7 @@ export function initRestorePanel(): void {
         }
       }
     } finally {
-      setReaderBusy(false);
-      ($('stop-scan') as HTMLButtonElement).disabled = true;
-      ($('scan') as HTMLButtonElement).disabled = false;
+      readerLock.release('scan');
       log.info('scan', 'Scan stopped');
     }
   });

--- a/webapp/app/ui/restore-panel.ts
+++ b/webapp/app/ui/restore-panel.ts
@@ -7,7 +7,7 @@ import { filesController } from './files-panel.js';
 import { humanError } from './errors.js';
 import { mimeForFilename } from '../download-mime.js';
 import { log } from '../../src/log/logger.js';
-import { t } from '../i18n/index.js';
+import { t, onLocaleChange } from '../i18n/index.js';
 import { ensureMinInterval, FailureBreaker } from '../../src/loop-guards.js';
 
 const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
@@ -52,6 +52,11 @@ export function initRestorePanel(): void {
     if (connected) setStatus(t.restoreReady);
   });
   readerLock.onChange(syncButtons);
+  // The title is set from `t`, not from data-i18n markup, so applyStaticText()
+  // never rewrites it — re-derive it here or a language switch mid-scan leaves
+  // the tooltip in the old language. device.ts:onLocaleChange does the same for
+  // its own inspectNeedsChameleon title.
+  onLocaleChange(syncButtons);
 
   $('scan').addEventListener('click', async () => {
     const transport = currentTransport();

--- a/webapp/test/download-mime.test.ts
+++ b/webapp/test/download-mime.test.ts
@@ -1,0 +1,44 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mimeForFilename } from '../app/download-mime.js';
+
+test('text files carry an explicit UTF-8 charset', () => {
+  // The reported defect: a restored Cyrillic .txt downloaded as an untyped
+  // Blob arrives as application/octet-stream, so the Android viewer has no
+  // charset to work from, guesses, and mojibakes every non-ASCII byte. The
+  // bytes on disk are already correct — this only tells the viewer how to
+  // decode them.
+  assert.equal(mimeForFilename('text_note.txt'), 'text/plain;charset=utf-8');
+  assert.equal(mimeForFilename('notes.md'), 'text/markdown;charset=utf-8');
+  assert.equal(mimeForFilename('rows.csv'), 'text/csv;charset=utf-8');
+});
+
+test('extensions are matched case-insensitively', () => {
+  assert.equal(mimeForFilename('NOTE.TXT'), 'text/plain;charset=utf-8');
+});
+
+test('binary formats get their type without a charset', () => {
+  // charset is meaningless on a binary type, and JSON is defined as UTF-8 by
+  // RFC 8259 — it has no charset parameter at all.
+  assert.equal(mimeForFilename('photo.png'), 'image/png');
+  assert.equal(mimeForFilename('doc.pdf'), 'application/pdf');
+  assert.equal(mimeForFilename('data.json'), 'application/json');
+});
+
+test('the last extension wins on a multi-part name', () => {
+  assert.equal(mimeForFilename('archive.tar.gz'), 'application/gzip');
+});
+
+test('unknown and extensionless names fall back to octet-stream', () => {
+  assert.equal(mimeForFilename('payload.zzz'), 'application/octet-stream');
+  assert.equal(mimeForFilename('README'), 'application/octet-stream');
+});
+
+test('a leading dot is not an extension', () => {
+  // '.bashrc'.lastIndexOf('.') === 0 — the name IS the dotfile, not a suffix.
+  assert.equal(mimeForFilename('.bashrc'), 'application/octet-stream');
+});
+
+test('a trailing dot yields no extension', () => {
+  assert.equal(mimeForFilename('weird.'), 'application/octet-stream');
+});

--- a/webapp/test/reader-lock.test.ts
+++ b/webapp/test/reader-lock.test.ts
@@ -1,0 +1,76 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { ReaderLock } from '../app/ui/reader-lock.js';
+
+test('a free lock can be acquired and reports its owner', () => {
+  const lock = new ReaderLock();
+  assert.equal(lock.current(), null);
+  assert.equal(lock.acquire('scan'), true);
+  assert.equal(lock.current(), 'scan');
+});
+
+test('a second subsystem cannot acquire a held lock', () => {
+  // The production defect: the scan loop holds BrowserNdefIO's single waiter
+  // slot, and starting an archive on top of it made every tap fail with
+  // "Already waiting for a reading" until the breaker discarded the archive.
+  const lock = new ReaderLock();
+  lock.acquire('scan');
+  assert.equal(lock.acquire('archive'), false);
+  assert.equal(lock.current(), 'scan', 'a refused acquire must not steal ownership');
+});
+
+test('re-acquiring while already the owner is refused', () => {
+  // No caller needs re-entrancy, and allowing it would let one release()
+  // free a lock that two call sites believe they hold.
+  const lock = new ReaderLock();
+  lock.acquire('scan');
+  assert.equal(lock.acquire('scan'), false);
+});
+
+test('the owner can release, freeing the lock', () => {
+  const lock = new ReaderLock();
+  lock.acquire('archive');
+  lock.release('archive');
+  assert.equal(lock.current(), null);
+  assert.equal(lock.acquire('scan'), true);
+});
+
+test('release by a non-owner is a no-op', () => {
+  // The second production defect: readerBusy was a plain boolean written by
+  // scan, archive and inspect alike, so whichever finished FIRST cleared it
+  // for the others. Observed live — the archive loop's finally re-enabled
+  // Disconnect while the scan loop was still running.
+  const lock = new ReaderLock();
+  lock.acquire('scan');
+  lock.release('archive');
+  assert.equal(lock.current(), 'scan', 'only the owner may release');
+});
+
+test('listeners see every ownership change', () => {
+  const lock = new ReaderLock();
+  const seen: Array<string | null> = [];
+  lock.onChange((owner) => seen.push(owner));
+  lock.acquire('scan');
+  lock.release('scan');
+  assert.deepEqual(seen, ['scan', null]);
+});
+
+test('a refused acquire notifies nobody', () => {
+  const lock = new ReaderLock();
+  lock.acquire('scan');
+  const seen: Array<string | null> = [];
+  lock.onChange((owner) => seen.push(owner));
+  lock.acquire('archive');
+  lock.release('archive');
+  assert.deepEqual(seen, [], 'no state changed, so no notification');
+});
+
+test('unsubscribing stops notifications', () => {
+  const lock = new ReaderLock();
+  const seen: Array<string | null> = [];
+  const off = lock.onChange((owner) => seen.push(owner));
+  lock.acquire('scan');
+  off();
+  lock.release('scan');
+  assert.deepEqual(seen, ['scan']);
+});


### PR DESCRIPTION
Two defects reported from the same hardware session on 2026-07-31, the first
successful end-to-end run of Web NFC on a real phone.

## 1. `Error: Already waiting for a reading` during an archive write

A restore scan started at 12:53:01 was never stopped. At 12:54:36 an archive
of 16 cards was started on top of it, and every card failed:

```
12:53:01.582  [scan] Scan started            ← still running
12:54:36.574  [archive] Prepared {"cards":16}
12:54:36.827  failed ┐
12:54:37.081  failed │ 254 ms
12:54:37.339  failed │ 258 ms   ← ensureMinInterval(250)
12:54:37.596  failed │ 257 ms
12:54:37.854  Stopped after repeated failures ← FailureBreaker at 5
12:54:49.338  [scan] Detection {"archives":2} ← scan loop still eating taps
```

**Root cause.** The scan loop held `BrowserNdefIO`'s single waiter slot, so
the archive loop's `awaitReading()` hit the guard at `browser-ndef-io.ts:129`
on every tap. That guard is correct. What was wrong is the premise recorded
in the design spec for #52:

> Only one waiter exists at a time. A second concurrent `awaitReading()` is a
> programming error — **the app never does this.**

The app does exactly this, and nothing prevented it. `restore-panel` disabled
the *Scan* button while scanning and `archive-panel` disabled the *Archive*
button while archiving, but neither disabled the other. `setReaderBusy` looked
like the interlock but only ever gated **Inspect** and **Disconnect**.

**This is not a Web NFC bug.** Two loops calling `awaitTag()` on one reader is
equally wrong over a Chameleon — there they simply race for tags, silently.
Web NFC's single-waiter invariant is what turned a silent race into a
diagnosable error.

**Fix.** `app/ui/reader-lock.ts` holds one owner (`scan` | `archive` |
`inspect`). Both panels acquire it and derive their buttons from it, so each
greys the other out with a tooltip saying why.

A second, related defect fixed in passing: `readerBusy` was a plain boolean
written by all three subsystems, so whichever finished *first* cleared it for
the others. Confirmed live — the archive loop's `finally` re-enabled Disconnect
while the scan loop was still running. `release()` is now owner-checked.

### Disconnect is deliberately no longer gated

The old boolean was *intended* to disable Disconnect while busy. Restoring
that faithfully would have been a mistake: the archive loop has **no Stop
control at all** (`archive-orchestrator.ts:102` notes this), so gating
Disconnect leaves a wedged write with no way out — and pressing Disconnect is
precisely how the reported incident was escaped. Both loops handle a
mid-flight teardown cleanly (`usable()` in the archive loop; `stop()` rejecting
the pending waiter with `AbortError`), so this is safe rather than tolerated.

## 2. Garbled Cyrillic in a restored text file

The bytes were never wrong — the same archive restores correctly in the
Android app, and both paths are plain UTF-8. But `restore-panel` and
`files-panel` both built `new Blob([data])` with **no MIME type**, so the
download arrives as `application/octet-stream` and Android's viewer has no
charset to work from. It guesses, which mojibakes Cyrillic while leaving ASCII
looking perfect.

`app/download-mime.ts` resolves the type from the filename and appends
`;charset=utf-8` for text formats. This is the browser-side twin of the
`share_plus` MIME rule already documented in CLAUDE.md for the Flutter app,
which has the same root cause in Android's `ContentResolver`.

Honest scope: this is a probable contributor, not a proven cure — a viewer may
garble it regardless. It is correct either way, and changes no bytes on disk.

## Testing

289 tests pass (274 + 15 new), `npm run build:site` clean. New tests cover the
lock's refusal, owner-checked release, and notification semantics, plus MIME
resolution including dotfiles, trailing dots, and multi-part extensions.

Not verified on hardware. The concurrency fix is reachable by simply starting
an archive while a scan runs; the MIME change needs a phone to judge.

Adds `readerBusyElsewhere` to all seven locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)