### PR TITLE
refactor(nfc): put an NdefIO seam in front of the platform NDEF class

### DIFF
--- a/lib/features/nfc/data/nfc_repository.dart
+++ b/lib/features/nfc/data/nfc_repository.dart
@@ -10,6 +10,7 @@ import '../domain/mifare_block_io.dart';
 import '../domain/mifare_tag_codec.dart';
 import '../domain/ndef_availability.dart';
 import '../domain/ndef_formatter.dart';
+import '../domain/ndef_io.dart';
 import '../domain/ndef_tag_codec.dart';
 import '../domain/tag_codec.dart';
 import 'nfc_capabilities.dart';
@@ -51,7 +52,7 @@ class NfcRepository {
   /// MifareClassic is unambiguously ours. NDEF handles everything else.
   final List<TagCodec> _codecs = [
     MifareTagCodec(mifareIoFor),
-    NdefTagCodec(),
+    NdefTagCodec(ndefIoFor),
   ];
 
   /// First codec that can handle this tag, or null.
@@ -235,7 +236,7 @@ class NfcRepository {
           // not the (1-4 byte stricter) `codec.capacityBytes(tag)` used below
           // for other media.
           if (codec is NdefTagCodec) {
-            final ndef = Ndef.from(tag)!;
+            final ndef = ndefIoFor(tag)!;
             if (!ndef.isWritable) {
               onError('Tag is not writable');
               return;
@@ -446,7 +447,7 @@ class NfcRepository {
 
     // Try to get NDEF info
     final codec = _codecFor(tag);
-    final ndef = codec != null ? Ndef.from(tag) : null;
+    final ndef = codec != null ? ndefIoFor(tag) : null;
     if (ndef != null) {
       capacity = ndef.maxSize;
       isWritable = ndef.isWritable;

--- a/lib/features/nfc/domain/ndef_io.dart
+++ b/lib/features/nfc/domain/ndef_io.dart
@@ -1,0 +1,51 @@
+import 'package:nfc_manager/nfc_manager.dart';
+
+/// Narrow NDEF access to a tag.
+///
+/// Exists for the same reason as [MifareBlockIO]: `nfc_manager`'s `Ndef` cannot
+/// be constructed in a test, so a codec that calls `Ndef.from(tag)` directly is
+/// only exercisable with a card in hand. Injecting the lookup instead lets the
+/// codec's real logic run against a fake.
+///
+/// It also isolates the one place that names a platform NDEF class. `nfc_manager`
+/// v4 replaces the platform-agnostic `Ndef` with separate `NdefAndroid` and
+/// `NdefIos` types whose members differ (`maxSize` vs `capacity`, a bool
+/// `isWritable` vs an `NdefStatusIos` enum), so that migration becomes a change
+/// to the adapter below rather than to every call site.
+abstract interface class NdefIO {
+  /// Capacity of the NDEF *message* area, in bytes.
+  int get maxSize;
+
+  /// Whether the tag will accept a write.
+  bool get isWritable;
+
+  /// Read the stored NDEF message.
+  Future<NdefMessage> read();
+
+  /// Replace the stored NDEF message. Throws on failure.
+  Future<void> write(NdefMessage message);
+}
+
+/// Real implementation over `nfc_manager`.
+class NfcManagerNdefIO implements NdefIO {
+  NfcManagerNdefIO(this._ndef);
+  final Ndef _ndef;
+
+  @override
+  int get maxSize => _ndef.maxSize;
+
+  @override
+  bool get isWritable => _ndef.isWritable;
+
+  @override
+  Future<NdefMessage> read() => _ndef.read();
+
+  @override
+  Future<void> write(NdefMessage message) => _ndef.write(message);
+}
+
+/// Adapter used in production: null when the tag carries no NDEF technology.
+NdefIO? ndefIoFor(NfcTag tag) {
+  final ndef = Ndef.from(tag);
+  return ndef == null ? null : NfcManagerNdefIO(ndef);
+}

--- a/lib/features/nfc/domain/ndef_tag_codec.dart
+++ b/lib/features/nfc/domain/ndef_tag_codec.dart
@@ -3,24 +3,27 @@ import 'package:nfc_manager/nfc_manager.dart';
 import '../../../core/constants/nfar_format.dart';
 import '../../../core/models/chunk.dart';
 import 'ndef_formatter.dart';
+import 'ndef_io.dart';
 import 'tag_codec.dart';
 
 /// NDEF-backed tags: NTAG213/215/216 and Mifare Ultralight.
 class NdefTagCodec implements TagCodec {
-  NdefTagCodec([NdefFormatter? formatter])
+  NdefTagCodec(this._ioFor, [NdefFormatter? formatter])
       : _formatter = formatter ?? NdefFormatter.instance;
 
+  /// Injected so the codec is testable without a card — see [NdefIO].
+  final NdefIO? Function(NfcTag tag) _ioFor;
   final NdefFormatter _formatter;
 
   @override
   String get name => 'NDEF';
 
   @override
-  bool supports(NfcTag tag) => Ndef.from(tag) != null;
+  bool supports(NfcTag tag) => _ioFor(tag) != null;
 
   @override
   Future<int> capacityBytes(NfcTag tag) async {
-    final ndef = Ndef.from(tag)!;
+    final ndef = _ioFor(tag)!;
     // ndef.maxSize is the NDEF *message* capacity. Subtract the record overhead
     // and the terminator byte to get the chunk bytes that actually fit.
     //
@@ -37,13 +40,13 @@ class NdefTagCodec implements TagCodec {
 
   @override
   Future<Chunk?> readChunk(NfcTag tag) async {
-    final ndef = Ndef.from(tag)!;
+    final ndef = _ioFor(tag)!;
     return _formatter.ndefToChunk(await ndef.read());
   }
 
   @override
   Future<void> writeChunk(NfcTag tag, Chunk chunk) async {
-    final ndef = Ndef.from(tag)!;
+    final ndef = _ioFor(tag)!;
     if (!ndef.isWritable) {
       throw StateError('Tag is not writable');
     }

--- a/test/ndef_tag_codec_test.dart
+++ b/test/ndef_tag_codec_test.dart
@@ -1,0 +1,102 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nfc_archiver/core/models/chunk.dart';
+import 'package:nfc_archiver/core/services/checksum_service.dart';
+import 'package:nfc_archiver/features/nfc/domain/ndef_io.dart';
+import 'package:nfc_archiver/features/nfc/domain/ndef_tag_codec.dart';
+import 'package:nfc_manager/nfc_manager.dart';
+
+/// nfc_manager exposes a const NfcTag constructor explicitly for testing.
+NfcTag fakeTag() => const NfcTag(handle: 'test', data: <String, dynamic>{});
+
+/// In-memory NDEF tag. Mirrors `FakeMifareBlockIO`: the codec's real logic runs
+/// against it, so everything above the platform boundary is testable without a
+/// card. `Ndef` itself cannot be constructed in a test, which is the whole
+/// reason this seam exists.
+class FakeNdefIO implements NdefIO {
+  FakeNdefIO({this.maxSize = 868, this.isWritable = true, this.stored});
+
+  @override
+  final int maxSize;
+  @override
+  final bool isWritable;
+
+  NdefMessage? stored;
+  final List<NdefMessage> writes = [];
+
+  @override
+  Future<NdefMessage> read() async => stored ?? NdefMessage([]);
+
+  @override
+  Future<void> write(NdefMessage message) async {
+    writes.add(message);
+    stored = message;
+  }
+}
+
+Chunk makeChunk(int payloadLen) {
+  final payload =
+      Uint8List.fromList(List.generate(payloadLen, (i) => (i + 3) % 256));
+  return Chunk(
+    archiveId: Uint8List(16)..fillRange(0, 16, 7),
+    totalChunks: 2,
+    chunkIndex: 1,
+    payload: payload,
+    crc32: ChecksumService.instance.calculate(payload),
+  );
+}
+
+void main() {
+  test('writeChunk refuses a tag that is not writable', () async {
+    final io = FakeNdefIO(isWritable: false);
+    final codec = NdefTagCodec((_) => io);
+
+    await expectLater(
+      () => codec.writeChunk(fakeTag(), makeChunk(64)),
+      throwsStateError,
+    );
+    expect(io.writes, isEmpty, reason: 'nothing may be written to a locked tag');
+  });
+
+  test('write then read round-trips a chunk', () async {
+    final io = FakeNdefIO();
+    final codec = NdefTagCodec((_) => io);
+    final chunk = makeChunk(120);
+
+    await codec.writeChunk(fakeTag(), chunk);
+    final read = await codec.readChunk(fakeTag());
+
+    expect(read, isNotNull);
+    expect(read!.payload, chunk.payload);
+    expect(read.chunkIndex, chunk.chunkIndex);
+    expect(read.totalChunks, chunk.totalChunks);
+    expect(read.archiveId, chunk.archiveId);
+  });
+
+  test('readChunk returns null when the tag holds no NFAR record', () async {
+    final io = FakeNdefIO(stored: NdefMessage([]));
+    final codec = NdefTagCodec((_) => io);
+
+    expect(await codec.readChunk(fakeTag()), isNull);
+  });
+
+  test('does not claim a tag that carries no NDEF technology', () {
+    expect(NdefTagCodec((_) => null).supports(fakeTag()), isFalse);
+  });
+
+  test('claims a tag that carries NDEF', () {
+    expect(NdefTagCodec((_) => FakeNdefIO()).supports(fakeTag()), isTrue);
+  });
+
+  test('capacityBytes is derived from the tag NDEF message capacity', () async {
+    // NTAG215's 496-byte message area. The codec reports *chunk* bytes, so the
+    // answer must be smaller than maxSize — the record overhead comes off.
+    final codec = NdefTagCodec((_) => FakeNdefIO(maxSize: 496));
+
+    final capacity = await codec.capacityBytes(fakeTag());
+
+    expect(capacity, lessThan(496));
+    expect(capacity, greaterThan(0));
+  });
+}


### PR DESCRIPTION
Stage 1 of the [nfc_manager v4 migration](https://github.com/mezinster/nfcarchiver/pull/70). Pure refactor — **no dependency change**, still on `nfc_manager ^3.5.1`. Behaviour is unchanged.

## The problem

`NdefTagCodec` called `Ndef.from(tag)` at four sites, so none of its logic could run without a card: a fake tag makes `Ndef.from` return null and the null-assert throws. Its real decisions — refusing a locked tag, decoding a chunk, reporting capacity — had **no test coverage at all**.

`MifareTagCodec` already solved exactly this by taking an injected `MifareBlockIO? Function(NfcTag)`. This mirrors that.

## What changed

- New `NdefIO` interface over the members the app actually uses (`maxSize`, `isWritable`, `read`, `write`), plus an `ndefIoFor` adapter for production.
- `NdefTagCodec` takes the injected lookup instead of calling `Ndef.from` itself.
- The two remaining `Ndef.from` sites in `NfcRepository` converted as well — both use only `maxSize`/`isWritable`, so it's a one-for-one swap. This is what makes the seam's claim true: **`ndef_io.dart` is now the only file in `lib/` that names a platform NDEF class.**

## Why this is worth landing separately

`nfc_manager` v4 removes the platform-agnostic `Ndef` entirely, replacing it with `NdefAndroid` and `NdefIos` whose members diverge — `maxSize` vs `capacity`, a bool `isWritable` vs an `NdefStatusIos` enum. That divergence now has one place to live.

Test-merged onto the v4 branch and measured, so the effect is known rather than assumed:

| File | v4 errors before | v4 errors after |
|---|---|---|
| `ndef_tag_codec.dart` | 4 | **0** |
| `nfc_repository.dart` | 17 | 14 |
| `ndef_io.dart` *(new)* | — | 6 |

To be clear, the **total goes up** (38 → 45) because the seam and its tests are new code that must also be migrated. The win is redistribution, not reduction: the 6 errors in `ndef_io.dart` are all `Undefined class 'Ndef'`/`'NdefMessage'`, i.e. every Android/iOS divergence concentrated into one ~50-line file — and the 4 errors that vanished were in code nothing could verify without hardware.

## Verification

- 6 new tests, each watched failing first (two distinct red signals: `NdefIO not found`, then `Null check operator used on a null value` — which *is* the untestability being fixed)
- `flutter analyze`: 0 errors, 0 warnings
- `flutter test`: 256 pass, up from 250

## Known gap

The two `NfcRepository` call sites have no unit coverage — it's a session-driving singleton with no injection point, so they rest on the analyzer and the existing suite. Their behaviour is unchanged because `ndefIoFor` wraps `Ndef.from` one-for-one and every member delegates straight through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)