### PR TITLE
fix(webapp): stop the closed inspect dialog rendering as a ghost

### DIFF
--- a/webapp/app/index.html
+++ b/webapp/app/index.html
@@ -269,12 +269,15 @@
          overflow-x also stays hidden there: the hex dump grows wider as pages
          are read, and each <pre> scrolls internally, which is what keeps the
          dump readable. */
-      dialog.inspect {
-        max-width: min(96vw, 62rem); max-height: 88vh;
-        overflow: hidden; padding: 0;
-        display: flex; flex-direction: column;
-      }
-      .inspect-body { overflow-y: auto; overflow-x: hidden; padding: 1.25rem; }
+      /* NEVER set `display` on a dialog here. Author CSS beats the UA sheet
+         whatever the specificity, so a `display:` on `dialog.inspect` also
+         overrides the UA's `dialog:not([open]) { display: none }` — the closed
+         dialog then renders permanently in the page as a ghost copy, and Close
+         appears dead because it shuts a modal that a twin is still standing in
+         for. The height cap therefore lives on .inspect-body, not on a flex
+         parent: the dialog is fit-content around it either way. */
+      dialog.inspect { max-width: min(96vw, 62rem); overflow: hidden; padding: 0; }
+      .inspect-body { max-height: 88vh; overflow-y: auto; overflow-x: hidden; padding: 1.25rem; }
       .inspect-head { display: flex; align-items: baseline; gap: 0.6rem; flex-wrap: wrap; }
       .inspect-actions { margin-left: auto; display: flex; gap: 0.4rem; }
       dialog.inspect pre {

--- a/webapp/test/markup-ids.test.ts
+++ b/webapp/test/markup-ids.test.ts
@@ -55,6 +55,58 @@ test('the tab strip keeps the structure shell.ts queries', () => {
   assert.match(tabs[1]!, /aria-selected="true"/, 'no tab is initially selected');
 });
 
+/**
+ * Two CSS invariants that only bite in a real browser, so nothing else in the
+ * suite can catch them. Both were live bugs in the inspect dialog.
+ *
+ * Returns the author rules whose subject is a <dialog> element itself — not a
+ * descendant (`dialog.inspect pre`) and not a pseudo-element (`dialog::backdrop`),
+ * neither of which is the dialog box.
+ */
+function dialogSubjectRules(): Array<{ selector: string; body: string }> {
+  const style = /<style>([\s\S]*?)<\/style>/.exec(html);
+  assert.ok(style, 'no <style> block in index.html');
+  const css = style[1]!
+    .replace(/\/\*[\s\S]*?\*\//g, '')     // comments may contain example CSS
+    .replace(/@media[^{]*\{/g, '');       // flatten, so rules inside are scanned too
+
+  const out: Array<{ selector: string; body: string }> = [];
+  for (const rule of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    const body = rule[2]!;
+    for (const selector of rule[1]!.split(',')) {
+      // The subject is the last compound selector: what the rule actually styles.
+      const subject = selector.trim().split(/[\s>+~]+/).pop() ?? '';
+      if (/^dialog\b/.test(subject) && !subject.includes('::')) out.push({ selector: subject, body });
+    }
+  }
+  assert.ok(out.length > 0, 'no dialog rules found — the CSS scan may be stale');
+  return out;
+}
+
+test('no author rule sets display on a dialog that can be closed', () => {
+  // Author CSS beats the UA sheet regardless of specificity, so `display` on a
+  // bare `dialog…` selector also defeats `dialog:not([open]) { display: none }`.
+  // The closed dialog then renders permanently as a ghost copy of itself, and
+  // Close looks broken: it shuts a modal whose twin is still on screen.
+  // Qualifying the selector with [open] is the escape hatch.
+  const offenders = dialogSubjectRules()
+    .filter((r) => /(^|[;\s])display\s*:/.test(r.body) && !r.selector.includes('[open]'))
+    .map((r) => r.selector);
+  assert.deepEqual(offenders, [],
+    `these rules set display on a dialog without an [open] qualifier: ${offenders.join(', ')}`);
+});
+
+test('a dialog is never its own scroll container', () => {
+  // A rounded box cannot clip its own scrollbar — Chromium paints the gutter
+  // outside the border-radius clip, so a scrolling dialog goes square down its
+  // right edge. An inner wrapper must scroll instead.
+  const offenders = dialogSubjectRules()
+    .filter((r) => /overflow(-[xy])?\s*:\s*(auto|scroll)/.test(r.body))
+    .map((r) => r.selector);
+  assert.deepEqual(offenders, [],
+    `these rules let a dialog scroll itself, squaring its corners: ${offenders.join(', ')}`);
+});
+
 test('every icon referenced by <use> is defined in the sprite', () => {
   const defined = new Set([...html.matchAll(/<symbol id="([^"]+)"/g)].map((m) => m[1]!));
   const referenced = new Set<string>();


### PR DESCRIPTION
Follow-up to #60, which introduced this.

## Symptom

Copy / Download / Close in the card inspector stopped responding.

## Root cause

#60 set `display: flex` on `dialog.inspect` to make the body a flex child. **Author CSS beats the UA stylesheet regardless of specificity**, so that declaration also overrode the UA's `dialog:not([open]) { display: none }`. The closed dialog therefore never stopped rendering.

Measured in headless Chrome against the real markup:

| | closed dialog |
|---|---|
| before #60 | `display: none`, rect `0×0` |
| after #60 | `display: flex`, rect `992×188` at `y=960` |

So a full-width copy of the dialog was permanently parked in the page.

Those were never the modal's buttons — with the dialog open they hit-test to themselves and always did. What the user was clicking was the ghost:

- Close the inspector → the modal closes, the visually identical ghost stays (no backdrop) → Close looks broken.
- Click it again → `dialog.close()` on an already-closed dialog → a no-op.
- On a fresh page load it is worse: `inspect-panel.ts` wires the handlers inside `openInspector()` behind a `wired` flag, so before the first inspection the ghost's three buttons have **no listeners at all**.

## Fix

The flex parent was never needed. The height cap moves from the dialog to `.inspect-body`, which is a `fit-content`-sized block child either way — so **no rule sets `display` on the dialog**, and the UA keeps control of the open/closed state.

```css
dialog.inspect { max-width: min(96vw, 62rem); overflow: hidden; padding: 0; }
.inspect-body { max-height: 88vh; overflow-y: auto; overflow-x: hidden; padding: 1.25rem; }
```

#60's actual goal is preserved: the dialog still is not the scroll container, so its `border-radius` still clips the scrollbar.

## Verification

Headless Chrome on the real `index.html` (probe harness drives `showModal()` and `elementFromPoint`), all three simultaneously:

- closed → `display: none`, rect `0×0` — ghost gone, matches pre-#60
- open → all three buttons hit-test to themselves, `CLICKABLE`
- scrolling → dialog `scrollHeight/clientHeight = 708/708` (does not scroll itself), body `1288/708` (does)

## Regression guards

Neither invariant is observable without a browser, so both are now enforced as static assertions over the stylesheet in `markup-ids.test.ts`, scoped to rules whose *subject* is a dialog (skipping `dialog.inspect pre` and `dialog::backdrop`):

1. no author rule sets `display` on a dialog lacking an `[open]` qualifier
2. no author rule lets a dialog scroll itself

Each was checked to fail on the commit that broke it and pass on the other — 1 fails on #60, 2 fails on its parent. Full suite: 294/294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)