### PR TITLE
fix(webapp): make a stalled archive write say what it is doing

### DIFF
--- a/webapp/app/controller.ts
+++ b/webapp/app/controller.ts
@@ -38,6 +38,24 @@ export interface DetectedArchive {
   complete: boolean;
 }
 
+/**
+ * Boundary events inside a single writeNextCard call, reported as they happen.
+ *
+ * A card operation is one long await from the caller's point of view — tag
+ * detection, the NFAR peek, then (on a Mifare Classic 1K) 47 block writes and
+ * 47 verify reads, 15-25 s of BLE round trips. Without these events a stall
+ * anywhere in that span is indistinguishable from "the user has not tapped
+ * yet": the status line still shows the previous card's prompt and the log is
+ * empty. The core stays free of the logger — the caller decides what to do
+ * with these.
+ */
+export type ArchiveWriteEvent =
+  | { phase: 'tag'; uid: string; maxChunkPayload: number }
+  | { phase: 'already-written'; uid: string }
+  | { phase: 'peeked'; uid: string; isNfar: boolean }
+  | { phase: 'writing'; uid: string; chunkIndex: number; bytes: number }
+  | { phase: 'written'; uid: string; chunkIndex: number };
+
 export class OverwriteRequiredError extends Error {
   constructor(message: string) {
     super(message);
@@ -105,22 +123,37 @@ export class ArchiveController {
     return { total: this.chunks.length, written: this.written, awaiting };
   }
 
-  async writeNextCard(signal?: AbortSignal, confirmOverwrite = false): Promise<{ done: boolean; progress: ArchiveProgress; rechunkedTo?: { total: number; payloadSize: number } }> {
+  async writeNextCard(
+    signal?: AbortSignal,
+    confirmOverwrite = false,
+    onEvent?: (e: ArchiveWriteEvent) => void,
+  ): Promise<{ done: boolean; progress: ArchiveProgress; rechunkedTo?: { total: number; payloadSize: number }; skipped?: 'already-written' }> {
     if (this.written >= this.chunks.length) return { done: true, progress: this.progress(null) };
     const tag = await this.transport.awaitTag({ signal });
     const key = uidHex(tag.uid);
+    onEvent?.({ phase: 'tag', uid: key, maxChunkPayload: tag.maxChunkPayload });
     if (this.writtenUids.has(key)) {
-      return { done: false, progress: this.progress(this.written) };
+      // No progress is possible from this card. Reported rather than returned
+      // as a bare no-op: the caller must be able to say so and to pace itself,
+      // or a card left sitting on the reader becomes an unthrottled, silent
+      // poll loop that looks exactly like a hang.
+      onEvent?.({ phase: 'already-written', uid: key });
+      return { done: false, progress: this.progress(this.written), skipped: 'already-written' };
     }
     let rechunkedTo: { total: number; payloadSize: number } | undefined;
     if (this.written === 0 && tag.maxChunkPayload !== this.payloadSize) {
       const total = this.rechunkForCapacity(tag.maxChunkPayload);
       rechunkedTo = { total, payloadSize: tag.maxChunkPayload };
     }
-    if (!confirmOverwrite && (await this.transport.peekIsNfar())) {
-      throw new OverwriteRequiredError('This card already holds NFAR data; confirm to overwrite');
+    if (!confirmOverwrite) {
+      const isNfar = await this.transport.peekIsNfar();
+      onEvent?.({ phase: 'peeked', uid: key, isNfar });
+      if (isNfar) throw new OverwriteRequiredError('This card already holds NFAR data; confirm to overwrite');
     }
-    await this.transport.writeChunk(encodeChunk(this.chunks[this.written]!));
+    const bytes = encodeChunk(this.chunks[this.written]!);
+    onEvent?.({ phase: 'writing', uid: key, chunkIndex: this.written, bytes: bytes.length });
+    await this.transport.writeChunk(bytes);
+    onEvent?.({ phase: 'written', uid: key, chunkIndex: this.written });
     this.writtenUids.add(key);
     this.written += 1;
     const done = this.written >= this.chunks.length;

--- a/webapp/app/i18n/be.ts
+++ b/webapp/app/i18n/be.ts
@@ -68,6 +68,10 @@ export const be: Messages = {
     `✓ запісана і праверана ${written} з ${total} — прыкладзіце наступную карту`,
   archiveDone: (n) => `Гатова — запісана і праверана ${n} ${pr(n, CARD_ACC)}.`,
   tapCardOf: (i, total) => `Прыкладзіце карту ${i} з ${total} да счытвальніка…`,
+  writingCard: (i, total) => `Запіс карты ${i} з ${total} — не прыбірайце карту…`,
+  cardAlreadyWritten: (uid) =>
+    `На карту ${uid} ужо запісана частка гэтага архіва — прыкладзіце іншую карту (у клонаў аднолькавы UID).`,
+  awaitingOverwriteAnswer: 'На карце ўжо ёсць даныя — чакаем вашага адказу ў дыялогу…',
   readerDisconnectedResume: 'Счытвальнік адключаны — падключыцеся зноў, каб працягнуць.',
   readerSwitchedResume: 'Счытвальнік зменены — працягваем на новым счытвальніку.',
   rechunked: (payloadSize, total) =>

--- a/webapp/app/i18n/en.ts
+++ b/webapp/app/i18n/en.ts
@@ -66,6 +66,10 @@ export const en = {
   progressWriting: (written: number, total: number) => `✓ ${written} of ${total} written & verified — tap the next card`,
   archiveDone: (n: number) => `Done — wrote and verified ${n} ${pr(n, { one: 'card', other: 'cards' })}.`,
   tapCardOf: (i: number, total: number) => `Tap card ${i} of ${total} on the reader…`,
+  writingCard: (i: number, total: number) => `Writing card ${i} of ${total} — hold it still…`,
+  cardAlreadyWritten: (uid: string) =>
+    `Card ${uid} already holds a chunk of this archive — tap a different card (cloned cards share a UID).`,
+  awaitingOverwriteAnswer: 'This card already holds data — waiting for your answer in the dialog…',
   readerDisconnectedResume: 'Reader disconnected — reconnect to resume.',
   readerSwitchedResume: 'Reader switched — resuming on the new reader.',
   rechunked: (payloadSize: number, total: number) =>

--- a/webapp/app/i18n/ka.ts
+++ b/webapp/app/i18n/ka.ts
@@ -65,6 +65,10 @@ export const ka: Messages = {
     `✓ ჩაწერილი და შემოწმებულია ${written} / ${total} — მიადეთ შემდეგი ბარათი`,
   archiveDone: (n) => `დასრულდა — ჩაწერილი და შემოწმებულია ${n} ${pr(n, CARD)}.`,
   tapCardOf: (i, total) => `მიადეთ ბარათი ${i} / ${total} წამკითხველს…`,
+  writingCard: (i, total) => `მიმდინარეობს ბარათის ${i} / ${total} ჩაწერა — არ მოხსნათ ბარათი…`,
+  cardAlreadyWritten: (uid) =>
+    `ბარათზე ${uid} უკვე ჩაწერილია ამ არქივის ნაწილი — მიადეთ სხვა ბარათი (კლონებს ერთი და იგივე UID აქვთ).`,
+  awaitingOverwriteAnswer: 'ბარათზე უკვე არის მონაცემები — ველოდებით თქვენს პასუხს დიალოგში…',
   readerDisconnectedResume: 'წამკითხველი გაითიშა — გასაგრძელებლად ხელახლა დააკავშირეთ.',
   readerSwitchedResume: 'წამკითხველი შეიცვალა — გრძელდება ახალ წამკითხველზე.',
   rechunked: (payloadSize, total) =>

--- a/webapp/app/i18n/pl.ts
+++ b/webapp/app/i18n/pl.ts
@@ -68,6 +68,10 @@ export const pl: Messages = {
     `✓ zapisano i zweryfikowano ${written} z ${total} — przyłóż następną kartę`,
   archiveDone: (n) => `Gotowe — zapisano i zweryfikowano ${n} ${pr(n, CARD_ACC)}.`,
   tapCardOf: (i, total) => `Przyłóż kartę ${i} z ${total} do czytnika…`,
+  writingCard: (i, total) => `Zapisywanie karty ${i} z ${total} — nie zabieraj karty…`,
+  cardAlreadyWritten: (uid) =>
+    `Karta ${uid} zawiera już fragment tego archiwum — przyłóż inną kartę (klony mają ten sam UID).`,
+  awaitingOverwriteAnswer: 'Ta karta zawiera już dane — czekamy na Twoją odpowiedź w oknie dialogowym…',
   readerDisconnectedResume: 'Czytnik rozłączony — połącz ponownie, aby kontynuować.',
   readerSwitchedResume: 'Zmieniono czytnik — wznawianie na nowym czytniku.',
   rechunked: (payloadSize, total) =>

--- a/webapp/app/i18n/ru.ts
+++ b/webapp/app/i18n/ru.ts
@@ -68,6 +68,10 @@ export const ru: Messages = {
     `✓ записано и проверено ${written} из ${total} — приложите следующую карту`,
   archiveDone: (n) => `Готово — записано и проверено ${n} ${pr(n, CARD_ACC)}.`,
   tapCardOf: (i, total) => `Приложите карту ${i} из ${total} к считывателю…`,
+  writingCard: (i, total) => `Запись карты ${i} из ${total} — не убирайте карту…`,
+  cardAlreadyWritten: (uid) =>
+    `На карту ${uid} уже записана часть этого архива — приложите другую карту (у клонов одинаковый UID).`,
+  awaitingOverwriteAnswer: 'На карте уже есть данные — ждём вашего ответа в диалоге…',
   readerDisconnectedResume: 'Считыватель отключён — переподключитесь, чтобы продолжить.',
   readerSwitchedResume: 'Считыватель изменён — продолжаем на новом считывателе.',
   rechunked: (payloadSize, total) =>

--- a/webapp/app/i18n/tr.ts
+++ b/webapp/app/i18n/tr.ts
@@ -65,6 +65,10 @@ export const tr: Messages = {
     `✓ ${total} karttan ${written} tanesi yazıldı ve doğrulandı — sonraki kartı okutun`,
   archiveDone: (n) => `Bitti — ${n} ${pr(n, CARD)} yazıldı ve doğrulandı.`,
   tapCardOf: (i, total) => `Kart ${i}/${total} — okuyucuya okutun…`,
+  writingCard: (i, total) => `Kart ${i}/${total} yazılıyor — kartı sabit tutun…`,
+  cardAlreadyWritten: (uid) =>
+    `${uid} kartı bu arşivin bir parçasını zaten içeriyor — başka bir kart okutun (klon kartlar aynı UID'yi paylaşır).`,
+  awaitingOverwriteAnswer: 'Bu kartta zaten veri var — iletişim kutusundaki yanıtınız bekleniyor…',
   readerDisconnectedResume: 'Okuyucu bağlantısı kesildi — devam etmek için yeniden bağlanın.',
   readerSwitchedResume: 'Okuyucu değişti — yeni okuyucuda devam ediliyor.',
   rechunked: (payloadSize, total) =>

--- a/webapp/app/i18n/uk.ts
+++ b/webapp/app/i18n/uk.ts
@@ -68,6 +68,10 @@ export const uk: Messages = {
     `✓ записано та перевірено ${written} з ${total} — прикладіть наступну картку`,
   archiveDone: (n) => `Готово — записано та перевірено ${n} ${pr(n, CARD_ACC)}.`,
   tapCardOf: (i, total) => `Прикладіть картку ${i} з ${total} до зчитувача…`,
+  writingCard: (i, total) => `Запис картки ${i} з ${total} — не прибирайте картку…`,
+  cardAlreadyWritten: (uid) =>
+    `На картку ${uid} вже записано частину цього архіву — прикладіть іншу картку (у клонів однаковий UID).`,
+  awaitingOverwriteAnswer: 'На картці вже є дані — чекаємо на вашу відповідь у діалозі…',
   readerDisconnectedResume: 'Зчитувач відключено — підключіться знову, щоб продовжити.',
   readerSwitchedResume: 'Зчитувач змінено — продовжуємо на новому зчитувачі.',
   rechunked: (payloadSize, total) =>

--- a/webapp/app/ui/archive-orchestrator.ts
+++ b/webapp/app/ui/archive-orchestrator.ts
@@ -7,7 +7,7 @@
  * on a fresh transport (see setTransport on the controller). The panel supplies
  * real DOM/browser IO; tests supply a stub IO + MockTransport.
  */
-import { ArchiveController, OverwriteRequiredError, type ArchiveRequest } from '../controller.js';
+import { ArchiveController, OverwriteRequiredError, type ArchiveRequest, type ArchiveWriteEvent } from '../controller.js';
 import { TagTimeoutError, UnsupportedTagError, type Transport } from '../../src/transport/transport.js';
 import { humanError } from './errors.js';
 import { t } from '../i18n/index.js';
@@ -75,6 +75,36 @@ export class ArchiveOrchestrator {
     let inUse = transport;
     const usable = (): boolean => this.io.isConnected() && this.io.activeTransport() === inUse;
     const breaker = new FailureBreaker();
+    // Turns the boundary events of one writeNextCard call into log lines and a
+    // live status. Everything below happens inside a single await, so without
+    // this the UI keeps showing the PREVIOUS card's prompt for the whole 15-25 s
+    // of a Mifare Classic write and the log stays empty between "Prepared" and
+    // "Write complete" — every way a card can get stuck looks the same.
+    const onEvent = (e: ArchiveWriteEvent): void => {
+      switch (e.phase) {
+        case 'tag':
+          this.io.log.debug('archive', 'Tag detected', { uid: e.uid, maxChunkPayload: e.maxChunkPayload });
+          break;
+        case 'already-written':
+          // The UID is the whole message. Cloned Mifare cards share one UID, so
+          // a user swapping twins sees a card they believe is new being refused
+          // over and over; naming the UID makes "the reader is seeing the same
+          // card" visible instead of leaving it to be inferred.
+          this.io.setStatus(t.cardAlreadyWritten(e.uid.toUpperCase()));
+          this.io.log.warn('archive', 'Card already written — skipped', { uid: e.uid });
+          break;
+        case 'peeked':
+          this.io.log.debug('archive', 'Peeked for existing NFAR data', { uid: e.uid, isNfar: e.isNfar });
+          break;
+        case 'writing':
+          this.io.setStatus(t.writingCard(e.chunkIndex + 1, total));
+          this.io.log.info('archive', 'Writing chunk to card', { uid: e.uid, chunk: e.chunkIndex + 1, bytes: e.bytes });
+          break;
+        case 'written':
+          this.io.log.info('archive', 'Card written & verified', { uid: e.uid, chunk: e.chunkIndex + 1 });
+          break;
+      }
+    };
     while (!done) {
       const iterationStart = Date.now();
       if (!usable()) {
@@ -87,9 +117,20 @@ export class ArchiveOrchestrator {
         continue;
       }
       try {
-        const res = await ctrl.writeNextCard(undefined, overwriteAll);
+        const res = await ctrl.writeNextCard(undefined, overwriteAll, onEvent);
         total = res.progress.total;
         done = res.done;
+        if (res.skipped === 'already-written') {
+          // Not a failure and not progress: a card the user already wrote is
+          // sitting on the reader. Pacing is what makes this safe — the success
+          // path bypasses the catch block's ensureMinInterval, so without it
+          // this is an unthrottled poll of the reader that renders no change
+          // and logs nothing. That is precisely what a hang looks like.
+          // (The status is set by the 'already-written' event above, which
+          // carries the UID.)
+          await ensureMinInterval(iterationStart, 250);
+          continue;
+        }
         this.render(res.progress.written, total, done);
         if (res.rechunkedTo) {
           this.io.setStatus(t.rechunked(res.rechunkedTo.payloadSize, res.rechunkedTo.total));
@@ -110,11 +151,18 @@ export class ArchiveOrchestrator {
         await ensureMinInterval(iterationStart, 250);
         if (e instanceof TagTimeoutError) { this.io.setStatus(t.noCardTapHold); continue; }
         if (e instanceof OverwriteRequiredError) {
+          // Announced BEFORE the prompt opens. The await below is unbounded, so
+          // a dialog the user never answers — or one that never became visible
+          // — is an indefinite silent stall with the previous card's prompt
+          // still on screen. The status line and log now name the wait.
+          this.io.setStatus(t.awaitingOverwriteAnswer);
+          this.io.log.info('archive', 'Overwrite prompt opened — awaiting the answer');
           const choice = await this.io.confirmOverwrite();
+          this.io.log.info('archive', 'Overwrite prompt answered', { choice });
           if (choice === 'skip') { this.io.setStatus(t.skippedTapDifferent); continue; }
           if (choice === 'all') { overwriteAll = true; this.io.log.info('archive', 'Overwrite all remaining'); }
           try {
-            const res = await ctrl.writeNextCard(undefined, true);
+            const res = await ctrl.writeNextCard(undefined, true, onEvent);
             total = res.progress.total;
             done = res.done;
             this.render(res.progress.written, total, done);

--- a/webapp/test/archive-orchestrator.test.ts
+++ b/webapp/test/archive-orchestrator.test.ts
@@ -283,3 +283,105 @@ test('repeated wrong-media taps never trip the archive breaker', async () => {
   await inner.awaitTag();
   assert.equal(decodeChunk(await inner.readChunk()).chunkIndex, 0, 'the archive still completed');
 });
+
+// ---------------------------------------------------------------------------
+// Traceability of a stuck write. A multi-card archive that stops making
+// progress used to look identical whatever the cause: the status line still
+// showed the previous card's tap prompt (render() only runs after a whole card
+// completes) and the log held nothing between "Prepared" and "Write complete".
+// These three tests pin the boundary reporting that tells the causes apart.
+// ---------------------------------------------------------------------------
+
+const twoCardData = crypto.getRandomValues(new Uint8Array(1000)); // incompressible -> 2 cards
+
+test('re-tapping an already-written card says so instead of silently skipping', async () => {
+  const inner = new MockTransport();
+  const logger = new Logger();
+  const { io, statuses } = makeIO(inner, { log: logger });
+  const orch = new ArchiveOrchestrator(io);
+
+  inner.enqueueTag(uid(0)); // card 1 written
+  inner.enqueueTag(uid(0)); // user puts the SAME card back — no progress possible
+  inner.enqueueTag(uid(0)); // and again
+  inner.enqueueTag(uid(1)); // finally a fresh card -> archive completes
+
+  const startedAt = Date.now();
+  await orch.run(inner, { data: twoCardData, fileName: 'blob.bin', compress: false, payloadSize: 720 });
+  const elapsed = Date.now() - startedAt;
+
+  // The UID must be in the message. Cloned Mifare cards share a UID, so a user
+  // swapping twins sees a card they believe is new refused over and over — a
+  // message without the UID leaves that to be inferred, which is exactly the
+  // 90-second silent skip loop observed on hardware on 2026-08-13.
+  assert.ok(statuses.some((s) => /already holds/i.test(s) && /A00000/i.test(s)),
+    `the user must be told WHICH card is already written; got ${JSON.stringify(statuses)}`);
+  assert.ok(logger.snapshot().some((e) => /already written/i.test(e.msg)),
+    'the skip must reach the log — it is otherwise invisible');
+  // The skip is a SUCCESS return, so it never reaches the catch block's
+  // ensureMinInterval. Unpaced, a card left on the reader is an unthrottled
+  // poll that renders no change and logs nothing — indistinguishable from a
+  // hang, and the exact shape loop-guards.ts exists to prevent. Two skips must
+  // therefore cost at least two intervals.
+  assert.ok(elapsed >= 500, `two skips must be paced at 250 ms each; took ${elapsed} ms`);
+});
+
+test('each card is logged at every boundary so a stall can be located', async () => {
+  const inner = new MockTransport();
+  const logger = new Logger();
+  const { io } = makeIO(inner, { log: logger });
+
+  inner.enqueueTag(uid(0));
+  inner.enqueueTag(uid(1));
+  await new ArchiveOrchestrator(io).run(inner, {
+    data: twoCardData, fileName: 'blob.bin', compress: false, payloadSize: 720,
+  });
+
+  const msgs = logger.snapshot().map((e) => e.msg);
+  assert.ok(msgs.some((m) => /tag detected/i.test(m)),
+    `a tap must be logged, so "no card" is distinguishable from "stuck mid-write"; got ${JSON.stringify(msgs)}`);
+  assert.ok(msgs.some((m) => /writing chunk/i.test(m)),
+    'the start of a card write must be logged — a stall inside it is otherwise silent');
+  assert.equal(msgs.filter((m) => /card written/i.test(m)).length, 2,
+    'every completed card must be logged with its UID');
+});
+
+test('a write in flight replaces the tap prompt instead of leaving it frozen', async () => {
+  const inner = new MockTransport();
+  const { io, statuses } = makeIO(inner);
+
+  inner.enqueueTag(uid(0));
+  inner.enqueueTag(uid(1));
+  await new ArchiveOrchestrator(io).run(inner, {
+    data: twoCardData, fileName: 'blob.bin', compress: false, payloadSize: 720,
+  });
+
+  // On a Mifare Classic 1K a card write is 94 BLE round trips (47 blocks +
+  // 47 verify reads), 15-25 s. Showing "tap the next card" throughout makes a
+  // working write and a hung one indistinguishable.
+  assert.ok(statuses.some((s) => /writing card/i.test(s)),
+    `a write in progress must be visible; got ${JSON.stringify(statuses)}`);
+});
+
+test('the overwrite prompt announces itself, so an unanswered dialog is traceable', async () => {
+  const inner = new MockTransport();
+  const logger = new Logger();
+  const existing = encodeChunk({
+    archiveId: new Uint8Array(16).fill(9), totalChunks: 1, chunkIndex: 0,
+    payload: new Uint8Array([1]), crc32: 0, flags: 0,
+  });
+  const { io, statuses } = makeIO(inner, { log: logger, confirmOverwrite: async () => 'once' });
+
+  inner.enqueueTag(uid(0), existing); // tap -> prompt (throws, tag consumed)
+  inner.enqueueTag(uid(0), existing); // re-tap -> the confirmed write
+  inner.enqueueTag(uid(1), existing); // second card, prompted again
+  inner.enqueueTag(uid(1), existing);
+
+  await new ArchiveOrchestrator(io).run(inner, {
+    data: twoCardData, fileName: 'blob.bin', compress: false, payloadSize: 720,
+  });
+
+  assert.ok(logger.snapshot().some((e) => /overwrite/i.test(e.msg)),
+    'opening the prompt must be logged — a dialog nobody answers is otherwise a silent hang');
+  assert.ok(statuses.some((s) => /waiting for your answer/i.test(s)),
+    `the status line must say a prompt is open; got ${JSON.stringify(statuses)}`);
+});


### PR DESCRIPTION
## The report

A 2-card Mifare Classic archive appeared to hang on card 2. The status line sat on *"Tap card 2 of 2"*, the log held nothing between `Prepared` and `Write complete`, and the failure could not be diagnosed from either.

## Why it was undiagnosable

The write path was unobservable. `render()` runs only **after** a whole card completes, so tag detection, the NFAR peek and 94 BLE round trips (47 block writes + 47 verify reads, 15–25 s) all happened inside a single `await` with the **previous** card's prompt still on screen — emitting zero log lines throughout.

Four unrelated failures therefore presented identically:

| Mechanism | Looked like |
|---|---|
| Card holds NFAR → overwrite dialog awaiting an answer | frozen prompt, empty log |
| Card has non-factory keys → `CardAuthError` storm | frozen prompt, empty log |
| Same-UID re-tap → silent unpaced skip loop | frozen prompt, empty log |
| Stall inside `writeChunk`'s BLE round trips | frozen prompt, empty log |

## What changed

`writeNextCard` now reports its boundaries (`tag` / `already-written` / `peeked` / `writing` / `written`) through an optional callback. `src/` stays free of the logger — the orchestrator, which already holds `io.log`, turns those events into log lines and a live *"Writing card N of M"* status.

It also fixes the one defect this exposed. Re-tapping an already-written card returned a bare success no-op: no message, no log, and it bypassed the catch block's `ensureMinInterval` entirely — so a card left on the reader became an unthrottled poll that rendered no change and logged nothing. Indistinguishable from a hang, and exactly the shape `loop-guards.ts` exists to prevent. It is now paced, logged, and **names the UID**.

The overwrite prompt announces itself before opening, so a dialog nobody answers cannot stall indefinitely and silently either.

## Outcome

Confirmed on hardware: the instrumented build identified the cause **on the first tap, from the log alone**. The two test cards were clones sharing UID `b9162751` — the reader could not tell them apart, so `writtenUids` correctly skipped every tap. Not an app defect; naming the UID in the message is what makes that self-evident, hence the wording.

Note the guard ordering is deliberate and unchanged: the duplicate-UID check runs **before** the NFAR peek. Peeking first would let an "Overwrite" click drop chunk N on top of chunk N−1 and destroy the in-progress archive.

## Verification

- 300/300 tests pass, `tsc` clean (4 new tests)
- The pacing guard was verified to bite by disabling the fix: **1 ms unpaced vs ≥500 ms paced**
- 3 new i18n keys across all 7 locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)