### PR TITLE
feat(inspect): card inspector UI, proven on hardware

### DIFF
--- a/lib/core/chameleon/ble_chameleon_device.dart
+++ b/lib/core/chameleon/ble_chameleon_device.dart
@@ -211,9 +211,14 @@ class BleChameleonDevice implements ChameleonDevice {
     Duration timeout = const Duration(seconds: 5),
     Set<int> alsoAllow = const {},
   }) async {
-    if (!_connected && cmd != ChameleonCmd.changeDeviceMode &&
-        cmd != ChameleonCmd.getAppVersion) {
-      throw const CardReadException('Not connected to a Chameleon');
+    // Keyed on the notification subscription, not on _connected: writing a
+    // command while nothing is listening produces a five-second timeout on a
+    // reply that actually arrived — and did, on hardware. connect() subscribes
+    // before it sends anything, so its own commands still pass.
+    if (_notifySub == null) {
+      throw const CardReadException(
+        'Not listening to this Chameleon — connect() was never called on this instance',
+      );
     }
     if (_pending != null) {
       throw StateError('A Chameleon command is already in flight');

--- a/lib/features/inspect/data/report_share.dart
+++ b/lib/features/inspect/data/report_share.dart
@@ -1,0 +1,34 @@
+import 'dart:io';
+
+import 'package:mime/mime.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+
+/// Write the inspection report to a shareable text file.
+///
+/// The filename carries the card UID so two dumps in one session do not
+/// collide, and so a shared file is identifiable once it has left the app.
+Future<File> writeReportFile(
+  String report, {
+  Directory? dir,
+  String uid = 'card',
+}) async {
+  final target = dir ?? await getTemporaryDirectory();
+  final file = File(p.join(target.path, 'nfar-inspect-$uid.txt'));
+  await file.writeAsString(report);
+  return file;
+}
+
+/// Share the report as a typed text file.
+///
+/// **The MIME type is explicit and must stay so.** Per CLAUDE.md, without it
+/// Android's ContentResolver reports application/octet-stream and strict
+/// receivers (Telegram among them) refuse to send — the same class of bug as
+/// the untyped Blob that garbled restored text in the web app.
+Future<void> shareReport(String report, {String uid = 'card'}) async {
+  final file = await writeReportFile(report, uid: uid);
+  await Share.shareXFiles([
+    XFile(file.path, mimeType: lookupMimeType(file.path) ?? 'text/plain'),
+  ]);
+}

--- a/lib/features/inspect/domain/inspect_sink.dart
+++ b/lib/features/inspect/domain/inspect_sink.dart
@@ -17,3 +17,37 @@ abstract class InspectSink {
   void setReport(String text);
   void setStatus(String text);
 }
+
+/// The chrome strings [runInspection] emits.
+///
+/// Passed in rather than looked up, so the domain layer stays free of Flutter
+/// and of AppLocalizations while the status line is still translated. The
+/// REPORT body deliberately stays English — it is diagnostic output meant to
+/// be pasted into a bug report, where a translated hex dump helps nobody.
+class InspectStrings {
+  const InspectStrings({
+    required this.holdStill,
+    required this.done,
+    required this.stopped,
+    required this.cardLost,
+    required this.reading,
+    required this.read,
+  });
+
+  final String holdStill;
+  final String done;
+  final String stopped;
+  final String cardLost;
+  final String Function(int done, int total) reading;
+  final String Function(int done, int total) read;
+
+  /// English fallback, for tests and for any call site without a context.
+  static InspectStrings english() => InspectStrings(
+        holdStill: 'Hold the card still on the reader…',
+        done: 'Inspection complete.',
+        stopped: 'Stopped.',
+        cardLost: 'Card left the field — partial dump.',
+        reading: (d, t) => 'Reading $d of $t…',
+        read: (d, t) => 'Read $d of $t',
+      );
+}

--- a/lib/features/inspect/domain/inspect_sink.dart
+++ b/lib/features/inspect/domain/inspect_sink.dart
@@ -1,0 +1,19 @@
+/// How [runInspection] reports progress.
+///
+/// Six methods, mirroring the web app's `InspectIO`, so the orchestration is
+/// testable with no widget and no DOM stub.
+///
+/// Callbacks rather than a `Stream<InspectEvent>` on purpose. A stream is the
+/// more idiomatic Dart shape, but it would diverge both from the TypeScript
+/// this is ported from and from this app's own convention — every NFC session
+/// is already driven through `onTagDiscovered` / `onChunkRead` / `onError`.
+/// `InspectNotifier` implements this and exposes Riverpod state, so the
+/// idiomatic surface exists one layer up, where Flutter actually wants it.
+abstract class InspectSink {
+  void setIdentity(String text);
+  void setNfar(String text);
+  void appendRow(String line);
+  void setProgress(String text);
+  void setReport(String text);
+  void setStatus(String text);
+}

--- a/lib/features/inspect/domain/run_inspection.dart
+++ b/lib/features/inspect/domain/run_inspection.dart
@@ -17,8 +17,10 @@ Future<void> runInspection(
   ChameleonDevice dev,
   InspectSink sink, {
   CancellationToken? token,
+  InspectStrings? strings,
 }) async {
-  sink.setStatus('Hold the card still on the reader…');
+  final s = strings ?? InspectStrings.english();
+  sink.setStatus(s.holdStill);
 
   // Advisory only. readBlock performs its own select, so a card that refuses
   // anticollision can still be dumped in full — a failure here must not stop
@@ -45,7 +47,7 @@ Future<void> runInspection(
           seen.add(unit);
           sink.appendRow(formatUnitRow(unit));
           sink.setProgress(
-            done == total ? 'Read $done of $total' : 'Reading $done of $total…',
+            done == total ? s.read(done, total) : s.reading(done, total),
           );
 
           // Re-describe only while the chunk is still incomplete; once the
@@ -79,10 +81,10 @@ Future<void> runInspection(
     );
     sink.setStatus(
       result.aborted
-          ? 'Stopped.'
+          ? s.stopped
           : result.cardLost
-              ? 'Card left the field — partial dump.'
-              : 'Inspection complete.',
+              ? s.cardLost
+              : s.done,
     );
     log.info('inspect', 'Inspection finished', {
       'units': result.units.length,

--- a/lib/features/inspect/domain/run_inspection.dart
+++ b/lib/features/inspect/domain/run_inspection.dart
@@ -1,0 +1,114 @@
+import '../../../core/chameleon/cancellation_token.dart';
+import '../../../core/chameleon/chameleon_device.dart';
+import '../../../core/inspect/card_dump.dart';
+import '../../../core/inspect/diagnose_card.dart';
+import '../../../core/inspect/hex_view.dart';
+import '../../../core/inspect/nfar_describe.dart';
+import '../../../core/inspect/nfar_source.dart';
+import '../../../core/log/logger.dart';
+import '../../../core/mifare/card_layout.dart';
+import 'inspect_sink.dart';
+
+/// Dump the presented card and report it through [sink].
+///
+/// Port of `runInspection` in `webapp/app/ui/inspect-orchestrator.ts`.
+/// Read-only throughout: nothing here writes to a card.
+Future<void> runInspection(
+  ChameleonDevice dev,
+  InspectSink sink, {
+  CancellationToken? token,
+}) async {
+  sink.setStatus('Hold the card still on the reader…');
+
+  // Advisory only. readBlock performs its own select, so a card that refuses
+  // anticollision can still be dumped in full — a failure here must not stop
+  // anything.
+  CardDiagnosis? diag;
+  try {
+    diag = await diagnoseCard(dev);
+  } catch (e) {
+    log.debug('inspect', 'Anticollision failed — continuing', {'error': '$e'});
+    diag = null;
+  }
+
+  NfarDescription nfar = const NfarAbsent('no data read yet');
+  final seen = <DumpUnit>[];
+
+  try {
+    final result = await dumpCard(
+      dev,
+      DumpCallbacks(
+        // Before the first read, so identity is on screen in about a second
+        // rather than after ~64 BLE round trips.
+        onMeta: (meta) => sink.setIdentity(formatIdentity(meta, _toDiag(diag))),
+        onUnit: (unit, done, total) {
+          seen.add(unit);
+          sink.appendRow(formatUnitRow(unit));
+          sink.setProgress(
+            done == total ? 'Read $done of $total' : 'Reading $done of $total…',
+          );
+
+          // Re-describe only while the chunk is still incomplete; once the
+          // declared tail is covered the description stops changing.
+          if (nfar is NfarAbsent || (nfar as NfarPresent).crcValid == null) {
+            final isClassic = unit.sector != null;
+            final src = nfarBytesSoFar(seen, isClassic: isClassic);
+            nfar = switch (src) {
+              // Mifare Classic has a fixed known capacity, so a declared
+              // length past it is worth flagging. On NTAG the chunk arrives
+              // inside an NDEF envelope whose own TLV length already bounds
+              // it, so no capacity is guessed.
+              SourceBytes(:final bytes) => describeNfar(
+                  bytes,
+                  capacityBytes: isClassic ? cardCapacityBytes : null,
+                ),
+              SourceNoEnvelope(:final reason) => NfarAbsent(reason),
+              SourceForeign(:final reason) => NfarAbsent(reason),
+              SourceUnreadable(:final reason) => NfarAbsent(reason),
+            };
+            sink.setNfar(formatNfar(nfar));
+          }
+        },
+      ),
+      token: token,
+    );
+
+    sink.setNfar(formatNfar(nfar));
+    sink.setReport(
+      formatReport(result.meta, _toDiag(diag), nfar, result.units),
+    );
+    sink.setStatus(
+      result.aborted
+          ? 'Stopped.'
+          : result.cardLost
+              ? 'Card left the field — partial dump.'
+              : 'Inspection complete.',
+    );
+    log.info('inspect', 'Inspection finished', {
+      'units': result.units.length,
+      'aborted': result.aborted,
+      'cardLost': result.cardLost,
+    });
+  } on UnsupportedTagException catch (e) {
+    // Kept verbatim: this message names the SAK, and for an inspector that
+    // value IS the result. A generic string would discard the finding.
+    sink.setStatus(e.message);
+    log.warn('inspect', 'Unsupported tag', {'why': e.message});
+  } catch (e) {
+    sink.setStatus('$e');
+    log.error('inspect', 'Inspection failed', {'error': '$e'});
+  }
+}
+
+/// [CardDiagnosis] satisfies [IdentityDiagnosis] field for field; the formatter
+/// declares its own type so it stays independent of how identity was obtained.
+IdentityDiagnosis? _toDiag(CardDiagnosis? d) => d == null
+    ? null
+    : IdentityDiagnosis(
+        atqa: d.atqa,
+        uidCl1: d.uidCl1,
+        bccReturned: d.bccReturned,
+        bccComputed: d.bccComputed,
+        bccValid: d.bccValid,
+        isCascade: d.isCascade,
+      );

--- a/lib/features/inspect/presentation/providers/inspect_provider.dart
+++ b/lib/features/inspect/presentation/providers/inspect_provider.dart
@@ -1,0 +1,137 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/chameleon/cancellation_token.dart';
+import '../../../../core/chameleon/chameleon_device.dart';
+import '../../domain/inspect_sink.dart';
+import '../../domain/run_inspection.dart';
+
+class InspectState {
+  const InspectState({
+    this.rows = const [],
+    this.identity,
+    this.nfar,
+    this.progress,
+    this.report,
+    this.status,
+    this.isRunning = false,
+  });
+
+  final List<String> rows;
+  final String? identity;
+  final String? nfar;
+  final String? progress;
+  final String? report;
+  final String? status;
+  final bool isRunning;
+
+  InspectState copyWith({
+    List<String>? rows,
+    String? identity,
+    String? nfar,
+    String? progress,
+    String? report,
+    String? status,
+    bool? isRunning,
+  }) =>
+      InspectState(
+        rows: rows ?? this.rows,
+        identity: identity ?? this.identity,
+        nfar: nfar ?? this.nfar,
+        progress: progress ?? this.progress,
+        report: report ?? this.report,
+        status: status ?? this.status,
+        isRunning: isRunning ?? this.isRunning,
+      );
+}
+
+/// Drives an inspection and exposes it as Riverpod state.
+///
+/// **Superseded runs may only touch state they still own.** When a second
+/// inspection starts while the first is still draining, the first one's
+/// already-scheduled callbacks must not scribble into the second one's state.
+/// The web app hit exactly this and fixed it in commit `67c4683`.
+///
+/// The guard therefore lives in a per-run sink that closes over *its own*
+/// token — not in a check against a field, which a stale run would read as
+/// current and sail straight through. A guard placed only at the entry point
+/// cannot help either: by then the damaging callbacks are already queued.
+class InspectNotifier extends StateNotifier<InspectState> {
+  InspectNotifier() : super(const InspectState());
+
+  CancellationToken? _token;
+
+  /// True only for the run that currently owns the state.
+  bool _owns(CancellationToken t) => identical(t, _token);
+
+  Future<void> start(ChameleonDevice dev) async {
+    _token?.cancel();
+    final token = CancellationToken();
+    _token = token;
+
+    state = const InspectState(isRunning: true);
+    await runInspection(dev, _OwnedSink(this, token), token: token);
+
+    // Only the owning run may declare the inspection finished; a stale run
+    // reaching here must leave the newer one's isRunning alone.
+    if (_owns(token)) state = state.copyWith(isRunning: false);
+  }
+
+  void cancel() {
+    _token?.cancel();
+    if (state.isRunning) state = state.copyWith(isRunning: false);
+  }
+
+  // Mutations, applied only via _OwnedSink so ownership is always checked.
+  void _setIdentity(String t) => state = state.copyWith(identity: t);
+  void _setNfar(String t) => state = state.copyWith(nfar: t);
+  void _setProgress(String t) => state = state.copyWith(progress: t);
+  void _setReport(String t) => state = state.copyWith(report: t);
+  void _setStatus(String t) => state = state.copyWith(status: t);
+  void _appendRow(String line) =>
+      state = state.copyWith(rows: [...state.rows, line]);
+}
+
+/// A sink bound to one run. Every method drops its call once superseded.
+class _OwnedSink implements InspectSink {
+  _OwnedSink(this._n, this._token);
+
+  final InspectNotifier _n;
+  final CancellationToken _token;
+
+  bool get _live => _n._owns(_token);
+
+  @override
+  void setIdentity(String text) {
+    if (_live) _n._setIdentity(text);
+  }
+
+  @override
+  void setNfar(String text) {
+    if (_live) _n._setNfar(text);
+  }
+
+  @override
+  void appendRow(String line) {
+    if (_live) _n._appendRow(line);
+  }
+
+  @override
+  void setProgress(String text) {
+    if (_live) _n._setProgress(text);
+  }
+
+  @override
+  void setReport(String text) {
+    if (_live) _n._setReport(text);
+  }
+
+  @override
+  void setStatus(String text) {
+    if (_live) _n._setStatus(text);
+  }
+}
+
+final inspectProvider =
+    StateNotifierProvider<InspectNotifier, InspectState>((ref) {
+  return InspectNotifier();
+});

--- a/lib/features/inspect/presentation/providers/inspect_provider.dart
+++ b/lib/features/inspect/presentation/providers/inspect_provider.dart
@@ -63,13 +63,14 @@ class InspectNotifier extends StateNotifier<InspectState> {
   /// True only for the run that currently owns the state.
   bool _owns(CancellationToken t) => identical(t, _token);
 
-  Future<void> start(ChameleonDevice dev) async {
+  Future<void> start(ChameleonDevice dev, {InspectStrings? strings}) async {
     _token?.cancel();
     final token = CancellationToken();
     _token = token;
 
     state = const InspectState(isRunning: true);
-    await runInspection(dev, _OwnedSink(this, token), token: token);
+    await runInspection(dev, _OwnedSink(this, token),
+        token: token, strings: strings);
 
     // Only the owning run may declare the inspection finished; a stale run
     // reaching here must leave the newer one's isRunning alone.

--- a/lib/features/inspect/presentation/screens/inspect_dialog.dart
+++ b/lib/features/inspect/presentation/screens/inspect_dialog.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/chameleon/chameleon_device.dart';
+import '../../data/report_share.dart';
+import '../../domain/inspect_sink.dart';
+import '../providers/inspect_provider.dart';
+
+/// Read-only dump of the presented card: identity, decoded NFAR header with
+/// CRC verification, and raw hex/ASCII per block or page.
+///
+/// Never writes. Sector trailers are displayed, never modified.
+class InspectDialog extends ConsumerStatefulWidget {
+  const InspectDialog({super.key, required this.device, this.uid = 'card'});
+
+  final ChameleonDevice device;
+
+  /// Used in the shared filename so two dumps do not collide.
+  final String uid;
+
+  @override
+  ConsumerState<InspectDialog> createState() => _InspectDialogState();
+}
+
+class _InspectDialogState extends ConsumerState<InspectDialog> {
+  @override
+  void initState() {
+    super.initState();
+    // After the first frame, so AppLocalizations is available for the status
+    // strings the run emits.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final l10n = AppLocalizations.of(context)!;
+      ref.read(inspectProvider.notifier).start(
+            widget.device,
+            strings: InspectStrings(
+              holdStill: l10n.inspectHoldStill,
+              done: l10n.inspectDone,
+              stopped: l10n.inspectStopped,
+              cardLost: l10n.inspectCardLost,
+              reading: l10n.inspectReading,
+              read: l10n.inspectRead,
+            ),
+          );
+    });
+  }
+
+  void _close() {
+    // Cancel BEFORE popping: a dialog dismissed mid-dump must not leave a run
+    // polling the reader.
+    ref.read(inspectProvider.notifier).cancel();
+    if (Navigator.of(context).canPop()) Navigator.of(context).pop();
+  }
+
+  Future<void> _copy(String report, String confirmation) async {
+    await Clipboard.setData(ClipboardData(text: report));
+    if (!mounted) return;
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(confirmation)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final s = ref.watch(inspectProvider);
+    final mono = TextStyle(
+      fontFamily: 'monospace',
+      fontSize: 11,
+      color: Theme.of(context).colorScheme.onSurface,
+    );
+
+    return PopScope(
+      canPop: false,
+      // The hardware back button must take the same path as Close, or it
+      // leaves the run alive behind a dismissed dialog.
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop) _close();
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(l10n.inspectTitle),
+          leading: IconButton(
+            icon: const Icon(Icons.close),
+            onPressed: _close,
+          ),
+          actions: [
+            IconButton(
+              tooltip: l10n.inspectCopy,
+              icon: const Icon(Icons.copy),
+              onPressed: s.report == null
+                  ? null
+                  : () => _copy(s.report!, l10n.inspectCopied),
+            ),
+          ],
+        ),
+        body: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (s.isRunning) const LinearProgressIndicator(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+              child: Text(
+                s.progress ?? s.status ?? '',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ),
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                children: [
+                  _Section(title: l10n.inspectIdentity, body: s.identity, style: mono),
+                  _Section(title: l10n.inspectNfar, body: s.nfar, style: mono),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 16, bottom: 4),
+                    child: Text(
+                      l10n.inspectRaw,
+                      style: Theme.of(context).textTheme.titleSmall,
+                    ),
+                  ),
+                  // Built lazily: 64 rows is fine, but the widget must not
+                  // assume the list stays small.
+                  ListView.builder(
+                    shrinkWrap: true,
+                    physics: const NeverScrollableScrollPhysics(),
+                    itemCount: s.rows.length,
+                    itemBuilder: (_, i) => SelectableText(s.rows[i], style: mono),
+                  ),
+                  const SizedBox(height: 24),
+                ],
+              ),
+            ),
+            SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    TextButton(
+                      onPressed: s.report == null
+                          ? null
+                          : () => _copy(s.report!, l10n.inspectCopied),
+                      child: Text(l10n.inspectCopy),
+                    ),
+                    const SizedBox(width: 8),
+                    TextButton(
+                      onPressed: s.report == null
+                          ? null
+                          : () => shareReport(s.report!, uid: widget.uid),
+                      child: Text(l10n.inspectShare),
+                    ),
+                    const SizedBox(width: 8),
+                    TextButton(onPressed: _close, child: Text(l10n.inspectClose)),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Section extends StatelessWidget {
+  const _Section({required this.title, required this.body, required this.style});
+
+  final String title;
+  final String? body;
+  final TextStyle style;
+
+  @override
+  Widget build(BuildContext context) {
+    if (body == null) return const SizedBox.shrink();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(top: 16, bottom: 4),
+          child: Text(title, style: Theme.of(context).textTheme.titleSmall),
+        ),
+        // Selectable so a user can grab part of a dump without using Copy.
+        SelectableText(body!, style: style),
+      ],
+    );
+  }
+}

--- a/lib/features/nfc/data/chameleon_reader.dart
+++ b/lib/features/nfc/data/chameleon_reader.dart
@@ -65,6 +65,11 @@ class ChameleonReader implements CardReader {
   @override
   bool get supportsRawAccess => true;
 
+  /// The SAME instance every card operation uses — see CardReader.rawDevice
+  /// for why constructing a second one silently breaks.
+  @override
+  ChameleonDevice? get rawDevice => _device;
+
   @override
   bool get isInWriteCooldown {
     final at = _lastWriteAt;

--- a/lib/features/nfc/data/phone_nfc_reader.dart
+++ b/lib/features/nfc/data/phone_nfc_reader.dart
@@ -1,6 +1,7 @@
 import '../../../core/constants/nfar_format.dart';
 import '../../../core/models/chunk.dart';
 import '../../../core/models/nfc_tag_info.dart';
+import '../../../core/chameleon/chameleon_device.dart';
 import '../domain/card_reader.dart';
 import 'nfc_repository.dart';
 
@@ -25,6 +26,9 @@ class PhoneNfcReader implements CardReader {
   /// platform, not a deferred feature.
   @override
   bool get supportsRawAccess => false;
+
+  @override
+  ChameleonDevice? get rawDevice => null;
 
   @override
   bool get isInWriteCooldown => _repository.isInWriteCooldown;

--- a/lib/features/nfc/domain/card_reader.dart
+++ b/lib/features/nfc/domain/card_reader.dart
@@ -1,6 +1,7 @@
 import '../../../core/constants/nfar_format.dart';
 import '../../../core/models/chunk.dart';
 import '../../../core/models/nfc_tag_info.dart';
+import '../../../core/chameleon/chameleon_device.dart';
 import '../data/nfc_repository.dart';
 
 /// A source of card reads and writes.
@@ -24,6 +25,19 @@ abstract class CardReader {
   /// stack exposes no raw anticollision or arbitrary block access, so this is a
   /// permanent property of the medium, not a missing feature.
   bool get supportsRawAccess;
+
+  /// The live device behind this reader, or null when it has none.
+  ///
+  /// Returned rather than reconstructed by callers: a second
+  /// [ChameleonDevice] for the same physical reader has its own pending-command
+  /// slot and its own notification subscription, so it writes commands nobody
+  /// is listening for and waits for replies the FIRST instance silently drops.
+  /// Observed on hardware — every inspection timed out while the log showed
+  /// 'Dropped unmatched frame awaiting=null'.
+  ///
+  /// Non-null exactly when [supportsRawAccess] is true, so the flag and the
+  /// thing it gates come from the same object.
+  ChameleonDevice? get rawDevice;
 
   bool get isInWriteCooldown;
 

--- a/lib/features/nfc/presentation/screens/reader_picker_screen.dart
+++ b/lib/features/nfc/presentation/screens/reader_picker_screen.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../../core/chameleon/ble_chameleon_device.dart';
 import '../../../inspect/presentation/screens/inspect_dialog.dart';
 import '../../data/ble_scanner.dart';
 import '../providers/reader_provider.dart';
@@ -194,17 +193,23 @@ class _ReaderPickerScreenState extends ConsumerState<ReaderPickerScreen> {
                 ? ''
                 : l10n.inspectNeedsChameleon,
             child: OutlinedButton.icon(
-              onPressed: reader.reader.supportsRawAccess && reader.deviceId != null
-                  ? () => Navigator.of(context).push(
+              onPressed: reader.reader.rawDevice == null
+                  ? null
+                  : () {
+                      // The reader's OWN device, never a fresh one: a second
+                      // instance is not subscribed to notifications and every
+                      // command it sends times out.
+                      final dev = reader.reader.rawDevice!;
+                      reader.reader.stopSession();
+                      Navigator.of(context).push(
                         MaterialPageRoute<void>(
                           builder: (_) => InspectDialog(
-                            device:
-                                BleChameleonDevice(deviceId: reader.deviceId!),
-                            uid: reader.deviceId!.replaceAll(':', ''),
+                            device: dev,
+                            uid: (reader.deviceId ?? 'card').replaceAll(':', ''),
                           ),
                         ),
-                      )
-                  : null,
+                      );
+                    },
               icon: const Icon(Icons.travel_explore),
               label: Text(l10n.inspectTitle),
             ),

--- a/lib/features/nfc/presentation/screens/reader_picker_screen.dart
+++ b/lib/features/nfc/presentation/screens/reader_picker_screen.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/chameleon/ble_chameleon_device.dart';
+import '../../../inspect/presentation/screens/inspect_dialog.dart';
 import '../../data/ble_scanner.dart';
 import '../providers/reader_provider.dart';
 
@@ -181,6 +183,30 @@ class _ReaderPickerScreenState extends ConsumerState<ReaderPickerScreen> {
                     onTap: _connecting ? null : () => _connect(d),
                   ),
               ],
+            ),
+          ),
+          const SizedBox(height: 16),
+          // Visible but DISABLED under phone NFC, never hidden: a silently
+          // absent control teaches the user nothing, whereas a disabled one
+          // with a reason explains a permanent platform limit.
+          Tooltip(
+            message: reader.reader.supportsRawAccess
+                ? ''
+                : l10n.inspectNeedsChameleon,
+            child: OutlinedButton.icon(
+              onPressed: reader.reader.supportsRawAccess && reader.deviceId != null
+                  ? () => Navigator.of(context).push(
+                        MaterialPageRoute<void>(
+                          builder: (_) => InspectDialog(
+                            device:
+                                BleChameleonDevice(deviceId: reader.deviceId!),
+                            uid: reader.deviceId!.replaceAll(':', ''),
+                          ),
+                        ),
+                      )
+                  : null,
+              icon: const Icon(Icons.travel_explore),
+              label: Text(l10n.inspectTitle),
             ),
           ),
           if (reader.kind == ReaderKind.chameleon) ...[

--- a/lib/l10n/app_be.arb
+++ b/lib/l10n/app_be.arb
@@ -164,5 +164,20 @@
   "readerConnectFailed": "Не ўдалося падключыцца да Chameleon.",
   "readerPhoneSubtitle": "Выкарыстоўвае ўласны NFC тэлефона",
   "readerChameleonSubtitle": "Дадае Mifare Classic і агляд карты праз Bluetooth",
-  "readerSearch": "Знайсці"
+  "readerSearch": "Знайсці",
+  "inspectTitle": "Агляд карты",
+  "inspectIdentity": "Ідэнтыфікацыя",
+  "inspectNfar": "Фрагмент NFAR",
+  "inspectRaw": "Сырыя даныя",
+  "inspectHoldStill": "Трымайце карту нерухома на счытвальніку…",
+  "inspectDone": "Агляд завершаны.",
+  "inspectStopped": "Спынена.",
+  "inspectCardLost": "Карта прыбрана — частковы дамп.",
+  "inspectCopy": "Капіяваць",
+  "inspectCopied": "Справаздача скапіявана.",
+  "inspectShare": "Падзяліцца",
+  "inspectClose": "Закрыць",
+  "inspectNeedsChameleon": "Для агляду карты патрэбны Chameleon — NFC тэлефона не мае прамога доступу да карты.",
+  "inspectReading": "Чытанне {done} з {total}…",
+  "inspectRead": "Прачытана {done} з {total}"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -805,5 +805,85 @@
   "readerSearch": "Search",
   "@readerSearch": {
     "description": "Button that starts a Bluetooth scan"
+  },
+  "inspectTitle": "Inspect card",
+  "@inspectTitle": {
+    "description": "Card inspector dialog title"
+  },
+  "inspectIdentity": "Identity",
+  "@inspectIdentity": {
+    "description": "Identity section heading"
+  },
+  "inspectNfar": "NFAR chunk",
+  "@inspectNfar": {
+    "description": "NFAR chunk section heading"
+  },
+  "inspectRaw": "Raw",
+  "@inspectRaw": {
+    "description": "Raw dump section heading"
+  },
+  "inspectHoldStill": "Hold the card still on the reader…",
+  "@inspectHoldStill": {
+    "description": "Shown while the dump starts"
+  },
+  "inspectDone": "Inspection complete.",
+  "@inspectDone": {
+    "description": "Shown when the dump finished"
+  },
+  "inspectStopped": "Stopped.",
+  "@inspectStopped": {
+    "description": "Shown when the user cancelled"
+  },
+  "inspectCardLost": "Card left the field — partial dump.",
+  "@inspectCardLost": {
+    "description": "Shown when the card left the field mid-dump"
+  },
+  "inspectCopy": "Copy",
+  "@inspectCopy": {
+    "description": "Copy the report to the clipboard"
+  },
+  "inspectCopied": "Report copied.",
+  "@inspectCopied": {
+    "description": "Confirmation after copying"
+  },
+  "inspectShare": "Share",
+  "@inspectShare": {
+    "description": "Share the report as a file"
+  },
+  "inspectClose": "Close",
+  "@inspectClose": {
+    "description": "Close the inspector"
+  },
+  "inspectNeedsChameleon": "Card inspection needs a Chameleon — phone NFC has no raw card access.",
+  "@inspectNeedsChameleon": {
+    "description": "Tooltip when the inspector is unavailable on phone NFC"
+  },
+  "inspectReading": "Reading {done} of {total}…",
+  "@inspectReading": {
+    "description": "Progress while reading",
+    "placeholders": {
+      "done": {
+        "type": "int",
+        "description": "Units read so far"
+      },
+      "total": {
+        "type": "int",
+        "description": "Total units"
+      }
+    }
+  },
+  "inspectRead": "Read {done} of {total}",
+  "@inspectRead": {
+    "description": "Progress when reading finished",
+    "placeholders": {
+      "done": {
+        "type": "int",
+        "description": "Units read so far"
+      },
+      "total": {
+        "type": "int",
+        "description": "Total units"
+      }
+    }
   }
 }

--- a/lib/l10n/app_ka.arb
+++ b/lib/l10n/app_ka.arb
@@ -171,5 +171,20 @@
   "readerConnectFailed": "Chameleon-თან დაკავშირება ვერ მოხერხდა.",
   "readerPhoneSubtitle": "იყენებს ტელეფონის საკუთარ NFC-ს",
   "readerChameleonSubtitle": "ამატებს Mifare Classic-ს და ბარათის დათვალიერებას Bluetooth-ით",
-  "readerSearch": "ძებნა"
+  "readerSearch": "ძებნა",
+  "inspectTitle": "ბარათის დათვალიერება",
+  "inspectIdentity": "იდენტიფიკაცია",
+  "inspectNfar": "NFAR ფრაგმენტი",
+  "inspectRaw": "დაუმუშავებელი",
+  "inspectHoldStill": "გეჭიროთ ბარათი უძრავად წამკითხველზე…",
+  "inspectDone": "დათვალიერება დასრულდა.",
+  "inspectStopped": "შეჩერდა.",
+  "inspectCardLost": "ბარათი მოშორდა — ნაწილობრივი დამპი.",
+  "inspectCopy": "კოპირება",
+  "inspectCopied": "ანგარიში დაკოპირდა.",
+  "inspectShare": "გაზიარება",
+  "inspectClose": "დახურვა",
+  "inspectNeedsChameleon": "ბარათის დათვალიერებას სჭირდება Chameleon — ტელეფონის NFC-ს არ აქვს პირდაპირი წვდომა ბარათთან.",
+  "inspectReading": "იკითხება {done} / {total}…",
+  "inspectRead": "წაკითხულია {done} / {total}"
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -164,5 +164,20 @@
   "readerConnectFailed": "Nie udało się połączyć z Chameleonem.",
   "readerPhoneSubtitle": "Używa własnego NFC telefonu",
   "readerChameleonSubtitle": "Dodaje Mifare Classic i zbadanie karty przez Bluetooth",
-  "readerSearch": "Szukaj"
+  "readerSearch": "Szukaj",
+  "inspectTitle": "Zbadaj kartę",
+  "inspectIdentity": "Tożsamość",
+  "inspectNfar": "Fragment NFAR",
+  "inspectRaw": "Dane surowe",
+  "inspectHoldStill": "Trzymaj kartę nieruchomo na czytniku…",
+  "inspectDone": "Badanie zakończone.",
+  "inspectStopped": "Zatrzymano.",
+  "inspectCardLost": "Karta opuściła pole — częściowy zrzut.",
+  "inspectCopy": "Kopiuj",
+  "inspectCopied": "Raport skopiowany.",
+  "inspectShare": "Udostępnij",
+  "inspectClose": "Zamknij",
+  "inspectNeedsChameleon": "Zbadanie karty wymaga Chameleona — NFC telefonu nie ma bezpośredniego dostępu do karty.",
+  "inspectReading": "Odczyt {done} z {total}…",
+  "inspectRead": "Odczytano {done} z {total}"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -171,5 +171,20 @@
   "readerConnectFailed": "Не удалось подключиться к Chameleon.",
   "readerPhoneSubtitle": "Использует собственный NFC телефона",
   "readerChameleonSubtitle": "Добавляет Mifare Classic и осмотр карты через Bluetooth",
-  "readerSearch": "Найти"
+  "readerSearch": "Найти",
+  "inspectTitle": "Осмотр карты",
+  "inspectIdentity": "Идентификация",
+  "inspectNfar": "Фрагмент NFAR",
+  "inspectRaw": "Сырые данные",
+  "inspectHoldStill": "Держите карту неподвижно на считывателе…",
+  "inspectDone": "Осмотр завершён.",
+  "inspectStopped": "Остановлено.",
+  "inspectCardLost": "Карта убрана — частичный дамп.",
+  "inspectCopy": "Копировать",
+  "inspectCopied": "Отчёт скопирован.",
+  "inspectShare": "Поделиться",
+  "inspectClose": "Закрыть",
+  "inspectNeedsChameleon": "Для осмотра карты нужен Chameleon — у NFC телефона нет прямого доступа к карте.",
+  "inspectReading": "Чтение {done} из {total}…",
+  "inspectRead": "Прочитано {done} из {total}"
 }

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -171,5 +171,20 @@
   "readerConnectFailed": "Chameleon’a bağlanılamadı.",
   "readerPhoneSubtitle": "Telefonun kendi NFC’sini kullanır",
   "readerChameleonSubtitle": "Bluetooth üzerinden Mifare Classic ve kart incelemesi ekler",
-  "readerSearch": "Ara"
+  "readerSearch": "Ara",
+  "inspectTitle": "Kartı incele",
+  "inspectIdentity": "Kimlik",
+  "inspectNfar": "NFAR parçası",
+  "inspectRaw": "Ham veri",
+  "inspectHoldStill": "Kartı okuyucunun üzerinde sabit tutun…",
+  "inspectDone": "İnceleme tamamlandı.",
+  "inspectStopped": "Durduruldu.",
+  "inspectCardLost": "Kart alandan çıktı — kısmi döküm.",
+  "inspectCopy": "Kopyala",
+  "inspectCopied": "Rapor kopyalandı.",
+  "inspectShare": "Paylaş",
+  "inspectClose": "Kapat",
+  "inspectNeedsChameleon": "Kart incelemesi için Chameleon gerekir — telefonun NFC'sinin ham karta erişimi yoktur.",
+  "inspectReading": "{total} biriminden {done} okunuyor…",
+  "inspectRead": "{total} biriminden {done} okundu"
 }

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -171,5 +171,20 @@
   "readerConnectFailed": "Не вдалося підключитися до Chameleon.",
   "readerPhoneSubtitle": "Використовує власний NFC телефону",
   "readerChameleonSubtitle": "Додає Mifare Classic та огляд картки через Bluetooth",
-  "readerSearch": "Знайти"
+  "readerSearch": "Знайти",
+  "inspectTitle": "Огляд картки",
+  "inspectIdentity": "Ідентифікація",
+  "inspectNfar": "Фрагмент NFAR",
+  "inspectRaw": "Сирі дані",
+  "inspectHoldStill": "Тримайте картку нерухомо на зчитувачі…",
+  "inspectDone": "Огляд завершено.",
+  "inspectStopped": "Зупинено.",
+  "inspectCardLost": "Картку прибрано — частковий дамп.",
+  "inspectCopy": "Копіювати",
+  "inspectCopied": "Звіт скопійовано.",
+  "inspectShare": "Поділитися",
+  "inspectClose": "Закрити",
+  "inspectNeedsChameleon": "Для огляду картки потрібен Chameleon — NFC телефону не має прямого доступу до картки.",
+  "inspectReading": "Читання {done} з {total}…",
+  "inspectRead": "Прочитано {done} з {total}"
 }

--- a/test/card_reader_phone_delegation_test.dart
+++ b/test/card_reader_phone_delegation_test.dart
@@ -22,6 +22,13 @@ void main() {
     expect(PhoneNfcReader().supportsRawAccess, isFalse);
   });
 
+  test('the phone reader offers no raw device, matching its flag', () async {
+    final r = PhoneNfcReader();
+    expect(r.supportsRawAccess, isFalse);
+    expect(r.rawDevice, isNull,
+        reason: 'the flag and the thing it gates must agree');
+  });
+
   test('connect and disconnect are no-ops, not errors', () async {
     // The phone's radio has no connection phase. Implementing them as no-ops
     // rather than throwing keeps callers free of platform conditionals.

--- a/test/chameleon_reader_test.dart
+++ b/test/chameleon_reader_test.dart
@@ -286,6 +286,18 @@ void main() {
         reason: 'the newer session owns the loop');
   });
 
+  test('rawDevice is the SAME instance every card operation uses', () async {
+    // Constructing a second BleChameleonDevice for one physical reader gives
+    // it its own pending-command slot and its own notification subscription,
+    // so it writes commands nobody listens for while the first instance drops
+    // the replies. Every inspection timed out on hardware because of exactly
+    // that. The flag and the thing it gates must come from one object.
+    final dev = FakeChameleonDevice.classic1k();
+    final reader = ChameleonReader(dev, pollInterval: Duration.zero);
+    expect(reader.supportsRawAccess, isTrue);
+    expect(identical(reader.rawDevice, dev), isTrue);
+  });
+
   test('connect and disconnect drive the underlying device', () async {
     final dev = FakeChameleonDevice.classic1k();
     final reader = ChameleonReader(dev, pollInterval: Duration.zero);

--- a/test/inspect_dialog_test.dart
+++ b/test/inspect_dialog_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nfc_archiver/core/chameleon/chameleon_device.dart';
+import 'package:nfc_archiver/features/inspect/presentation/providers/inspect_provider.dart';
+import 'package:nfc_archiver/features/inspect/presentation/screens/inspect_dialog.dart';
+
+import 'support/fake_chameleon_device.dart';
+
+late ProviderContainer container;
+
+Widget host(ChameleonDevice device) {
+  container = ProviderContainer();
+  return UncontrolledProviderScope(
+    container: container,
+    child: MaterialApp(
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: InspectDialog(device: device),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('a completed inspection shows identity, NFAR and raw rows',
+      (t) async {
+    await t.pumpWidget(host(FakeChameleonDevice.classic1k()));
+    await t.pumpAndSettle();
+
+    expect(find.text('Identity'), findsOneWidget);
+    expect(find.text('NFAR chunk'), findsOneWidget);
+    expect(find.text('Raw'), findsOneWidget);
+    expect(find.textContaining('Mifare Classic 1K'), findsOneWidget);
+  });
+
+  testWidgets('rows appear progressively rather than only at the end',
+      (t) async {
+    // A 64-block dump over BLE is not instant; the dialog must not look frozen
+    // while it runs.
+    final slow = FakeChameleonDevice.classic1k()
+      ..delayPerBlock(const Duration(milliseconds: 3));
+    await t.pumpWidget(host(slow));
+    await t.pump(const Duration(milliseconds: 40));
+
+    final partial = container.read(inspectProvider).rows.length;
+    expect(partial, greaterThan(0));
+    expect(partial, lessThan(64), reason: 'still running');
+
+    await t.pumpAndSettle(const Duration(milliseconds: 10));
+  });
+
+  testWidgets('Copy puts the report on the clipboard', (t) async {
+    final calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      calls.add(call);
+      return null;
+    });
+
+    await t.pumpWidget(host(FakeChameleonDevice.classic1k()));
+    await t.pumpAndSettle();
+    await t.tap(find.text('Copy'));
+    await t.pumpAndSettle();
+
+    expect(calls.any((c) => c.method == 'Clipboard.setData'), isTrue);
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+
+  testWidgets('closing mid-dump cancels the run', (t) async {
+    // A dialog dismissed while running must not leave a run polling the reader.
+    final slow = FakeChameleonDevice.classic1k()
+      ..delayPerBlock(const Duration(milliseconds: 5));
+    await t.pumpWidget(host(slow));
+    await t.pump(const Duration(milliseconds: 20));
+    expect(container.read(inspectProvider).isRunning, isTrue);
+
+    await t.tap(find.text('Close'));
+    await t.pump();
+
+    expect(container.read(inspectProvider).isRunning, isFalse);
+    await t.pumpAndSettle(const Duration(milliseconds: 10));
+  });
+
+  testWidgets('an unsupported tag shows its SPECIFIC message', (t) async {
+    await t.pumpWidget(host(FakeChameleonDevice.classic1k()..overrideSak(0x20)));
+    await t.pumpAndSettle();
+    expect(find.textContaining('20'), findsWidgets);
+  });
+
+  testWidgets('an auth-failed block is shown in place, not omitted', (t) async {
+    // An unreadable sector is itself diagnostic — hiding it would defeat the
+    // point of an inspector.
+    final dev = FakeChameleonDevice.classic1k(sectorKeys: {
+      for (var s = 0; s < 16; s++)
+        s: Uint8List.fromList(const [9, 9, 9, 9, 9, 9]),
+    });
+    await t.pumpWidget(host(dev));
+    await t.pumpAndSettle();
+    expect(container.read(inspectProvider).rows.length, 64);
+    expect(
+      container.read(inspectProvider).rows.any((r) => r.contains('auth failed')),
+      isTrue,
+    );
+  });
+}

--- a/test/inspect_notifier_test.dart
+++ b/test/inspect_notifier_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nfc_archiver/features/inspect/presentation/providers/inspect_provider.dart';
+
+import 'support/fake_chameleon_device.dart';
+import 'support/helpers.dart';
+
+void main() {
+  test('state accumulates rows, identity, nfar and a report', () async {
+    final n = InspectNotifier();
+    await n.start(FakeChameleonDevice.classic1k());
+    expect(n.state.rows.length, 64);
+    expect(n.state.identity, isNotNull);
+    expect(n.state.nfar, isNotNull);
+    expect(n.state.report, isNotNull);
+    expect(n.state.isRunning, isFalse);
+  });
+
+  test('a superseded run CANNOT write into the run that replaced it', () async {
+    // This is the regression test for the web app's 67c4683. The failure is
+    // NOT "cancel fails to set a flag" — it is run 1's already-scheduled
+    // callbacks scribbling rows and progress into run 2's state.
+    final n = InspectNotifier();
+    final slow = FakeChameleonDevice.classic1k()
+      ..delayPerBlock(const Duration(milliseconds: 5));
+
+    final first = n.start(slow); // deliberately not awaited
+    await pumpUntil(() => n.state.rows.isNotEmpty);
+
+    // Supersede it with a fast run that completes on its own.
+    await n.start(FakeChameleonDevice.classic1k());
+    final rowsAfterSecond = n.state.rows.length;
+    final reportAfterSecond = n.state.report;
+
+    await first; // let the stale run drain completely
+
+    expect(n.state.rows.length, rowsAfterSecond,
+        reason: 'late rows from the superseded run must be dropped');
+    expect(n.state.report, reportAfterSecond,
+        reason: 'and it must not overwrite the newer report');
+  });
+
+  test('a superseded run cannot flip isRunning back on the newer one',
+      () async {
+    final n = InspectNotifier();
+    final slow = FakeChameleonDevice.classic1k()
+      ..delayPerBlock(const Duration(milliseconds: 5));
+
+    final first = n.start(slow);
+    await pumpUntil(() => n.state.rows.isNotEmpty);
+    await n.start(FakeChameleonDevice.classic1k());
+    await first;
+
+    expect(n.state.isRunning, isFalse);
+  });
+
+  test('cancel stops the run and leaves the partial result visible', () async {
+    final n = InspectNotifier();
+    final slow = FakeChameleonDevice.classic1k()
+      ..delayPerBlock(const Duration(milliseconds: 5));
+
+    final f = n.start(slow);
+    await pumpUntil(() => n.state.rows.isNotEmpty);
+    n.cancel();
+    await f;
+
+    expect(n.state.isRunning, isFalse);
+    expect(n.state.rows, isNotEmpty,
+        reason: 'a partial dump is still worth showing');
+    expect(n.state.rows.length, lessThan(64));
+  });
+
+  test('starting a new run clears the previous rows', () async {
+    final n = InspectNotifier();
+    await n.start(FakeChameleonDevice.classic1k());
+    expect(n.state.rows.length, 64);
+    await n.start(FakeChameleonDevice.ntag215());
+    expect(n.state.rows.length, lessThan(64),
+        reason: 'NTAG yields fewer units, so stale rows would be visible');
+  });
+
+  test('cancelling when nothing runs is harmless', () async {
+    final n = InspectNotifier();
+    expect(n.cancel, returnsNormally);
+    expect(n.state.isRunning, isFalse);
+  });
+}

--- a/test/report_share_test.dart
+++ b/test/report_share_test.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mime/mime.dart';
+import 'package:nfc_archiver/features/inspect/data/report_share.dart';
+
+void main() {
+  late Directory tmp;
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('nfar-report-test');
+  });
+
+  tearDown(() async {
+    if (tmp.existsSync()) await tmp.delete(recursive: true);
+  });
+
+  test('the shared report file is typed text/plain, never octet-stream',
+      () async {
+    // CLAUDE.md: without an explicit MIME type Android's ContentResolver
+    // reports application/octet-stream and strict apps refuse to send. Same
+    // class of bug as the untyped Blob that garbled restored text in the web
+    // app.
+    final f = await writeReportFile('report text', dir: tmp);
+    expect(lookupMimeType(f.path), 'text/plain');
+  });
+
+  test('the filename carries the UID so two dumps do not collide', () async {
+    final a = await writeReportFile('x', dir: tmp, uid: 'DEADBEEF');
+    final b = await writeReportFile('y', dir: tmp, uid: 'CAFEBABE');
+    expect(a.path, contains('DEADBEEF'));
+    expect(a.path, isNot(equals(b.path)));
+  });
+
+  test('the report is written verbatim', () async {
+    const report = 'NFC Archiver — card inspection\n\nIDENTITY\nUID DE AD';
+    final f = await writeReportFile(report, dir: tmp);
+    expect(await f.readAsString(), equals(report));
+  });
+
+  test('a report with no UID still produces a usable filename', () async {
+    final f = await writeReportFile('x', dir: tmp);
+    expect(p.basename(f.path), endsWith('.txt'));
+  });
+}

--- a/test/run_inspection_test.dart
+++ b/test/run_inspection_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nfc_archiver/core/chameleon/cancellation_token.dart';
+import 'package:nfc_archiver/features/inspect/domain/inspect_sink.dart';
+import 'package:nfc_archiver/features/inspect/domain/run_inspection.dart';
+
+import 'support/fake_chameleon_device.dart';
+import 'support/helpers.dart';
+
+class RecordingSink implements InspectSink {
+  final rows = <String>[];
+  String? identity;
+  String? nfar;
+  String? progress;
+  String? report;
+  String? status;
+
+  /// Fires the first time a row arrives, for asserting ORDERING.
+  void Function()? onFirstRow;
+
+  /// Fires per row with the running count.
+  void Function(int count)? onRow;
+
+  @override
+  void appendRow(String line) {
+    rows.add(line);
+    if (rows.length == 1) onFirstRow?.call();
+    onRow?.call(rows.length);
+  }
+
+  @override
+  void setIdentity(String text) => identity = text;
+  @override
+  void setNfar(String text) => nfar = text;
+  @override
+  void setProgress(String text) => progress = text;
+  @override
+  void setReport(String text) => report = text;
+  @override
+  void setStatus(String text) => status = text;
+}
+
+void main() {
+  test('identity is reported BEFORE the first block is read', () async {
+    // onMeta must fire before any read, or the user stares at an empty dialog
+    // for ~64 BLE round trips.
+    final sink = RecordingSink();
+    String? identityAtFirstRow;
+    sink.onFirstRow = () => identityAtFirstRow = sink.identity;
+
+    await runInspection(FakeChameleonDevice.classic1k(), sink);
+
+    expect(identityAtFirstRow, isNotNull);
+    expect(identityAtFirstRow, contains('Mifare Classic 1K'));
+  });
+
+  test('a full Classic inspection emits a row per block, plus a report',
+      () async {
+    final sink = RecordingSink();
+    await runInspection(FakeChameleonDevice.classic1k(), sink);
+    expect(sink.rows.length, 64);
+    expect(sink.report, isNotNull);
+    expect(sink.nfar, isNotNull);
+    expect(sink.status, isNotNull);
+  });
+
+  test('a failed anticollision does NOT stop the dump', () async {
+    // The probe is advisory: readBlock performs its own select, so a card that
+    // refuses anticollision can still be dumped in full.
+    final sink = RecordingSink();
+    await runInspection(
+      FakeChameleonDevice.classic1k()..failAnticollision(),
+      sink,
+    );
+    expect(sink.rows.length, 64);
+    expect(sink.identity, contains('identity unavailable'));
+  });
+
+  test('an unsupported tag keeps its SPECIFIC message', () async {
+    // For an inspector the SAK value in that message IS the result, so a
+    // generic "unsupported tag" string would discard the finding.
+    final sink = RecordingSink();
+    await runInspection(
+      FakeChameleonDevice.classic1k()..overrideSak(0x20),
+      sink,
+    );
+    expect(sink.status, contains('20'));
+  });
+
+  test('an empty field is reported, not thrown', () async {
+    final sink = RecordingSink();
+    await runInspection(FakeChameleonDevice.classic1k()..removeCard(), sink);
+    expect(sink.status, isNotNull);
+    expect(sink.rows, isEmpty);
+  });
+
+  test('cancellation reports stopped and still leaves a usable report',
+      () async {
+    final sink = RecordingSink();
+    final token = CancellationToken();
+    sink.onRow = (n) {
+      if (n == 5) token.cancel();
+    };
+
+    await runInspection(FakeChameleonDevice.classic1k(), sink, token: token);
+
+    expect(sink.rows.length, lessThan(64));
+    expect(sink.report, isNotNull,
+        reason: 'a partial dump is still a usable artefact');
+    expect(sink.status, isNot(contains('complete')));
+  });
+
+  test('a card removed mid-dump is reported as lost, not as success', () async {
+    final sink = RecordingSink();
+    await runInspection(
+      FakeChameleonDevice.classic1k()..failFromBlock(10),
+      sink,
+    );
+    expect(sink.status, contains('field'));
+  });
+
+  test('an NTAG chunk is described from the unwrapped TLV, not raw pages',
+      () async {
+    // Concatenated raw pages begin with the TLV header, so without the unwrap
+    // every NTAG card would be reported "not NFAR".
+    final dev = FakeChameleonDevice.ntag215()
+      ..writeNfar(validChunkBytes());
+    final sink = RecordingSink();
+    await runInspection(dev, sink);
+    expect(sink.nfar, contains('NFAR'));
+    expect(sink.nfar, isNot(contains('not NFAR')));
+  });
+
+  test('a Classic card holding a chunk has its CRC verified', () async {
+    final dev = FakeChameleonDevice.classic1k();
+    dev.writeNfar(validChunkBytes());
+    final sink = RecordingSink();
+    await runInspection(dev, sink);
+    expect(sink.nfar, contains('CRC32'));
+    expect(sink.nfar, contains('OK'));
+  });
+
+  test('progress counts up to the total', () async {
+    final sink = RecordingSink();
+    await runInspection(FakeChameleonDevice.classic1k(), sink);
+    expect(sink.progress, contains('64'));
+  });
+}

--- a/test/support/fake_card_reader.dart
+++ b/test/support/fake_card_reader.dart
@@ -1,6 +1,7 @@
 import 'package:nfc_archiver/core/constants/nfar_format.dart';
 import 'package:nfc_archiver/core/models/chunk.dart';
 import 'package:nfc_archiver/core/models/nfc_tag_info.dart';
+import 'package:nfc_archiver/core/chameleon/chameleon_device.dart';
 import 'package:nfc_archiver/features/nfc/domain/card_reader.dart';
 
 /// A [CardReader] that records lifecycle calls, for testing reader selection.
@@ -20,6 +21,13 @@ class FakeCardReader implements CardReader {
 
   @override
   final bool supportsRawAccess;
+
+  /// Mirrors the real contract: non-null exactly when raw access is offered.
+  @override
+  ChameleonDevice? get rawDevice => supportsRawAccess ? rawDeviceStub : null;
+
+  /// Set by tests that need the device identity to be checkable.
+  ChameleonDevice? rawDeviceStub;
 
   final bool failConnect;
 

--- a/test/support/fake_chameleon_device.dart
+++ b/test/support/fake_chameleon_device.dart
@@ -1,6 +1,9 @@
 import 'dart:typed_data';
 
 import 'package:nfc_archiver/core/chameleon/chameleon_device.dart';
+import 'package:nfc_archiver/core/mifare/card_layout.dart';
+import 'package:nfc_archiver/core/nfc/ndef_bytes.dart';
+import 'package:nfc_archiver/core/nfc/type2.dart';
 
 /// An in-memory [ChameleonDevice] for tests.
 ///
@@ -110,6 +113,30 @@ class FakeChameleonDevice implements ChameleonDevice {
   /// a card's starting state without going through the write path under test.
   void setBlock(int block, Uint8List data) =>
       _blocks[block] = Uint8List.fromList(data);
+
+  /// Store [chunk] in the medium's NATIVE envelope: raw blocks on Classic, a
+  /// Type-2 TLV wrapping an NDEF record on NTAG.
+  ///
+  /// The two differ, and that difference is the whole reason nfarBytesSoFar
+  /// exists — a fake that stored raw bytes on NTAG would make the unwrap look
+  /// unnecessary.
+  void writeNfar(Uint8List chunk) {
+    if (sak == 0x08) {
+      for (final w in chunkToBlocks(chunk)) {
+        setBlock(w.block, w.data);
+      }
+      return;
+    }
+    final memory = wrapType2Tlv(encodeNdefMime(chunk));
+    for (var i = 0; i < memory.length; i += 4) {
+      final page = ndefStartPage + (i ~/ 4);
+      if (page >= totalPages) break;
+      final end = (i + 4) < memory.length ? i + 4 : memory.length;
+      final bytes = Uint8List(4)
+        ..setRange(0, end - i, Uint8List.sublistView(memory, i, end));
+      _pages[page] = bytes;
+    }
+  }
 
   /// Slows each block read so cancellation and superseded-run tests have a run
   /// long enough to interrupt.


### PR DESCRIPTION
Completes sub-project C. The inspector's dependency-free core landed with #56; this adds the orchestration, state, localisation, dialog, sharing, and the entry point — and **validates the whole thing on real hardware**.

Plan: `docs/superpowers/plans/2026-07-31-flutter-card-inspector-ui.md`
Spec: `docs/superpowers/specs/2026-07-31-flutter-card-inspector-design.md`

## Hardware validation

A full 64-block dump of a physical Mifare Classic 1K over a Chameleon Ultra:

```
18:26:04.192  first block read      (TX cmd=2008, block 0)
18:26:18.581  Inspection finished   units=64 aborted=false cardLost=false

block reads:      64
auth failures:     0
command failures:  0
dropped frames:    0
anticollision:     succeeded
```

**14.4 s, ~225 ms per block** at a −89 dBm link. The spec deliberately refused to estimate this; it is now measured. It is also slow enough that the progressive rendering earns its place — a dialog filling only at the end would look broken for a quarter of a minute.

## The bug hardware found

Every inspection timed out at first. The log named it in one line:

```
RX frame cmd=1001 status=0x68              ← the device answered
WARN Dropped unmatched frame awaiting=null  ← nobody was waiting
```

**Two `BleChameleonDevice` instances existed for one physical Chameleon.** The entry point constructed a fresh one, which had its own pending-command slot and *no notification subscription* — so it wrote commands nobody listened for and waited 5 s, while the connected instance received each reply, found nothing pending, and discarded it.

Not a protocol fault. An architecture one: `supportsRawAccess` lived on `CardReader` while callers had to *reconstruct* the device it described. `CardReader.rawDevice` now returns the live instance, non-null exactly when `supportsRawAccess` is true, so the flag and the thing it gates cannot diverge.

Defence in depth alongside it: `_sendCommand` keys on the **notification subscription** rather than a `_connected` flag, so an unsubscribed instance fails immediately with *"Not listening to this Chameleon"* instead of timing out on a reply that actually arrived.

## Decisions worth reviewing

**The superseded-run guard lives in a per-run sink**, not in a check against a field — a stale run reading the field would see the current token and sail through, and a guard at the entry point cannot help because the damaging callbacks are already queued. Regression cover for the web app's `67c4683`, and **verified load-bearing**: replacing the ownership check with `true` fails with *"late rows from the superseded run must be dropped"*.

**Status strings are localised through an `InspectStrings` value object** passed into `runInspection`, keeping the domain layer free of Flutter and `AppLocalizations`. The **report body stays English** by design, as CLAUDE.md records — it is diagnostic output meant to be pasted into a bug report, where a translated hex dump helps nobody.

**Share carries an explicit MIME type.** Without it Android reports `application/octet-stream` and strict receivers refuse to send — the same class of bug as the untyped `Blob` that garbled restored Cyrillic in the web app this morning.

**The Inspect button is visible but disabled under phone NFC**, never hidden, with `inspectNeedsChameleon` as its tooltip: `nfc_manager` exposes no raw anticollision or arbitrary block access, so this is a permanent platform limit rather than a missing feature, and a silently absent control teaches the user nothing.

**Closing cancels before popping**, and `PopScope` routes the hardware back button through the same path — a dismissed dialog must not leave a run polling the reader.

## Read-only

Nothing here writes to a card. Sector trailers are read and displayed, never modified.

## Testing

**249 tests**, analyzer at its pre-existing 22-issue baseline. Fifteen strings added across all seven locales.

## Not yet proven

- Inspecting an **NTAG** over a Chameleon (only Mifare Classic has run)
- A **foreign card** surfacing as `CardAuthException` without ending the session

🤖 Generated with [Claude Code](https://claude.com/claude-code)