### PR TITLE
chore(fdroid): pin 1.1.0's SHA, and correct the release guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,11 @@ A browser port that reads/writes NFAR archives on physical cards, either via a C
 
 ## F-Droid Build Notes
 
-F-Droid metadata lives in `fdroid/com.nfcarchiver.nfc_archiver.yml` (local copy) and is submitted via MR to [fdroiddata](https://gitlab.com/fdroid/fdroiddata). Key gotchas for future updates:
+F-Droid metadata lives in `fdroid/com.nfcarchiver.nfc_archiver.yml` (a reference mirror); the authoritative copy is in [fdroiddata](https://gitlab.com/fdroid/fdroiddata).
+
+**Routine version bumps need no manual MR.** `AutoUpdateMode: Version` + `UpdateCheckMode: Tags` + `UpdateCheckData` mean F-Droid's bot watches git tags, reads the version from `pubspec.yaml`, and generates the `Builds:` entry itself — pushing a `vX.Y.Z` tag is the whole trigger. An MR is needed only when the **build recipe** changes (a new prebuild step, system package, JDK/SDK/Flutter pinning, `srclibs`/`rm`/`scandelete`). See `docs/RELEASING.md`.
+
+Key gotchas:
 
 - **`compileSdk` must stay at 34** — F-Droid's build server has a JDK 21 `jlink`/`JdkImageTransform` bug with SDK 35. Do not bump `compileSdk` unless F-Droid upgrades their JDK or the bug is fixed. The build also installs JDK 17 from Debian Bookworm as a workaround.
 - **Flutter version is pinned from the release workflow** — `prebuild` extracts `FLUTTER_VERSION` from `.github/workflows/release.yml` via `sed`. If you rename/restructure the workflow, the F-Droid build will break.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -57,32 +57,52 @@ Play's limit is 4000 characters.
 git tag -a v1.1.0 -m "1.1.0" && git push origin v1.1.0
 ```
 
-## 6. F-Droid metadata
+## 6. F-Droid — usually nothing to do
 
-`fdroid/com.nfcarchiver.nfc_archiver.yml` is a **local copy**. The authoritative
-file lives in [fdroiddata](https://gitlab.com/fdroid/fdroiddata) and is updated
-by merge request. The local copy has drifted before — it currently carries the
-1.0.8 and 1.1.0 build entries only, while upstream also has 1.0.9–1.0.12.
+**Routine version bumps need no manual action.** The metadata is configured for
+automatic updates:
 
-For each release, add a `Builds:` entry and update `CurrentVersion` /
-`CurrentVersionCode`.
-
-**`commit:` must be the full SHA of the release commit on master — never a tag
-reference.** A new entry is committed with `REPLACE_WITH_RELEASE_COMMIT_SHA` as a
-deliberate tripwire; substituting it is step one of submitting the MR:
-
-```bash
-git rev-parse v1.1.0^{commit}
+```yaml
+AutoUpdateMode: Version
+UpdateCheckMode: Tags
+UpdateCheckData: pubspec.yaml|version:\s.+\+(\d+)|.|version:\s(.+)\+
 ```
 
-Then, in a fdroiddata checkout:
+F-Droid's bot watches the repo's **git tags**, reads `versionName` and
+`versionCode` straight out of `pubspec.yaml` with that regex, and generates the
+new `Builds:` entry itself by cloning the previous one. Pushing the tag in step 5
+is the entire trigger.
+
+Two things follow from that:
+
+- **`pubspec.yaml`'s `version:` must stay in `X.Y.Z+N` form.** The regex depends
+  on it. Break the format and F-Droid silently stops seeing new releases.
+- **The build recipe is inherited.** Whatever `sudo`/`prebuild`/`build` the last
+  entry used is what the new one gets.
+
+`fdroid/com.nfcarchiver.nfc_archiver.yml` in this repo is a **reference mirror**,
+not the file F-Droid builds from — the authoritative copy lives in
+[fdroiddata](https://gitlab.com/fdroid/fdroiddata) and is bot-maintained. The
+mirror has drifted before; it currently holds 1.0.8 and 1.1.0 while upstream also
+has 1.0.9–1.0.12.
+
+### When a manual MR IS required
+
+Only when the **build recipe itself** changes — not when the version does:
+
+- a new dependency needs an extra `prebuild` step or a system package
+- the JDK, `compileSdk`, or Flutter pinning changes
+- `srclibs`, `rm`, or `scandelete` need adjusting
+
+In that case, edit the file in a fdroiddata checkout and run:
 
 ```bash
 rewritemeta com.nfcarchiver.nfc_archiver
 ```
 
-`rewritemeta` enforces field ordering and line formatting — `sudo:` must follow
-`commit:`, and compound shell commands must be on a single line.
+It enforces field ordering and line formatting — `sudo:` must follow `commit:`,
+and compound shell commands must be on a single line. Use the **full commit SHA**
+in `commit:`, never a tag reference.
 
 ### Constraints that must not drift
 
@@ -103,7 +123,7 @@ rewritemeta com.nfcarchiver.nfc_archiver
   `rxandroid`, `kotlin-stdlib`, `protobuf-javalite`) are Apache-2.0 or BSD-3.
   **Never add `flutter_blue_plus`** — it relicensed to a custom non-free licence
   and F-Droid would reject the app.
-- **`pubspec.lock` is tracked**, so F-Droid resolves the same versions verified
+- **`pubspec.lock` is tracked**, so F-Droid resolves the versions verified
   locally.
 
 ## 7. Verify the built APK

--- a/fdroid/com.nfcarchiver.nfc_archiver.yml
+++ b/fdroid/com.nfcarchiver.nfc_archiver.yml
@@ -42,7 +42,7 @@ Builds:
 
   - versionName: 1.1.0
     versionCode: 13
-    commit: REPLACE_WITH_RELEASE_COMMIT_SHA
+    commit: 4567440489984e253b7da1c63b184a7ef96dabb9
     sudo:
       - echo 'deb http://deb.debian.org/debian bookworm main' > /etc/apt/sources.list.d/bookworm.list
       - apt-get update


### PR DESCRIPTION
Two things, both about the F-Droid metadata.

## 1. Fill the SHA tripwire

`REPLACE_WITH_RELEASE_COMMIT_SHA` → `4567440489984e253b7da1c63b184a7ef96dabb9`, the commit `v1.1.0` points at. The placeholder existed because the release commit could not be known before tagging.

## 2. I had the F-Droid process wrong

`docs/RELEASING.md`, written earlier today, told the reader to hand-edit fdroiddata and submit an MR for every release. That is wrong for routine version bumps. The metadata is configured for automatic updates:

```yaml
AutoUpdateMode: Version
UpdateCheckMode: Tags
UpdateCheckData: pubspec.yaml|version:\s.+\+(\d+)|.|version:\s(.+)\+
```

F-Droid's bot watches the repo's git tags, reads `versionName`/`versionCode` straight out of `pubspec.yaml` with that regex, and generates the `Builds:` entry itself by cloning the previous one. **Pushing the `v1.1.0` tag was the entire trigger** — nothing further is needed for this release.

CLAUDE.md said "submitted via MR", which is true of the *initial* submission and of build-recipe changes, but not of version bumps. I conflated the two. Both documents now separate the cases and say when an MR genuinely is required: a new `prebuild` step or system package, a JDK/`compileSdk`/Flutter pinning change, or `srclibs`/`rm`/`scandelete` edits.

Both also now state the consequence that actually matters: **`pubspec.yaml`'s `version:` must stay in `X.Y.Z+N` form**, because the regex depends on it — break the format and F-Droid silently stops seeing new releases.

The in-repo `fdroid/*.yml` is relabelled a **reference mirror**, since it is not the file F-Droid builds from and has drifted before (it holds 1.0.8 and 1.1.0; upstream also has 1.0.9-1.0.12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
