### PR TITLE
ci: run only the checks a change actually needs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,72 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Decides which of the two codebases a change actually touches. The jobs below
+  # gate on this with a job-level `if:`, never with a workflow-level `paths:`
+  # filter: "Analyze & Test" and "Build Android APK" are required status checks,
+  # and a workflow filtered out by `paths:` never reports them at all, leaving
+  # every web-app-only PR stuck on "Expected — waiting for status". A job skipped
+  # by `if:` still posts its check run, with conclusion "skipped", which the
+  # ruleset accepts.
+  changes:
+    name: Detect changed areas
+    runs-on: ubuntu-latest
+    outputs:
+      flutter: ${{ steps.filter.outputs.flutter }}
+      webapp: ${{ steps.filter.outputs.webapp }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # Full history so the base commit of the diff is present locally.
+          fetch-depth: 0
+
+      - name: Classify changed paths
+        id: filter
+        env:
+          # Interpolated into the environment, not into the script body.
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+
+          # Branch creation, a force-pushed base, or any unreachable commit means
+          # we cannot tell what changed. Fail open and run everything.
+          if [ -z "$BASE_SHA" ] || ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            echo "Base commit unavailable ($BASE_SHA) — running all jobs."
+            echo "flutter=true" >> "$GITHUB_OUTPUT"
+            echo "webapp=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Three-dot: diff against the merge base, so commits that landed on the
+          # base branch after this PR opened are not counted as our changes.
+          files=$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}")
+          echo "Changed files:"
+          echo "$files" | sed 's/^/  /'
+
+          flutter=false
+          webapp=false
+
+          # This workflow appears in both sets: a change to the pipeline must be
+          # validated by every job the pipeline runs.
+          if grep -qE '^(lib|test|tool|android|ios)/|^(pubspec\.(yaml|lock)|analysis_options\.yaml|l10n\.yaml)$|^\.github/workflows/ci\.yml$' <<< "$files"; then
+            flutter=true
+          fi
+          if grep -qE '^webapp/|^\.github/workflows/ci\.yml$' <<< "$files"; then
+            webapp=true
+          fi
+
+          echo "flutter=$flutter" >> "$GITHUB_OUTPUT"
+          echo "webapp=$webapp" >> "$GITHUB_OUTPUT"
+          echo "flutter=\`$flutter\` webapp=\`$webapp\`" >> "$GITHUB_STEP_SUMMARY"
+
   analyze-and-test:
     name: Analyze & Test
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.flutter == 'true'
 
     steps:
       - name: Checkout repository
@@ -49,7 +112,10 @@ jobs:
   build-android:
     name: Build Android APK
     runs-on: ubuntu-latest
-    needs: analyze-and-test
+    # Deliberately not gated on analyze-and-test: it consumes none of that job's
+    # output, and serialising the two cost ~2 min of wall clock on every PR.
+    needs: changes
+    if: needs.changes.outputs.flutter == 'true'
 
     steps:
       - name: Checkout repository
@@ -88,6 +154,8 @@ jobs:
   webapp:
     name: Web app core (TypeScript)
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.webapp == 'true'
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Problem

Every PR paid **5m24s** of CI regardless of what it touched. Measured from run [30694007760](https://github.com/mezinster/nfcarchiver/actions/runs/30694007760):

| Job | Wall clock | Where the time goes |
|---|---|---|
| Analyze & Test | 2m00 | Flutter setup 34s · analyze 19s · `flutter test` 60s |
| Web app core (TS) | 17s | `npm ci` + `tsc && node --test` |
| Build Android APK | 3m21 | Java setup 34s · Flutter 15s · **APK build 2m17** |

Two independent sources of waste:

1. **`build-android` was gated on `analyze-and-test`** (`needs:`), yet consumes none of its output. Pure serialisation — 2 min of wall clock on every Flutter PR.
2. **No path filtering.** Of the last 25 merges, **17 touched no Flutter file** and still ran `flutter analyze`, `flutter test` and a full debug APK build. PR #59 (three F-Droid metadata files) ran the entire Android pipeline twice — once on the PR, once on the master push.

## Change

A `changes` job classifies the diff into `flutter` / `webapp`; the three existing jobs gate on it with a job-level `if:`. `build-android` loses its `needs: analyze-and-test`.

| PR type | Before | After |
|---|---|---|
| web-app only | 5m24 | **~25s** |
| Flutter only | 5m24 | **~3m30** |
| both | 5m24 | ~3m30 |
| docs / fastlane only | 5m24 | **~10s** |

## Why `if:` and not a workflow-level `paths:` filter

`Analyze & Test` and `Build Android APK` are required status checks in ruleset `master-protection`. A workflow excluded by `paths:` never creates those check runs, so every web-app-only PR would sit on *"Expected — waiting for status"* and become unmergeable. A job skipped by `if:` still posts its check run with conclusion `skipped`, which satisfies the requirement.

## Correctness details

- **Three-dot diff.** `base.sha...head.sha` diffs against the merge base, so commits that landed on master after the PR opened are not misattributed to it.
- **Fails open.** An empty, all-zeros or unreachable base commit (branch creation, force-pushed base) runs every job rather than silently skipping.
- **`ci.yml` is in both path sets**, so the pipeline always validates changes to itself — as this PR demonstrates by running all three jobs.
- **No third-party action**, consistent with the dependency discipline in `deploy-webapp.yml`.

## Verification

The filter's grep patterns were replayed against the last 25 merges and every classification is correct, including the non-obvious ones — #44 is `flutter=true` because it edits `ci.yml`; #58 because it bumps `pubspec.yaml`, which must rebuild the APK; #49 and #51 legitimately touch both codebases. Edge cases (all-zeros base, empty base, empty diff) were executed directly.

## Follow-up, not in this PR

`Web app core (TypeScript)` is **not** currently a required check, so a failing webapp test is mergeable today — in a repo where ~70% of PRs are webapp. Worth adding to the ruleset once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)