### PR TITLE
fix(inspect): flag a malformed ATQA instead of printing it as a card property

### DIFF
--- a/lib/core/inspect/hex_view.dart
+++ b/lib/core/inspect/hex_view.dart
@@ -38,6 +38,7 @@ class IdentityDiagnosis {
 }
 
 const int _hexWidth = 16 * 3 - 1; // "FF FF ... FF"
+const int _atqaBytes = 2;
 
 String _hex(Uint8List b) =>
     b.map((x) => x.toRadixString(16).padLeft(2, '0').toUpperCase()).join(' ');
@@ -92,7 +93,15 @@ String formatIdentity(DumpMeta meta, IdentityDiagnosis? diag) {
     return lines.join('\n');
   }
 
-  lines.add('ATQA      ${_hex(diag.atqa)}');
+  // ATQA is a fixed 2-byte field (Classic 1K answers 04 00, LSB first). A reader
+  // that returns anything else garbled the WUPA frame, and an unlabelled odd
+  // value reads as a real card property in a report meant for bug reports — one
+  // real tap rendered "ATQA 3F" while the anticollision right after it was clean.
+  // The bytes are kept, not dropped: in an inspector the failure is information.
+  final atqaNote = diag.atqa.length == _atqaBytes
+      ? ''
+      : '  ← malformed (expected $_atqaBytes bytes, got ${diag.atqa.length})';
+  lines.add('ATQA      ${_hex(diag.atqa)}$atqaNote');
   lines.add('UID (CL1) ${_hex(diag.uidCl1)}');
   lines.add(
     'BCC       returned ${_byte(diag.bccReturned)} · '

--- a/test/fixtures/inspect_report.txt
+++ b/test/fixtures/inspect_report.txt
@@ -3,7 +3,7 @@ NFC Archiver — card inspection
 IDENTITY
 Medium    Mifare Classic 1K (SAK 0x08)
 UID       DE AD BE EF
-ATQA      00 04
+ATQA      04 00
 UID (CL1) DE AD BE EF
 BCC       returned 0x22 · computed 0x22 · OK
 Verdict   BCC OK

--- a/test/inspect_hex_view_test.dart
+++ b/test/inspect_hex_view_test.dart
@@ -26,7 +26,8 @@ Uint8List _blockBytes(int b) =>
   );
 
   final diag = IdentityDiagnosis(
-    atqa: Uint8List.fromList(const [0x00, 0x04]),
+    // ATQA 0x0004 as a Classic 1K actually puts it on the wire: LSB first.
+    atqa: Uint8List.fromList(const [0x04, 0x00]),
     uidCl1: Uint8List.fromList(const [0xde, 0xad, 0xbe, 0xef]),
     bccReturned: bcc,
     bccComputed: bcc,
@@ -197,7 +198,7 @@ void main() {
       final meta = DumpMeta(
           sak: 0x08, uid: Uint8List.fromList(const [1, 2, 3, 4]), totalUnits: 64);
       final bad = IdentityDiagnosis(
-        atqa: Uint8List.fromList(const [0x00, 0x04]),
+        atqa: Uint8List.fromList(const [0x04, 0x00]),
         uidCl1: Uint8List.fromList(const [1, 2, 3, 4]),
         bccReturned: 0x00,
         bccComputed: 0x04,
@@ -205,6 +206,36 @@ void main() {
         isCascade: false,
       );
       expect(formatIdentity(meta, bad), contains('magic'));
+    });
+
+    test('a malformed ATQA is flagged rather than passed off as a card property',
+        () {
+      // Mirrors the TypeScript test of the same name. The shared fixture pins
+      // only a well-formed ATQA, so without this the two ports could diverge on
+      // the malformed path with nothing to notice.
+      final meta = DumpMeta(
+          sak: 0x08, uid: Uint8List.fromList(const [1, 2, 3, 4]), totalUnits: 64);
+      IdentityDiagnosis withAtqa(List<int> bytes) => IdentityDiagnosis(
+            atqa: Uint8List.fromList(bytes),
+            uidCl1: Uint8List.fromList(const [1, 2, 3, 4]),
+            bccReturned: 1 ^ 2 ^ 3 ^ 4,
+            bccComputed: 1 ^ 2 ^ 3 ^ 4,
+            bccValid: true,
+            isCascade: false,
+          );
+
+      final short = formatIdentity(meta, withAtqa(const [0x3f]));
+      expect(short, contains('3F'), reason: 'the offending bytes must survive');
+      expect(short, contains('malformed (expected 2 bytes, got 1)'));
+      expect(formatIdentity(meta, withAtqa(const [])),
+          contains('expected 2 bytes, got 0'));
+      expect(formatIdentity(meta, withAtqa(const [0x04, 0x00, 0x99])),
+          contains('expected 2 bytes, got 3'));
+
+      // A well-formed ATQA carries no note, and a bad one is not fatal.
+      expect(formatIdentity(meta, withAtqa(const [0x04, 0x00])),
+          isNot(contains('malformed')));
+      expect(short, contains('Verdict   BCC OK'));
     });
   });
 }

