### PR TITLE
feat(nfc): migrate to nfc_manager 4.2.1

### DIFF
--- a/lib/features/nfc/data/nfc_repository.dart
+++ b/lib/features/nfc/data/nfc_repository.dart
@@ -2,12 +2,15 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:nfc_manager/nfc_manager.dart';
+import 'package:nfc_manager/nfc_manager_android.dart';
+import 'package:nfc_manager/nfc_manager_ios.dart';
 
 import '../../../core/constants/nfar_format.dart';
 import '../../../core/models/chunk.dart';
 import '../../../core/models/nfc_tag_info.dart';
 import '../domain/mifare_block_io.dart';
 import '../domain/mifare_tag_codec.dart';
+import '../domain/android_tech_list.dart';
 import '../domain/ndef_availability.dart';
 import '../domain/ndef_formatter.dart';
 import '../domain/ndef_io.dart';
@@ -91,8 +94,15 @@ class NfcRepository {
   }
 
   /// Check if NFC is available on this device.
+  ///
+  /// v4 deprecates the plugin's own `isAvailable()` in favour of
+  /// [NfcManager.checkAvailability], which distinguishes "NFC is switched off"
+  /// from "this device has no NFC at all". Collapsed back to a bool here to keep
+  /// every caller's meaning identical; the richer state is available to any
+  /// future caller that wants to tell the user which of the two it is.
   Future<bool> isAvailable() async {
-    return NfcManager.instance.isAvailable();
+    return await NfcManager.instance.checkAvailability() ==
+        NfcAvailability.enabled;
   }
 
   /// Start an NFC session for reading chunks.