--- a/webapp/src/inspect/hex-view.ts
+++ b/webapp/src/inspect/hex-view.ts
@@ -24,6 +24,7 @@ export interface IdentityDiagnosis {
 }
 
 const HEX_WIDTH = 16 * 3 - 1; // "FF FF ... FF"
+const ATQA_BYTES = 2;
 
 const hex = (b: Uint8Array): string =>
   Array.from(b, (x) => x.toString(16).padStart(2, '0').toUpperCase()).join(' ');
@@ -64,7 +65,15 @@ export function formatIdentity(meta: DumpMeta, diag: IdentityDiagnosis | null): 
     lines.push('BCC       anticollision failed — identity unavailable (the dump may still work)');
     return lines.join('\n');
   }
-  lines.push(`ATQA      ${hex(diag.atqa)}`);
+  // ATQA is a fixed 2-byte field (Classic 1K answers 04 00, LSB first). A reader
+  // that returns anything else garbled the WUPA frame, and an unlabelled odd
+  // value reads as a real card property in a report meant for bug reports — one
+  // real tap rendered "ATQA 3F" while the anticollision right after it was clean.
+  // The bytes are kept, not dropped: in an inspector the failure is information.
+  const atqaNote = diag.atqa.length === ATQA_BYTES
+    ? ''
+    : `  ← malformed (expected ${ATQA_BYTES} bytes, got ${diag.atqa.length})`;
+  lines.push(`ATQA      ${hex(diag.atqa)}${atqaNote}`);
   lines.push(`UID (CL1) ${hex(diag.uidCl1)}`);
   lines.push(
     `BCC       returned ${byte(diag.bccReturned)} · computed ${byte(diag.bccComputed)} · ` +

--- a/webapp/test/hex-view.test.ts
+++ b/webapp/test/hex-view.test.ts
@@ -52,6 +52,33 @@ test('identity reports a Classic BCC verdict', () => {
   assert.match(text, /OK/);
 });
 
+test('a well-formed ATQA is reported without comment', () => {
+  const text = formatIdentity(CLASSIC_META, DIAG);
+  assert.match(text, /ATQA {6}04 00\s*$/m);
+});
+
+test('a malformed ATQA is flagged rather than passed off as a card property', () => {
+  // Observed on real hardware: one tap returned a single byte where the two-byte
+  // ATQA belongs, and the report rendered "ATQA  3F" — indistinguishable from a
+  // genuine value. The anticollision frame right after it was clean, so the dump
+  // stays useful; the inspector keeps the bytes and labels them instead of
+  // throwing, as it does everywhere else that a card disappoints it.
+  const short = formatIdentity(CLASSIC_META, { ...DIAG, atqa: new Uint8Array([0x3f]) });
+  assert.match(short, /3F/, 'the offending bytes must survive into the report');
+  assert.match(short, /malformed/i);
+  assert.match(short, /expected 2 bytes, got 1/);
+
+  const empty = formatIdentity(CLASSIC_META, { ...DIAG, atqa: new Uint8Array() });
+  assert.match(empty, /expected 2 bytes, got 0/);
+
+  const long = formatIdentity(CLASSIC_META, { ...DIAG, atqa: new Uint8Array([0x04, 0x00, 0x99]) });
+  assert.match(long, /expected 2 bytes, got 3/);
+
+  // The rest of the identity must still be reported — a bad ATQA is not fatal.
+  assert.match(short, /B9 16 27 51/);
+  assert.match(short, /Verdict {3}BCC OK/);
+});
+
 test('a 7-byte cascade UID is normal on NTAG and a fault on Classic', () => {
   const cascadeDiag = { ...DIAG, uidCl1: new Uint8Array([0x88, 0x04, 0xaa, 0xbb]), isCascade: true };
   const ntagMeta: DumpMeta = {

--- a/webapp/test/write_inspect_fixture.ts
+++ b/webapp/test/write_inspect_fixture.ts
@@ -30,7 +30,8 @@ const meta: DumpMeta = {
 };
 
 const diag: IdentityDiagnosis = {
-  atqa: new Uint8Array([0x00, 0x04]),
+  // ATQA 0x0004 as a Classic 1K actually puts it on the wire: LSB first.
+  atqa: new Uint8Array([0x04, 0x00]),
   uidCl1: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
   bccReturned: 0xde ^ 0xad ^ 0xbe ^ 0xef,
   bccComputed: 0xde ^ 0xad ^ 0xbe ^ 0xef,


### PR DESCRIPTION
Found while comparing two inspections of the same card (UID `B9 16 27 51`): one reported `ATQA 04 00`, the next `ATQA 3F`.

## The defect

ATQA is a fixed 2-byte field — Classic 1K answers `0x0004`. `3F` is not an ATQA; that WUPA frame came back short.

Nothing caught it. `diagnoseCard` assigns the raw WUPA response straight through (`app/diagnostics.ts:37,47`) with no length check, in pointed contrast to the anticollision response three lines below it, which *does* verify its 5 bytes (`app/diagnostics.ts:40-42`). The field is documented as "2 bytes" at `:21-22` and nothing enforces it.

`formatIdentity` then printed it bare (`src/inspect/hex-view.ts:67`), so a garbled frame was indistinguishable from a genuine card property — in the one artefact that exists to be pasted into bug reports, as that file's own header says.

**Scope:** nothing routes on ATQA (`AutoTransport` dispatches on SAK), so this is a reporting fix. That is why the rest of the dump was clean — BCC OK, 64/64 blocks, CRC OK.

**On the `3F` itself:** the WUPA frame was garbled while the anticollision immediately after it succeeded, which points to a transient rather than a decode bug. I can't confirm that without a hardware capture, so the fix makes the report say so instead of asserting a cause.

## Fix

Both formatters label a wrong-sized ATQA and **keep** the bytes:

```
ATQA      3F  ← malformed (expected 2 bytes, got 1)
```

Kept rather than dropped or rejected, matching how the inspector already treats a disappointing card — per CLAUDE.md, *"`describeNfar` is deliberately tolerant where `decodeChunk` throws — in an inspector the failure is the information."*

The check lives in the renderer, not in `diagnoseCard`: `CardDiagnosis` stays a faithful record of what the card returned, the renderer is already where anomalies are named (`BCC MISMATCH`, the cascade verdicts), and no interface changes.

## Fixture byte order

The ATQA fixtures disagreed with each other. `0x0004` goes LSB first on the wire, so a real Classic 1K capture is `04 00` — which is what `test/diagnostics.test.ts` and `test/hex-view.test.ts` already had, and what the two Dart fixtures and `write_inspect_fixture.ts` had backwards. Corrected, and `test/fixtures/inspect_report.txt` regenerated: that one line is the entire diff.

## Both ports

`lib/core/inspect/hex_view.dart` is a port verified byte-for-byte against the TypeScript via that shared fixture. The fixture pins only a *well-formed* ATQA, so the malformed path gets a matching test on each side — otherwise the two could diverge there with nothing to notice.

## Verification

- webapp `rm -rf dist && npm test` — 296/296
- `flutter test` — 250/250, including `formatReport matches the TypeScript byte for byte` against the regenerated fixture
- `flutter analyze` — no issues in the touched files (the 22 infos are pre-existing, elsewhere)
- new tests confirmed to fail before the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)