@@ -115,7 +125,10 @@ class NfcRepository {
     final completer = Completer<void Function()>();
 
     NfcManager.instance.startSession(
-      alertMessage: alertMessage,
+      // Required in v4. v3 defaulted to `NfcPollingOption.values.toSet()`, so
+      // passing anything narrower here would silently stop discovering tags.
+      pollingOptions: NfcPollingOption.values.toSet(),
+      alertMessageIos: alertMessage,
       onDiscovered: (tag) async {
         // Ignore reads during write cooldown to prevent re-reading just-written tags
         if (isInWriteCooldown) {
@@ -144,7 +157,7 @@ class NfcRepository {
           onError('Failed to read tag: $e');
         }
       },
-      onError: (error) async {
+      onSessionErrorIos: (error) {
         onError(error.message);
       },
     );
@@ -188,7 +201,10 @@ class NfcRepository {
     final completer = Completer<void Function()>();
 
     NfcManager.instance.startSession(
-      alertMessage: alertMessage,
+      // Required in v4. v3 defaulted to `NfcPollingOption.values.toSet()`, so
+      // passing anything narrower here would silently stop discovering tags.
+      pollingOptions: NfcPollingOption.values.toSet(),
+      alertMessageIos: alertMessage,
       onDiscovered: (tag) async {
         try {
           final tagInfo = _extractTagInfo(tag);
@@ -296,7 +312,7 @@ class NfcRepository {
           onError('Failed to write tag: $e');
         }
       },
-      onError: (error) async {
+      onSessionErrorIos: (error) {
         onError(error.message);
       },
     );
@@ -419,8 +435,8 @@ class NfcRepository {
   /// Stop any active NFC session.
   void stopSession({String? message}) {
     NfcManager.instance.stopSession(
-      alertMessage: message,
-      errorMessage: null,
+      alertMessageIos: message,
+      errorMessageIos: null,
     );
   }
 
@@ -430,12 +446,20 @@ class NfcRepository {
   /// `MifareUltralight` tag whose NDEF detection failed is a good tag that was
   /// tapped badly, not one the user needs to replace.
   NdefUnavailableReason _ndefUnavailableReason(NfcTag tag) {
+    // v3 read these off an untyped map; v4 exposes a typed tech list. Same
+    // evidence, looked up by class name instead of map key.
+    final techList = NfcTagAndroid.from(tag)?.techList ?? const <String>[];
     return classifyNdefUnavailable(
-      hasNfcA: tag.data['nfca'] != null,
-      hasMifareUltralight: tag.data['mifareultralight'] != null,
+      hasNfcA: androidHasTech(techList, 'NfcA'),
+      hasMifareUltralight: androidHasTech(techList, 'MifareUltralight'),
       deviceSupportsMifare: _deviceSupportsMifare,
     );
   }
+
+  /// Colon-separated lowercase hex, matching the identifier format v3 produced
+  /// from the untyped map ('04:1a:2b:...').
+  String _hexId(List<int> id) =>
+      id.map((b) => b.toRadixString(16).padLeft(2, '0')).join(':');
 
   /// Extract tag info from NFC tag.
   NfcTagInfo _extractTagInfo(NfcTag tag) {
@@ -454,46 +478,34 @@ class NfcRepository {
       technologies.add('NDEF');
     }
 
-    // Try NfcA (Android)
-    final nfcAData = tag.data['nfca'];
-    final nfcA = nfcAData is Map ? Map<String, dynamic>.from(nfcAData) : null;
-    if (nfcA != null) {
-      final id = nfcA['identifier'] as List<dynamic>?;
-      if (id != null) {
-        identifier = id.map((b) => (b as int).toRadixString(16).padLeft(2, '0')).join(':');
+    // Android exposes the tag's identity and technology list up front; v3
+    // required probing an untyped map key per technology.
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      final atag = NfcTagAndroid.from(tag);
+      if (atag != null) {
+        if (atag.id.isNotEmpty) identifier = _hexId(atag.id);
+        technologies.addAll(androidTechLabels(atag.techList));
+
+        final ultralight = MifareUltralightAndroid.from(tag);
+        switch (ultralight?.type) {
+          case MifareUltralightTypeAndroid.ultralight:
+            tagType = NfcTagType.mifareUltralight;
+          case MifareUltralightTypeAndroid.ultralightC:
+            tagType = NfcTagType.mifareUltralightC;
+          case MifareUltralightTypeAndroid.unknown:
+          case null:
+            break;
+        }
       }
-      technologies.add('NfcA');
     }
 
-    // Try MifareUltralight (Android)
-    final mifareData = tag.data['mifareultralight'];
-    final mifare = mifareData is Map ? Map<String, dynamic>.from(mifareData) : null;
-    if (mifare != null) {
-      final type = mifare['type'] as int?;
-      if (type == 1) {
-        tagType = NfcTagType.mifareUltralight;
-      } else if (type == 2) {
-        tagType = NfcTagType.mifareUltralightC;
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      final iso15693 = Iso15693Ios.from(tag);
+      if (iso15693 != null) {
+        identifier = _hexId(iso15693.identifier);
+        technologies.add('ISO15693');
       }
-      technologies.add('MifareUltralight');
-    }
-
-    // Try ISO15693 (iOS)
-    final iso15693Data = tag.data['iso15693'];
-    final iso15693 = iso15693Data is Map ? Map<String, dynamic>.from(iso15693Data) : null;
-    if (iso15693 != null) {
-      final id = iso15693['identifier'] as List<dynamic>?;
-      if (id != null) {
-        identifier = id.map((b) => (b as int).toRadixString(16).padLeft(2, '0')).join(':');
-      }
-      technologies.add('ISO15693');
-    }
-
-    // Try FeliCa (iOS/Android)
-    final felicaData = tag.data['felica'];
-    final felica = felicaData is Map ? Map<String, dynamic>.from(felicaData) : null;
-    if (felica != null) {
-      technologies.add('FeliCa');
+      if (FeliCaIos.from(tag) != null) technologies.add('FeliCa');
     }
 
     // Infer tag type from capacity if not already set

--- a/lib/features/nfc/data/nfc_repository.dart
+++ b/lib/features/nfc/data/nfc_repository.dart
@@ -10,6 +10,7 @@ import '../domain/mifare_block_io.dart';
 import '../domain/mifare_tag_codec.dart';
 import '../domain/ndef_availability.dart';
 import '../domain/ndef_formatter.dart';
+import '../domain/ndef_io.dart';
 import '../domain/ndef_tag_codec.dart';
 import '../domain/tag_codec.dart';
 import 'nfc_capabilities.dart';
@@ -51,7 +52,7 @@ class NfcRepository {
   /// MifareClassic is unambiguously ours. NDEF handles everything else.
   final List<TagCodec> _codecs = [
     MifareTagCodec(mifareIoFor),
-    NdefTagCodec(),
+    NdefTagCodec(ndefIoFor),
   ];
 
   /// First codec that can handle this tag, or null.
@@ -235,7 +236,7 @@ class NfcRepository {
           // not the (1-4 byte stricter) `codec.capacityBytes(tag)` used below
           // for other media.
           if (codec is NdefTagCodec) {
-            final ndef = Ndef.from(tag)!;
+            final ndef = ndefIoFor(tag)!;
             if (!ndef.isWritable) {
               onError('Tag is not writable');
               return;
@@ -446,7 +447,7 @@ class NfcRepository {
 
     // Try to get NDEF info
     final codec = _codecFor(tag);
-    final ndef = codec != null ? Ndef.from(tag) : null;
+    final ndef = codec != null ? ndefIoFor(tag) : null;
     if (ndef != null) {
       capacity = ndef.maxSize;
       isWritable = ndef.isWritable;

--- a/lib/features/nfc/domain/android_tech_list.dart
+++ b/lib/features/nfc/domain/android_tech_list.dart
@@ -1,0 +1,28 @@
+/// Reading Android's tag technology list.
+///
+/// Android reports a tapped tag's technologies as fully-qualified Java class
+/// names — `android.nfc.tech.NfcA`, `android.nfc.tech.MifareUltralight`, and so
+/// on. `nfc_manager` v3 flattened that into an untyped map the app probed by
+/// key (`tag.data['nfca']`); v4 exposes `NfcTagAndroid.techList` as a typed
+/// `List<String>`, so the lookup lives here instead of being spread through the
+/// repository as map indexing.
+library;
+
+const String _androidTechPrefix = 'android.nfc.tech.';
+
+/// Whether the tag exposed [simpleName], e.g. `'NfcA'`.
+///
+/// Matches the whole class name rather than a substring: `'NfcA'` occurs inside
+/// `'android.nfc.tech.NfcAFoo'`, and a `contains` check would claim a
+/// technology the tag does not have.
+bool androidHasTech(List<String> techList, String simpleName) =>
+    techList.contains('$_androidTechPrefix$simpleName');
+
+/// The short technology names the app displays, in the order the platform
+/// reported them. A name without the usual package prefix passes through
+/// unchanged rather than being dropped.
+List<String> androidTechLabels(List<String> techList) => techList
+    .map((t) => t.startsWith(_androidTechPrefix)
+        ? t.substring(_androidTechPrefix.length)
+        : t)
+    .toList();

--- a/lib/features/nfc/domain/mifare_block_io.dart
+++ b/lib/features/nfc/domain/mifare_block_io.dart
@@ -1,7 +1,8 @@
 import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart';
 import 'package:nfc_manager/nfc_manager.dart';
-import 'package:nfc_manager/platform_tags.dart';
+import 'package:nfc_manager/nfc_manager_android.dart';
 
 /// Factory key A. Every card this app writes stays factory-keyed, because
 /// sector trailers are never written.
@@ -30,7 +31,7 @@ abstract interface class MifareBlockIO {
 /// Real implementation over `nfc_manager`.
 class NfcManagerMifareBlockIO implements MifareBlockIO {
   NfcManagerMifareBlockIO(this._mifare);
-  final MifareClassic _mifare;
+  final MifareClassicAndroid _mifare;
 
   @override
   Future<bool> authenticateSector(int sectorIndex, Uint8List keyA) =>
@@ -46,8 +47,17 @@ class NfcManagerMifareBlockIO implements MifareBlockIO {
 }
 
 /// Adapter used in production: null when the tag is not a Mifare Classic card,
-/// or when this phone's controller cannot talk CRYPTO1.
+/// when this phone's controller cannot talk CRYPTO1, or when the platform has no
+/// Mifare Classic support at all.
+///
+/// The Android guard is not belt-and-braces. `MifareClassicAndroid.from` casts
+/// `tag.data as TagPigeon?`, which THROWS on an iOS tag rather than returning
+/// null — and `MifareTagCodec.supports()` calls this for every tap, so an
+/// unguarded lookup would break codec selection on the first tag an iPhone sees.
+/// (Core NFC has no CRYPTO1, so iOS could never read these cards anyway; the
+/// point is to answer "no" instead of throwing.)
 MifareBlockIO? mifareIoFor(NfcTag tag) {
-  final mifare = MifareClassic.from(tag);
+  if (defaultTargetPlatform != TargetPlatform.android) return null;
+  final mifare = MifareClassicAndroid.from(tag);
   return mifare == null ? null : NfcManagerMifareBlockIO(mifare);
 }

--- a/lib/features/nfc/domain/ndef_formatter.dart
+++ b/lib/features/nfc/domain/ndef_formatter.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:nfc_manager/nfc_manager.dart';
+import 'package:nfc_manager/ndef_record.dart';
 
 import '../../../core/constants/nfar_format.dart';
 import '../../../core/models/chunk.dart';
@@ -26,13 +26,13 @@ class NdefFormatter {
     // The field values are the tag's contents and the web app writes the same
     // record for NTAG, so they are pinned by test/ndef_formatter_test.dart.
     final record = NdefRecord(
-      typeNameFormat: NdefTypeNameFormat.media,
+      typeNameFormat: TypeNameFormat.media,
       type: ascii.encode(nfarMimeType),
       identifier: Uint8List(0),
       payload: bytes,
     );
 
-    return NdefMessage([record]);
+    return NdefMessage(records: [record]);
   }
 
   /// Convert NDEF message to a Chunk.
@@ -51,8 +51,8 @@ class NdefFormatter {
       }
 
       // Also try to parse as raw binary (for backwards compatibility)
-      if (record.typeNameFormat == NdefTypeNameFormat.unknown ||
-          record.typeNameFormat == NdefTypeNameFormat.media) {
+      if (record.typeNameFormat == TypeNameFormat.unknown ||
+          record.typeNameFormat == TypeNameFormat.media) {
         try {
           final data = Uint8List.fromList(record.payload);
           if (validateMagic(data)) {
@@ -69,7 +69,7 @@ class NdefFormatter {
 
   /// Check if an NDEF record is an NFAR chunk.
   bool _isNfarRecord(NdefRecord record) {
-    if (record.typeNameFormat != NdefTypeNameFormat.media) {
+    if (record.typeNameFormat != TypeNameFormat.media) {
       return false;
     }
 

--- a/lib/features/nfc/domain/ndef_formatter.dart
+++ b/lib/features/nfc/domain/ndef_formatter.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:nfc_manager/nfc_manager.dart';
@@ -16,10 +17,19 @@ class NdefFormatter {
   NdefMessage chunkToNdef(Chunk chunk) {
     final bytes = chunk.toBytes();
 
-    // Create NDEF record with custom MIME type
-    final record = NdefRecord.createMime(
-      nfarMimeType,
-      bytes,
+    // Built explicitly rather than via `NdefRecord.createMime`, which
+    // nfc_manager v4 removes — `ndef_record` ships only the general
+    // constructor. These are the exact fields createMime produced: it
+    // normalises the type with `toLowerCase().trim().split(';').first`, a
+    // no-op for [nfarMimeType], then passes an empty identifier.
+    //
+    // The field values are the tag's contents and the web app writes the same
+    // record for NTAG, so they are pinned by test/ndef_formatter_test.dart.
+    final record = NdefRecord(
+      typeNameFormat: NdefTypeNameFormat.media,
+      type: ascii.encode(nfarMimeType),
+      identifier: Uint8List(0),
+      payload: bytes,
     );
 
     return NdefMessage([record]);
@@ -100,13 +110,6 @@ class NdefFormatter {
     return 1 + 1 + lengthBytes + typeSize + payloadSize;
   }
 
-
-  /// Create an empty NDEF message (for erasing tags).
-  NdefMessage createEmpty() {
-    return NdefMessage([
-      NdefRecord.createText(''),
-    ]);
-  }
 
   /// Parse metadata from NDEF message without fully parsing the chunk.
   ///

--- a/lib/features/nfc/domain/ndef_io.dart
+++ b/lib/features/nfc/domain/ndef_io.dart
@@ -1,0 +1,51 @@
+import 'package:nfc_manager/nfc_manager.dart';
+
+/// Narrow NDEF access to a tag.
+///
+/// Exists for the same reason as [MifareBlockIO]: `nfc_manager`'s `Ndef` cannot
+/// be constructed in a test, so a codec that calls `Ndef.from(tag)` directly is
+/// only exercisable with a card in hand. Injecting the lookup instead lets the
+/// codec's real logic run against a fake.
+///
+/// It also isolates the one place that names a platform NDEF class. `nfc_manager`
+/// v4 replaces the platform-agnostic `Ndef` with separate `NdefAndroid` and
+/// `NdefIos` types whose members differ (`maxSize` vs `capacity`, a bool
+/// `isWritable` vs an `NdefStatusIos` enum), so that migration becomes a change
+/// to the adapter below rather than to every call site.
+abstract interface class NdefIO {
+  /// Capacity of the NDEF *message* area, in bytes.
+  int get maxSize;
+
+  /// Whether the tag will accept a write.
+  bool get isWritable;
+
+  /// Read the stored NDEF message.
+  Future<NdefMessage> read();
+
+  /// Replace the stored NDEF message. Throws on failure.
+  Future<void> write(NdefMessage message);
+}
+
+/// Real implementation over `nfc_manager`.
+class NfcManagerNdefIO implements NdefIO {
+  NfcManagerNdefIO(this._ndef);
+  final Ndef _ndef;
+
+  @override
+  int get maxSize => _ndef.maxSize;
+
+  @override
+  bool get isWritable => _ndef.isWritable;
+
+  @override
+  Future<NdefMessage> read() => _ndef.read();
+
+  @override
+  Future<void> write(NdefMessage message) => _ndef.write(message);
+}
+
+/// Adapter used in production: null when the tag carries no NDEF technology.
+NdefIO? ndefIoFor(NfcTag tag) {
+  final ndef = Ndef.from(tag);
+  return ndef == null ? null : NfcManagerNdefIO(ndef);
+}

--- a/lib/features/nfc/domain/ndef_io.dart
+++ b/lib/features/nfc/domain/ndef_io.dart
@@ -1,17 +1,22 @@
+import 'package:flutter/foundation.dart';
+import 'package:nfc_manager/ndef_record.dart';
 import 'package:nfc_manager/nfc_manager.dart';
+import 'package:nfc_manager/nfc_manager_android.dart';
+import 'package:nfc_manager/nfc_manager_ios.dart';
 
 /// Narrow NDEF access to a tag.
 ///
-/// Exists for the same reason as [MifareBlockIO]: `nfc_manager`'s `Ndef` cannot
-/// be constructed in a test, so a codec that calls `Ndef.from(tag)` directly is
+/// Exists for the same reason as [MifareBlockIO]: the platform NDEF classes
+/// cannot be constructed in a test, so a codec that reaches for them directly is
 /// only exercisable with a card in hand. Injecting the lookup instead lets the
 /// codec's real logic run against a fake.
 ///
-/// It also isolates the one place that names a platform NDEF class. `nfc_manager`
-/// v4 replaces the platform-agnostic `Ndef` with separate `NdefAndroid` and
-/// `NdefIos` types whose members differ (`maxSize` vs `capacity`, a bool
-/// `isWritable` vs an `NdefStatusIos` enum), so that migration becomes a change
-/// to the adapter below rather than to every call site.
+/// It is also the one place in `lib/` that names a platform NDEF class.
+/// `nfc_manager` v4 dropped the platform-agnostic `Ndef` in favour of
+/// [NdefAndroid] and [NdefIos], whose members diverge in both name and shape —
+/// `maxSize` vs `capacity`, a bool `isWritable` vs an [NdefStatusIos] enum,
+/// `getNdefMessage`/`writeNdefMessage` vs `readNdef`/`writeNdef`. Everything
+/// above this file is spared that split.
 abstract interface class NdefIO {
   /// Capacity of the NDEF *message* area, in bytes.
   int get maxSize;
@@ -19,17 +24,31 @@ abstract interface class NdefIO {
   /// Whether the tag will accept a write.
   bool get isWritable;
 
-  /// Read the stored NDEF message.
+  /// Read the stored NDEF message. A tag holding none reads as an empty
+  /// message, never null — see [ndefMessageOrEmpty].
   Future<NdefMessage> read();
 
   /// Replace the stored NDEF message. Throws on failure.
   Future<void> write(NdefMessage message);
 }
 
-/// Real implementation over `nfc_manager`.
-class NfcManagerNdefIO implements NdefIO {
-  NfcManagerNdefIO(this._ndef);
-  final Ndef _ndef;
+/// v3's `read()` returned a non-null message; v4 returns null when the tag holds
+/// none. The app's existing meaning for a blank tag is "no chunk here", which
+/// `NdefFormatter.ndefToChunk` already reports for a message with no records —
+/// so null collapses to empty rather than propagating and crashing a null-check.
+NdefMessage ndefMessageOrEmpty(NdefMessage? message) =>
+    message ?? const NdefMessage(records: []);
+
+/// iOS reports writability as a tri-state. Only [NdefStatusIos.readWrite]
+/// accepts a write; treating `readOnly` or `notSupported` as writable would let
+/// the codec attempt a write the tag then rejects.
+bool isWritableIosStatus(NdefStatusIos status) =>
+    status == NdefStatusIos.readWrite;
+
+/// Android's NDEF technology.
+class AndroidNdefIO implements NdefIO {
+  AndroidNdefIO(this._ndef);
+  final NdefAndroid _ndef;
 
   @override
   int get maxSize => _ndef.maxSize;
@@ -38,14 +57,46 @@ class NfcManagerNdefIO implements NdefIO {
   bool get isWritable => _ndef.isWritable;
 
   @override
-  Future<NdefMessage> read() => _ndef.read();
+  Future<NdefMessage> read() async =>
+      ndefMessageOrEmpty(await _ndef.getNdefMessage());
 
   @override
-  Future<void> write(NdefMessage message) => _ndef.write(message);
+  Future<void> write(NdefMessage message) => _ndef.writeNdefMessage(message);
+}
+
+/// iOS's NDEF technology.
+class IosNdefIO implements NdefIO {
+  IosNdefIO(this._ndef);
+  final NdefIos _ndef;
+
+  @override
+  int get maxSize => _ndef.capacity;
+
+  @override
+  bool get isWritable => isWritableIosStatus(_ndef.status);
+
+  @override
+  Future<NdefMessage> read() async =>
+      ndefMessageOrEmpty(await _ndef.readNdef());
+
+  @override
+  Future<void> write(NdefMessage message) => _ndef.writeNdef(message);
 }
 
 /// Adapter used in production: null when the tag carries no NDEF technology.
+///
+/// Dispatches on the host platform rather than trying both, because
+/// `NdefAndroid.from` and `NdefIos.from` each cast `tag.data` to their own
+/// platform's payload type and would throw on the other's tag.
 NdefIO? ndefIoFor(NfcTag tag) {
-  final ndef = Ndef.from(tag);
-  return ndef == null ? null : NfcManagerNdefIO(ndef);
+  switch (defaultTargetPlatform) {
+    case TargetPlatform.android:
+      final ndef = NdefAndroid.from(tag);
+      return ndef == null ? null : AndroidNdefIO(ndef);
+    case TargetPlatform.iOS:
+      final ndef = NdefIos.from(tag);
+      return ndef == null ? null : IosNdefIO(ndef);
+    default:
+      return null;
+  }
 }

--- a/lib/features/nfc/domain/ndef_tag_codec.dart
+++ b/lib/features/nfc/domain/ndef_tag_codec.dart
@@ -3,24 +3,27 @@ import 'package:nfc_manager/nfc_manager.dart';
 import '../../../core/constants/nfar_format.dart';
 import '../../../core/models/chunk.dart';
 import 'ndef_formatter.dart';
+import 'ndef_io.dart';
 import 'tag_codec.dart';
 
 /// NDEF-backed tags: NTAG213/215/216 and Mifare Ultralight.
 class NdefTagCodec implements TagCodec {
-  NdefTagCodec([NdefFormatter? formatter])
+  NdefTagCodec(this._ioFor, [NdefFormatter? formatter])
       : _formatter = formatter ?? NdefFormatter.instance;
 
+  /// Injected so the codec is testable without a card — see [NdefIO].
+  final NdefIO? Function(NfcTag tag) _ioFor;
   final NdefFormatter _formatter;
 
   @override
   String get name => 'NDEF';
 
   @override
-  bool supports(NfcTag tag) => Ndef.from(tag) != null;
+  bool supports(NfcTag tag) => _ioFor(tag) != null;
 
   @override
   Future<int> capacityBytes(NfcTag tag) async {
-    final ndef = Ndef.from(tag)!;
+    final ndef = _ioFor(tag)!;
     // ndef.maxSize is the NDEF *message* capacity. Subtract the record overhead
     // and the terminator byte to get the chunk bytes that actually fit.
     //
@@ -37,13 +40,13 @@ class NdefTagCodec implements TagCodec {
 
   @override
   Future<Chunk?> readChunk(NfcTag tag) async {
-    final ndef = Ndef.from(tag)!;
+    final ndef = _ioFor(tag)!;
     return _formatter.ndefToChunk(await ndef.read());
   }
 
   @override
   Future<void> writeChunk(NfcTag tag, Chunk chunk) async {
-    final ndef = Ndef.from(tag)!;
+    final ndef = _ioFor(tag)!;
     if (!ndef.isWritable) {
       throw StateError('Tag is not writable');
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -525,14 +525,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.4.4"
+  ndef_record:
+    dependency: transitive
+    description:
+      name: ndef_record
+      sha256: "210ffb12284961cab9e44b99462143316d9a20cd992581170706069ef77d74a6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.2"
   nfc_manager:
     dependency: "direct main"
     description:
       name: nfc_manager
-      sha256: "071faa6e43317f9feeef316067456ae6e61a40f7748ed6e93470a812e103c326"
+      sha256: "1b8d3788ed71bb34f59878a445e433891eb2268353289515c1542b2780151fe6"
       url: "https://pub.dev"
     source: hosted
-    version: "3.5.1"
+    version: "4.2.1"
   package_config:
     dependency: transitive
     description:
@@ -1075,5 +1083,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
+  dart: ">=3.11.4 <4.0.0"
   flutter: ">=3.41.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   riverpod_annotation: ^2.3.3
 
   # NFC
-  nfc_manager: ^3.5.1
+  nfc_manager: ^4.2.1
 
   # Bluetooth LE (Chameleon Ultra). BSD-3-Clause — flutter_blue_plus is NOT
   # an option: its licence is non-free and F-Droid would reject the app.

--- a/test/android_tech_list_test.dart
+++ b/test/android_tech_list_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nfc_archiver/features/nfc/domain/android_tech_list.dart';
+
+/// Android reports a tapped tag's technologies as fully-qualified Java class
+/// names. nfc_manager v3 flattened that into an untyped map whose keys the app
+/// probed by hand (`tag.data['nfca']`); v4 exposes `NfcTagAndroid.techList`
+/// directly, so the lookup moves here where it can be tested.
+///
+/// Getting this wrong is quiet rather than loud: a mis-spelled tech name simply
+/// never matches, and the app decides a good tag lacks NfcA — which feeds
+/// `classifyNdefUnavailable` and changes the advice shown to the user.
+void main() {
+  // A real Android NTAG215 tech list.
+  const ntag215 = [
+    'android.nfc.tech.NfcA',
+    'android.nfc.tech.MifareUltralight',
+    'android.nfc.tech.Ndef',
+  ];
+
+  group('androidHasTech', () {
+    test('matches a tech present on the tag', () {
+      expect(androidHasTech(ntag215, 'NfcA'), isTrue);
+      expect(androidHasTech(ntag215, 'MifareUltralight'), isTrue);
+    });
+
+    test('does not match a tech the tag lacks', () {
+      expect(androidHasTech(ntag215, 'MifareClassic'), isFalse);
+    });
+
+    test('matches on the full class name, not a bare substring', () {
+      // 'NfcA' is a substring of 'android.nfc.tech.NfcAFoo'; a contains() check
+      // would report a tech the tag does not have.
+      expect(androidHasTech(['android.nfc.tech.NfcAFoo'], 'NfcA'), isFalse);
+    });
+
+    test('an empty tech list matches nothing', () {
+      expect(androidHasTech(const [], 'NfcA'), isFalse);
+    });
+  });
+
+  group('androidTechLabels', () {
+    test('renders the short names the app displays', () {
+      expect(androidTechLabels(ntag215), ['NfcA', 'MifareUltralight', 'Ndef']);
+    });
+
+    test('preserves the order the platform reported', () {
+      expect(
+        androidTechLabels(
+            ['android.nfc.tech.Ndef', 'android.nfc.tech.NfcA']),
+        ['Ndef', 'NfcA'],
+      );
+    });
+
+    test('passes through a name that carries no package prefix', () {
+      expect(androidTechLabels(['NfcB']), ['NfcB']);
+    });
+  });
+}

--- a/test/mifare_tag_codec_test.dart
+++ b/test/mifare_tag_codec_test.dart
@@ -9,7 +9,7 @@ import 'package:nfc_manager/nfc_manager.dart';
 
 /// nfc_manager exposes a const NfcTag constructor explicitly for testing.
 // ignore: non_constant_identifier_names
-NfcTag FakeTag() => const NfcTag(handle: 'test', data: <String, dynamic>{});
+NfcTag FakeTag() => const NfcTag(data: <String, dynamic>{});
 
 /// In-memory Mifare Classic 1K: 64 blocks of 16 bytes, factory-keyed.
 class FakeMifareBlockIO implements MifareBlockIO {

--- a/test/ndef_formatter_test.dart
+++ b/test/ndef_formatter_test.dart
@@ -8,7 +8,6 @@ import 'package:nfc_archiver/core/nfc/ndef_bytes.dart';
 import 'package:nfc_archiver/core/services/checksum_service.dart';
 import 'package:nfc_archiver/features/nfc/domain/ndef_formatter.dart';
 import 'package:nfc_manager/ndef_record.dart';
-import 'package:nfc_manager/nfc_manager.dart';
 
 /// Characterization tests for the bytes `NdefFormatter` puts on a tag.
 ///

--- a/test/ndef_formatter_test.dart
+++ b/test/ndef_formatter_test.dart
@@ -1,0 +1,138 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nfc_archiver/core/constants/nfar_format.dart';
+import 'package:nfc_archiver/core/models/chunk.dart';
+import 'package:nfc_archiver/core/nfc/ndef_bytes.dart';
+import 'package:nfc_archiver/core/services/checksum_service.dart';
+import 'package:nfc_archiver/features/nfc/domain/ndef_formatter.dart';
+import 'package:nfc_manager/nfc_manager.dart';
+
+/// Characterization tests for the bytes `NdefFormatter` puts on a tag.
+///
+/// These pin the exact NDEF record fields rather than merely round-tripping,
+/// because a round-trip is self-consistent: the app could change what it writes
+/// and still read its own output perfectly while silently diverging from the
+/// web app, which writes the same MIME record for NTAG (`webapp/src/nfc/ndef.ts`).
+///
+/// They exist so `chunkToNdef` can stop depending on `NdefRecord.createMime`,
+/// which `nfc_manager` v4 removes (`ndef_record 1.4.2` ships only the general
+/// constructor). Building the record explicitly must reproduce createMime's
+/// output field for field; that is what these assert.
+
+Chunk makeChunk(int payloadLen) {
+  final payload =
+      Uint8List.fromList(List.generate(payloadLen, (i) => (i * 7 + 5) % 256));
+  return Chunk(
+    archiveId: Uint8List(16)..fillRange(0, 16, 0xAB),
+    totalChunks: 3,
+    chunkIndex: 2,
+    payload: payload,
+    crc32: ChecksumService.instance.calculate(payload),
+  );
+}
+
+void main() {
+  final formatter = NdefFormatter.instance;
+
+  test('chunkToNdef emits exactly one record', () {
+    final message = formatter.chunkToNdef(makeChunk(64));
+    expect(message.records, hasLength(1));
+  });
+
+  test('the record is a media record typed with the NFAR MIME string', () {
+    final record = formatter.chunkToNdef(makeChunk(64)).records.single;
+
+    expect(record.typeNameFormat, NdefTypeNameFormat.media);
+    expect(record.type, ascii.encode(nfarMimeType));
+    expect(String.fromCharCodes(record.type),
+        'application/vnd.nfcarchiver.chunk');
+  });
+
+  test('the record carries no identifier', () {
+    // createMime passes an empty identifier. A non-empty one would add an ID
+    // length byte to the header and shift every following byte on the tag.
+    final record = formatter.chunkToNdef(makeChunk(64)).records.single;
+    expect(record.identifier, isEmpty);
+  });
+
+  test('the payload is the serialized chunk, unmodified', () {
+    final chunk = makeChunk(200);
+    final record = formatter.chunkToNdef(chunk).records.single;
+
+    expect(record.payload, chunk.toBytes());
+  });
+
+  test('a written record reads back as the same chunk', () {
+    final chunk = makeChunk(120);
+    final read = formatter.ndefToChunk(formatter.chunkToNdef(chunk));
+
+    expect(read, isNotNull);
+    expect(read!.payload, chunk.payload);
+    expect(read.archiveId, chunk.archiveId);
+    expect(read.chunkIndex, chunk.chunkIndex);
+    expect(read.totalChunks, chunk.totalChunks);
+  });
+
+  test('a written record is recognised as holding an NFAR chunk', () {
+    expect(formatter.containsNfarChunk(formatter.chunkToNdef(makeChunk(64))),
+        isTrue);
+  });
+
+  group('agrees with the byte-level encoder used for the Chameleon', () {
+    // NdefFormatter drives the phone path (nfc_manager hands over parsed
+    // objects); encodeNdefMime drives the Chameleon path (raw pages over BLE)
+    // and is the port of webapp/src/nfc/ndef.ts. Both write the same logical
+    // record onto the same kind of tag, and until now nothing asserted they
+    // agree — a tag written by the phone had to stay readable by the web app
+    // purely on the strength of two independent implementations matching.
+
+    /// TNF is the low 3 bits of the NDEF header byte; 0x02 is media.
+    int tnfOf(Uint8List record) => record[0] & 0x07;
+
+    test('both declare TNF media', () {
+      final chunk = makeChunk(64);
+      final record = formatter.chunkToNdef(chunk).records.single;
+
+      expect(tnfOf(encodeNdefMime(chunk.toBytes())), 0x02);
+      expect(record.typeNameFormat, NdefTypeNameFormat.media);
+    });
+
+    test('both use the same MIME type bytes', () {
+      final chunk = makeChunk(64);
+      final raw = encodeNdefMime(chunk.toBytes());
+      final typeLen = raw[1];
+      // header(1) + typeLen(1) + payloadLen(1 when short) = 3
+      final rawType = raw.sublist(3, 3 + typeLen);
+
+      expect(rawType, formatter.chunkToNdef(chunk).records.single.type);
+    });
+
+    test('both carry the identical payload', () {
+      for (final len in [16, 200, 255, 256, 700]) {
+        final chunk = makeChunk(len);
+        final bytes = chunk.toBytes();
+        final raw = encodeNdefMime(bytes);
+        final short = bytes.length < 256;
+        final payloadStart = 2 + (short ? 1 : 4) + raw[1];
+
+        expect(raw.sublist(payloadStart),
+            formatter.chunkToNdef(chunk).records.single.payload,
+            reason: 'payload $len must match across both encoders');
+      }
+    });
+  });
+
+  test('requiredNdefSize matches what the record actually costs', () {
+    // The live write path compares this against `ndef.maxSize` to decide
+    // whether a chunk fits, so it must not under-report the real record.
+    for (final len in [16, 200, 255, 256, 700]) {
+      final chunk = makeChunk(len);
+      final record = formatter.chunkToNdef(chunk).records.single;
+
+      expect(formatter.requiredNdefSize(chunk), greaterThanOrEqualTo(record.byteLength),
+          reason: 'payload $len must not be under-reported');
+    }
+  });
+}

--- a/test/ndef_formatter_test.dart
+++ b/test/ndef_formatter_test.dart
@@ -7,6 +7,7 @@ import 'package:nfc_archiver/core/models/chunk.dart';
 import 'package:nfc_archiver/core/nfc/ndef_bytes.dart';
 import 'package:nfc_archiver/core/services/checksum_service.dart';
 import 'package:nfc_archiver/features/nfc/domain/ndef_formatter.dart';
+import 'package:nfc_manager/ndef_record.dart';
 import 'package:nfc_manager/nfc_manager.dart';
 
 /// Characterization tests for the bytes `NdefFormatter` puts on a tag.
@@ -44,7 +45,7 @@ void main() {
   test('the record is a media record typed with the NFAR MIME string', () {
     final record = formatter.chunkToNdef(makeChunk(64)).records.single;
 
-    expect(record.typeNameFormat, NdefTypeNameFormat.media);
+    expect(record.typeNameFormat, TypeNameFormat.media);
     expect(record.type, ascii.encode(nfarMimeType));
     expect(String.fromCharCodes(record.type),
         'application/vnd.nfcarchiver.chunk');
@@ -96,7 +97,7 @@ void main() {
       final record = formatter.chunkToNdef(chunk).records.single;
 
       expect(tnfOf(encodeNdefMime(chunk.toBytes())), 0x02);
-      expect(record.typeNameFormat, NdefTypeNameFormat.media);
+      expect(record.typeNameFormat, TypeNameFormat.media);
     });
 
     test('both use the same MIME type bytes', () {

--- a/test/ndef_io_test.dart
+++ b/test/ndef_io_test.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nfc_archiver/features/nfc/domain/ndef_io.dart';
+import 'package:nfc_manager/ndef_record.dart';
+import 'package:nfc_manager/nfc_manager_ios.dart';
+
+/// The two places nfc_manager v4 changed meaning rather than just names.
+///
+/// The adapters themselves wrap `NdefAndroid`/`NdefIos`, which cannot be
+/// constructed in a test — that is the whole reason [NdefIO] exists. So the
+/// decisions are extracted as pure functions and pinned here; the adapters are
+/// left as thin delegation with nothing to get wrong.
+void main() {
+  group('a tag with no message reads as empty, not as an error', () {
+    // v3's `Ndef.read()` returned a non-null NdefMessage. v4's
+    // `getNdefMessage()` / `readNdef()` return null for a tag that holds no
+    // message. Surfacing that null would turn a blank tag into a crash at
+    // `ndefToChunk`; the app's existing meaning is "no chunk here".
+
+    test('null becomes a message with no records', () {
+      expect(ndefMessageOrEmpty(null).records, isEmpty);
+    });
+
+    test('a real message passes through untouched', () {
+      final message = NdefMessage(records: [
+        NdefRecord(
+          typeNameFormat: TypeNameFormat.media,
+          type: ascii.encode('text/plain'),
+          identifier: Uint8List(0),
+          payload: ascii.encode('hi'),
+        )
+      ]);
+
+      expect(ndefMessageOrEmpty(message), same(message));
+    });
+  });
+
+  group('iOS writability is a tri-state, not a bool', () {
+    // Android exposes `isWritable`. iOS exposes `NdefStatusIos`, and only
+    // readWrite accepts a write — collapsing the other two to "writable" would
+    // make the codec attempt a write that the tag rejects.
+
+    test('readWrite is writable', () {
+      expect(isWritableIosStatus(NdefStatusIos.readWrite), isTrue);
+    });
+
+    test('readOnly is not writable', () {
+      expect(isWritableIosStatus(NdefStatusIos.readOnly), isFalse);
+    });
+
+    test('notSupported is not writable', () {
+      expect(isWritableIosStatus(NdefStatusIos.notSupported), isFalse);
+    });
+  });
+}

--- a/test/ndef_tag_codec_test.dart
+++ b/test/ndef_tag_codec_test.dart
@@ -27,7 +27,7 @@ class FakeNdefIO implements NdefIO {
   final List<NdefMessage> writes = [];
 
   @override
-  Future<NdefMessage> read() async => stored ?? NdefMessage(records: []);
+  Future<NdefMessage> read() async => stored ?? const NdefMessage(records: []);
 
   @override
   Future<void> write(NdefMessage message) async {
@@ -76,7 +76,7 @@ void main() {
   });
 
   test('readChunk returns null when the tag holds no NFAR record', () async {
-    final io = FakeNdefIO(stored: NdefMessage(records: []));
+    final io = FakeNdefIO(stored: const NdefMessage(records: []));
     final codec = NdefTagCodec((_) => io);
 
     expect(await codec.readChunk(fakeTag()), isNull);

--- a/test/ndef_tag_codec_test.dart
+++ b/test/ndef_tag_codec_test.dart
@@ -5,10 +5,11 @@ import 'package:nfc_archiver/core/models/chunk.dart';
 import 'package:nfc_archiver/core/services/checksum_service.dart';
 import 'package:nfc_archiver/features/nfc/domain/ndef_io.dart';
 import 'package:nfc_archiver/features/nfc/domain/ndef_tag_codec.dart';
+import 'package:nfc_manager/ndef_record.dart';
 import 'package:nfc_manager/nfc_manager.dart';
 
 /// nfc_manager exposes a const NfcTag constructor explicitly for testing.
-NfcTag fakeTag() => const NfcTag(handle: 'test', data: <String, dynamic>{});
+NfcTag fakeTag() => const NfcTag(data: <String, dynamic>{});
 
 /// In-memory NDEF tag. Mirrors `FakeMifareBlockIO`: the codec's real logic runs
 /// against it, so everything above the platform boundary is testable without a
@@ -26,7 +27,7 @@ class FakeNdefIO implements NdefIO {
   final List<NdefMessage> writes = [];
 
   @override
-  Future<NdefMessage> read() async => stored ?? NdefMessage([]);
+  Future<NdefMessage> read() async => stored ?? NdefMessage(records: []);
 
   @override
   Future<void> write(NdefMessage message) async {
@@ -75,7 +76,7 @@ void main() {
   });
 
   test('readChunk returns null when the tag holds no NFAR record', () async {
-    final io = FakeNdefIO(stored: NdefMessage([]));
+    final io = FakeNdefIO(stored: NdefMessage(records: []));
     final codec = NdefTagCodec((_) => io);
 
     expect(await codec.readChunk(fakeTag()), isNull);

--- a/test/ndef_tag_codec_test.dart
+++ b/test/ndef_tag_codec_test.dart
@@ -1,0 +1,102 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nfc_archiver/core/models/chunk.dart';
+import 'package:nfc_archiver/core/services/checksum_service.dart';
+import 'package:nfc_archiver/features/nfc/domain/ndef_io.dart';
+import 'package:nfc_archiver/features/nfc/domain/ndef_tag_codec.dart';
+import 'package:nfc_manager/nfc_manager.dart';
+
+/// nfc_manager exposes a const NfcTag constructor explicitly for testing.
+NfcTag fakeTag() => const NfcTag(handle: 'test', data: <String, dynamic>{});
+
+/// In-memory NDEF tag. Mirrors `FakeMifareBlockIO`: the codec's real logic runs
+/// against it, so everything above the platform boundary is testable without a
+/// card. `Ndef` itself cannot be constructed in a test, which is the whole
+/// reason this seam exists.
+class FakeNdefIO implements NdefIO {
+  FakeNdefIO({this.maxSize = 868, this.isWritable = true, this.stored});
+
+  @override
+  final int maxSize;
+  @override
+  final bool isWritable;
+
+  NdefMessage? stored;
+  final List<NdefMessage> writes = [];
+
+  @override
+  Future<NdefMessage> read() async => stored ?? NdefMessage([]);
+
+  @override
+  Future<void> write(NdefMessage message) async {
+    writes.add(message);
+    stored = message;
+  }
+}
+
+Chunk makeChunk(int payloadLen) {
+  final payload =
+      Uint8List.fromList(List.generate(payloadLen, (i) => (i + 3) % 256));
+  return Chunk(
+    archiveId: Uint8List(16)..fillRange(0, 16, 7),
+    totalChunks: 2,
+    chunkIndex: 1,
+    payload: payload,
+    crc32: ChecksumService.instance.calculate(payload),
+  );
+}
+
+void main() {
+  test('writeChunk refuses a tag that is not writable', () async {
+    final io = FakeNdefIO(isWritable: false);
+    final codec = NdefTagCodec((_) => io);
+
+    await expectLater(
+      () => codec.writeChunk(fakeTag(), makeChunk(64)),
+      throwsStateError,
+    );
+    expect(io.writes, isEmpty, reason: 'nothing may be written to a locked tag');
+  });
+
+  test('write then read round-trips a chunk', () async {
+    final io = FakeNdefIO();
+    final codec = NdefTagCodec((_) => io);
+    final chunk = makeChunk(120);
+
+    await codec.writeChunk(fakeTag(), chunk);
+    final read = await codec.readChunk(fakeTag());
+
+    expect(read, isNotNull);
+    expect(read!.payload, chunk.payload);
+    expect(read.chunkIndex, chunk.chunkIndex);
+    expect(read.totalChunks, chunk.totalChunks);
+    expect(read.archiveId, chunk.archiveId);
+  });
+
+  test('readChunk returns null when the tag holds no NFAR record', () async {
+    final io = FakeNdefIO(stored: NdefMessage([]));
+    final codec = NdefTagCodec((_) => io);
+
+    expect(await codec.readChunk(fakeTag()), isNull);
+  });
+
+  test('does not claim a tag that carries no NDEF technology', () {
+    expect(NdefTagCodec((_) => null).supports(fakeTag()), isFalse);
+  });
+
+  test('claims a tag that carries NDEF', () {
+    expect(NdefTagCodec((_) => FakeNdefIO()).supports(fakeTag()), isTrue);
+  });
+
+  test('capacityBytes is derived from the tag NDEF message capacity', () async {
+    // NTAG215's 496-byte message area. The codec reports *chunk* bytes, so the
+    // answer must be smaller than maxSize — the record overhead comes off.
+    final codec = NdefTagCodec((_) => FakeNdefIO(maxSize: 496));
+
+    final capacity = await codec.capacityBytes(fakeTag());
+
+    expect(capacity, lessThan(496));
+    expect(capacity, greaterThan(0));
+  });
+}

--- a/test/platform_tag_dispatch_test.dart
+++ b/test/platform_tag_dispatch_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nfc_archiver/features/nfc/domain/mifare_block_io.dart';
+import 'package:nfc_archiver/features/nfc/domain/ndef_io.dart';
+import 'package:nfc_manager/nfc_manager.dart';
+
+/// Platform dispatch in the two tag-technology lookups.
+///
+/// nfc_manager v4 made this load-bearing. Each platform's `from()` casts
+/// `tag.data` to *its own* platform's payload type:
+///
+///     final data = tag.data as TagPigeon?;
+///
+/// That cast THROWS on the other platform's tag — it does not return null. So a
+/// lookup that simply calls `MifareClassicAndroid.from(tag)` blows up on iOS,
+/// and since `MifareTagCodec.supports()` runs for every tap, it would take out
+/// codec selection on the first tag an iPhone sees.
+///
+/// v3's classes were platform-agnostic and returned null, so nothing upstream
+/// ever had to know. These tests pin the guards that keep that true.
+void main() {
+  NfcTag fakeTag() => const NfcTag(data: <String, dynamic>{});
+
+  tearDown(() => debugDefaultTargetPlatformOverride = null);
+
+  test('mifareIoFor yields null on iOS rather than casting an iOS tag', () {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    expect(mifareIoFor(fakeTag()), isNull);
+  });
+
+  test('ndefIoFor yields null on an unsupported platform', () {
+    debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+    expect(ndefIoFor(fakeTag()), isNull);
+  });
+
+  test('mifareIoFor yields null on an unsupported platform', () {
+    debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+    expect(mifareIoFor(fakeTag()), isNull);
+  });
+}

--- a/test/tag_codec_selection_test.dart
+++ b/test/tag_codec_selection_test.dart
@@ -8,7 +8,7 @@ import 'package:nfc_manager/nfc_manager.dart';
 /// Duplicated from mifare_tag_codec_test.dart (see Task 6 brief: Dart test
 /// files cannot cleanly import each other's private helpers) as lowerCamelCase
 /// to avoid the non_constant_identifier_names ignore that file needed.
-NfcTag fakeTag() => const NfcTag(handle: 'test', data: <String, dynamic>{});
+NfcTag fakeTag() => const NfcTag(data: <String, dynamic>{});
 
 void main() {
   test('Mifare is tried before NDEF', () {


### PR DESCRIPTION
Single PR superseding **#70** (the Dependabot bump), **#74** (NdefIO seam) and **#75** (explicit NDEF record). Their commits are contained here, so those three can be closed once this lands.

The bump alone produced **38 analyzer errors**. Rather than one large change, the two riskiest pieces were done first on the *current* dependency, where they were verifiable against an unchanged web app — then the version moved.

## What v4 changes

v4 removes the platform-agnostic tag classes:

| v3 | v4 |
|---|---|
| `Ndef` | `NdefAndroid` / `NdefIos` — `maxSize` vs `capacity`, bool `isWritable` vs `NdefStatusIos`, `getNdefMessage`/`writeNdefMessage` vs `readNdef`/`writeNdef` |
| `MifareClassic` | `MifareClassicAndroid` |
| `NdefMessage`, `NdefRecord` | moved to the `ndef_record` package; `createMime` removed |
| `tag.data['nfca']` | opaque `Object` behind typed per-platform accessors |

## Behaviour preserved at three points where v4 would change it quietly

- **`pollingOptions` is now required.** v3's source does `pollingOptions ??= NfcPollingOption.values.toSet()` — all three. Anything narrower would compile, pass every test, and simply stop discovering tags on hardware. All three are passed explicitly.
- **v4's NDEF read returns null** for a tag holding no message, where v3 returned a non-null message. `ndefMessageOrEmpty` collapses null to an empty message — which `ndefToChunk` already reports as "no chunk" — instead of letting it reach a null-check.
- **iOS writability is a tri-state.** `isWritableIosStatus` treats only `readWrite` as writable; folding `readOnly`/`notSupported` into "writable" would attempt writes the tag rejects.

## A crash this fixes before it ships

Each platform's `from()` casts `tag.data` to its **own** platform's payload type and **throws** on the other's tag rather than returning null:

```dart
final data = tag.data as TagPigeon?;   // TypeError on an iOS tag
```

`MifareTagCodec.supports()` runs for every tap, so an unguarded `MifareClassicAndroid.from` would break codec selection on the first tag an iPhone saw. Both lookups now dispatch on `defaultTargetPlatform`. Found by writing the test first — the red was `type '_ConstMap<String, dynamic>' is not a subtype of type 'TagPigeon?'`.

## A correction to the earlier scoping

The scoping pass called out "Android loses its session error channel" as the migration's biggest decision. That was wrong. v3's own doc comment reads:

> `(iOS only) onError is called when the session is stopped for some reason after the session has started.`

`onError` was **already iOS-only**. Android had nothing to lose; v4's `onSessionErrorIos` only renames it to say so.

## Also

- `_extractTagInfo` reads `NfcTagAndroid.id`/`.techList` and the iOS tag classes instead of indexing an untyped map. The tech-name lookup moved to `android_tech_list.dart` where it is tested — Android reports fully-qualified Java class names, and a substring match would claim technologies a tag does not have.
- Deprecated `isAvailable()` swapped for `checkAvailability()`, collapsed back to a bool so no caller's meaning changes.
- Removes the unused `createEmpty()`.

## Verification

- `flutter analyze`: **0 errors, 0 warnings** (down from 38 errors)
- `flutter test`: **281 pass** — 250 on master plus 31 new, each watched failing first
- **Interop verified both directions**: TypeScript decodes the current Dart output, and Dart decodes the current TypeScript output
- The NDEF record change was additionally mutation-checked: a wrong MIME type fails the field-level tests while the round-trip test still passes, because `ndefToChunk` falls through to its raw-binary branch

## Not verified

**No hardware testing.** CRYPTO1 auth, block I/O, polling behaviour and the write cooldown have no unit-testable surface. iOS has no validation path in this repo at all. This wants a device pass on Android before release, and iOS should be treated as unverified until someone taps a tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)